### PR TITLE
feat(social): provider adapter interface, registry, and media utilities

### DIFF
--- a/src/lib/social/__tests__/media.test.ts
+++ b/src/lib/social/__tests__/media.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  MediaConstraintError,
+  PLATFORM_MEDIA_CONSTRAINTS,
+  resizeImage,
+  validateMediaConstraints,
+} from "@/lib/social/media";
+import type { PublishMediaItem } from "@/lib/social/provider-interface";
+
+function makeImage(url = "https://example.com/img.jpg"): PublishMediaItem {
+  return { type: "image", url };
+}
+
+function makeVideo(url = "https://example.com/vid.mp4"): PublishMediaItem {
+  return { type: "video", url };
+}
+
+describe("social/media", () => {
+  describe("PLATFORM_MEDIA_CONSTRAINTS", () => {
+    it("defines constraints for all 6 platforms", () => {
+      const platforms = ["x", "linkedin", "instagram", "tiktok", "facebook", "youtube"] as const;
+      for (const platform of platforms) {
+        expect(PLATFORM_MEDIA_CONSTRAINTS[platform]).toBeDefined();
+        expect(PLATFORM_MEDIA_CONSTRAINTS[platform].maxImages).toBeTypeOf("number");
+        expect(PLATFORM_MEDIA_CONSTRAINTS[platform].maxVideos).toBeTypeOf("number");
+      }
+    });
+  });
+
+  describe("validateMediaConstraints", () => {
+    it("passes for valid single image on X", () => {
+      const result = validateMediaConstraints("x", [makeImage()]);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("passes for empty media", () => {
+      const result = validateMediaConstraints("x", []);
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects too many images on X (max 4)", () => {
+      const media = Array.from({ length: 5 }, () => makeImage());
+      const result = validateMediaConstraints("x", media);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("max 4 images");
+    });
+
+    it("rejects too many images on LinkedIn (max 9)", () => {
+      const media = Array.from({ length: 10 }, () => makeImage());
+      const result = validateMediaConstraints("linkedin", media);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("max 9 images");
+    });
+
+    it("passes 10 images on Instagram", () => {
+      const media = Array.from({ length: 10 }, () => makeImage());
+      const result = validateMediaConstraints("instagram", media);
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects 11 images on Instagram", () => {
+      const media = Array.from({ length: 11 }, () => makeImage());
+      const result = validateMediaConstraints("instagram", media);
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects images on YouTube", () => {
+      const result = validateMediaConstraints("youtube", [makeImage()]);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("video uploads, not images");
+    });
+
+    it("allows video on YouTube", () => {
+      const result = validateMediaConstraints("youtube", [makeVideo()]);
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects mixing images and videos on X", () => {
+      const result = validateMediaConstraints("x", [makeImage(), makeVideo()]);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("mixing images and videos");
+    });
+
+    it("rejects multiple videos", () => {
+      const result = validateMediaConstraints("x", [makeVideo(), makeVideo()]);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("max 1 video");
+    });
+
+    it("returns multiple errors at once", () => {
+      // 5 images + 2 videos on X (max 4 images, max 1 video, no mixing)
+      const media = [
+        ...Array.from({ length: 5 }, () => makeImage()),
+        makeVideo(),
+        makeVideo(),
+      ];
+      const result = validateMediaConstraints("x", media);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("resizeImage", () => {
+    it("resizes a large image to maxWidth", async () => {
+      const sharp = (await import("sharp")).default;
+      // Create a 2000x1000 test image
+      const input = await sharp({
+        create: { width: 2000, height: 1000, channels: 3, background: { r: 255, g: 0, b: 0 } },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const result = await resizeImage(input, 1000, "jpeg", 85);
+      const metadata = await sharp(result).metadata();
+      expect(metadata.width).toBe(1000);
+      expect(metadata.height).toBe(500);
+      expect(metadata.format).toBe("jpeg");
+    });
+
+    it("does not enlarge small images", async () => {
+      const sharp = (await import("sharp")).default;
+      const input = await sharp({
+        create: { width: 500, height: 250, channels: 3, background: { r: 0, g: 255, b: 0 } },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const result = await resizeImage(input, 1000, "jpeg", 85);
+      const metadata = await sharp(result).metadata();
+      expect(metadata.width).toBe(500);
+    });
+
+    it("converts to the requested format", async () => {
+      const sharp = (await import("sharp")).default;
+      const input = await sharp({
+        create: { width: 100, height: 100, channels: 3, background: { r: 0, g: 0, b: 255 } },
+      })
+        .png()
+        .toBuffer();
+
+      const result = await resizeImage(input, 1000, "webp", 80);
+      const metadata = await sharp(result).metadata();
+      expect(metadata.format).toBe("webp");
+    });
+  });
+
+  describe("MediaConstraintError", () => {
+    it("includes platform and violations", () => {
+      const error = new MediaConstraintError("x", ["too many images", "no video"]);
+      expect(error.name).toBe("MediaConstraintError");
+      expect(error.platform).toBe("x");
+      expect(error.violations).toEqual(["too many images", "no video"]);
+      expect(error.message).toContain("x");
+      expect(error.message).toContain("too many images");
+    });
+  });
+});

--- a/src/lib/social/__tests__/provider-registry.test.ts
+++ b/src/lib/social/__tests__/provider-registry.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearRegistry,
+  getProvider,
+  isProviderRegistered,
+  listProviderCapabilities,
+  listProviders,
+  registerProvider,
+  SocialProviderNotFoundError,
+  validatePlatform,
+} from "@/lib/social/provider-registry";
+import type { SocialProviderAdapter } from "@/lib/social/provider-interface";
+
+function createMockProvider(
+  overrides: Partial<SocialProviderAdapter> = {},
+): SocialProviderAdapter {
+  return {
+    identifier: "linkedin",
+    displayName: "LinkedIn",
+    maxContentLength: 3000,
+    supportsImages: true,
+    supportsVideo: true,
+    supportsCarousel: true,
+    maxImages: 9,
+    maxConcurrentJobs: 2,
+    requiresPageSelection: true,
+    generateAuthUrl: async () => ({
+      url: "https://example.com/auth",
+      state: "test-state",
+    }),
+    authenticate: async () => ({
+      platformUserId: "user-123",
+      accessToken: "token",
+      displayName: "Test User",
+    }),
+    refreshToken: async () => ({ accessToken: "new-token" }),
+    post: async () => [
+      {
+        postId: "post-1",
+        platformPostId: "plat-1",
+        platformPostUrl: "https://example.com/post/1",
+        status: "published" as const,
+      },
+    ],
+    classifyError: () => ({ type: "retry" as const, message: "Unknown error" }),
+    getCapabilities: () => ({
+      identifier: "linkedin" as const,
+      displayName: "LinkedIn",
+      maxContentLength: 3000,
+      supportsImages: true,
+      supportsVideo: true,
+      supportsCarousel: true,
+      requiresPageSelection: true,
+    }),
+    ...overrides,
+  };
+}
+
+describe("provider-registry", () => {
+  afterEach(() => {
+    clearRegistry();
+  });
+
+  describe("registerProvider", () => {
+    it("registers a provider successfully", () => {
+      const provider = createMockProvider();
+      registerProvider(provider);
+      expect(isProviderRegistered("linkedin")).toBe(true);
+    });
+
+    it("throws on duplicate registration", () => {
+      registerProvider(createMockProvider());
+      expect(() => registerProvider(createMockProvider())).toThrow(
+        'already registered',
+      );
+    });
+  });
+
+  describe("getProvider", () => {
+    it("returns a registered provider", () => {
+      const provider = createMockProvider();
+      registerProvider(provider);
+      expect(getProvider("linkedin")).toBe(provider);
+    });
+
+    it("throws SocialProviderNotFoundError for unknown platform", () => {
+      expect(() => getProvider("unknown")).toThrow(SocialProviderNotFoundError);
+      expect(() => getProvider("unknown")).toThrow(
+        'not available',
+      );
+    });
+
+    it("includes registered providers in error message", () => {
+      registerProvider(createMockProvider({ identifier: "x", displayName: "X" }));
+      try {
+        getProvider("unknown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(SocialProviderNotFoundError);
+        expect((error as SocialProviderNotFoundError).message).toContain("x");
+        expect((error as SocialProviderNotFoundError).platform).toBe("unknown");
+      }
+    });
+  });
+
+  describe("listProviders", () => {
+    it("returns empty array when no providers registered", () => {
+      expect(listProviders()).toEqual([]);
+    });
+
+    it("returns all registered providers", () => {
+      registerProvider(createMockProvider({ identifier: "linkedin", displayName: "LinkedIn" }));
+      registerProvider(createMockProvider({ identifier: "x", displayName: "X" }));
+      const providers = listProviders();
+      expect(providers).toHaveLength(2);
+      expect(providers.map((p) => p.identifier)).toEqual(["linkedin", "x"]);
+    });
+  });
+
+  describe("listProviderCapabilities", () => {
+    it("returns capabilities for all providers", () => {
+      registerProvider(createMockProvider());
+      const capabilities = listProviderCapabilities();
+      expect(capabilities).toHaveLength(1);
+      expect(capabilities[0]).toEqual({
+        identifier: "linkedin",
+        displayName: "LinkedIn",
+        maxContentLength: 3000,
+        supportsImages: true,
+        supportsVideo: true,
+        supportsCarousel: true,
+        requiresPageSelection: true,
+      });
+    });
+  });
+
+  describe("validatePlatform", () => {
+    it("returns typed platform for registered provider", () => {
+      registerProvider(createMockProvider());
+      expect(validatePlatform("linkedin")).toBe("linkedin");
+    });
+
+    it("throws for unregistered platform", () => {
+      expect(() => validatePlatform("unknown")).toThrow(
+        SocialProviderNotFoundError,
+      );
+    });
+  });
+
+  describe("clearRegistry", () => {
+    it("removes all registered providers", () => {
+      registerProvider(createMockProvider());
+      expect(listProviders()).toHaveLength(1);
+      clearRegistry();
+      expect(listProviders()).toHaveLength(0);
+    });
+  });
+});

--- a/src/lib/social/media.ts
+++ b/src/lib/social/media.ts
@@ -1,0 +1,243 @@
+import type { SocialPlatform } from "@/lib/db/schema";
+import type { PublishMediaItem } from "@/lib/social/provider-interface";
+
+/**
+ * Per-platform media constraints.
+ * Used for validation before upload and for processing (resize/format).
+ */
+export interface MediaConstraints {
+  maxImageWidth: number;
+  imageFormat: "jpeg" | "png" | "webp";
+  imageQuality: number;
+  maxImages: number;
+  maxVideos: number;
+  requirePublicUrl: boolean;
+}
+
+export const PLATFORM_MEDIA_CONSTRAINTS: Record<SocialPlatform, MediaConstraints> = {
+  x: {
+    maxImageWidth: 1000,
+    imageFormat: "jpeg",
+    imageQuality: 85,
+    maxImages: 4,
+    maxVideos: 1,
+    requirePublicUrl: false,
+  },
+  linkedin: {
+    maxImageWidth: 1000,
+    imageFormat: "jpeg",
+    imageQuality: 85,
+    maxImages: 9,
+    maxVideos: 1,
+    requirePublicUrl: false,
+  },
+  instagram: {
+    maxImageWidth: 1920,
+    imageFormat: "jpeg",
+    imageQuality: 90,
+    maxImages: 10,
+    maxVideos: 1,
+    requirePublicUrl: true,
+  },
+  tiktok: {
+    maxImageWidth: 1080,
+    imageFormat: "jpeg",
+    imageQuality: 90,
+    maxImages: 35,
+    maxVideos: 1,
+    requirePublicUrl: true,
+  },
+  facebook: {
+    maxImageWidth: 2048,
+    imageFormat: "jpeg",
+    imageQuality: 90,
+    maxImages: 10,
+    maxVideos: 1,
+    requirePublicUrl: true,
+  },
+  youtube: {
+    maxImageWidth: 0,
+    imageFormat: "jpeg",
+    imageQuality: 0,
+    maxImages: 0,
+    maxVideos: 1,
+    requirePublicUrl: false,
+  },
+};
+
+export interface MediaValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validate media items against a platform's constraints.
+ * Call this before attempting to publish.
+ */
+export function validateMediaConstraints(
+  platform: SocialPlatform,
+  media: PublishMediaItem[],
+): MediaValidationResult {
+  const constraints = PLATFORM_MEDIA_CONSTRAINTS[platform];
+  const errors: string[] = [];
+
+  const images = media.filter((m) => m.type === "image");
+  const videos = media.filter((m) => m.type === "video");
+
+  // YouTube is video-only — check before generic max images
+  if (platform === "youtube" && images.length > 0) {
+    errors.push("YouTube only supports video uploads, not images.");
+  } else if (images.length > constraints.maxImages) {
+    errors.push(
+      `${platform} supports max ${constraints.maxImages} images, got ${images.length}.`,
+    );
+  }
+
+  if (videos.length > constraints.maxVideos) {
+    errors.push(
+      `${platform} supports max ${constraints.maxVideos} video(s), got ${videos.length}.`,
+    );
+  }
+
+  // Can't mix images and videos on most platforms
+  if (images.length > 0 && videos.length > 0 && platform !== "facebook") {
+    errors.push(
+      `${platform} does not support mixing images and videos in one post.`,
+    );
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Resize an image buffer to fit within a maximum width.
+ * Uses sharp for format conversion and quality control.
+ */
+export async function resizeImage(
+  buffer: Buffer,
+  maxWidth: number,
+  format: "jpeg" | "png" | "webp" = "jpeg",
+  quality: number = 85,
+): Promise<Buffer> {
+  const sharp = (await import("sharp")).default;
+
+  let pipeline = sharp(buffer);
+
+  // Only resize if maxWidth > 0 (YouTube has 0 = no image processing)
+  if (maxWidth > 0) {
+    const metadata = await sharp(buffer).metadata();
+    if (metadata.width && metadata.width > maxWidth) {
+      pipeline = pipeline.resize({ width: maxWidth, withoutEnlargement: true });
+    }
+  }
+
+  if (format === "jpeg") {
+    pipeline = pipeline.jpeg({ quality });
+  } else if (format === "png") {
+    pipeline = pipeline.png({ quality });
+  } else if (format === "webp") {
+    pipeline = pipeline.webp({ quality });
+  }
+
+  return pipeline.toBuffer();
+}
+
+/**
+ * Download a URL to a Buffer.
+ * Used by providers that require binary upload (e.g., X/Twitter).
+ */
+export async function downloadToBuffer(
+  url: string,
+): Promise<{ buffer: Buffer; mimeType: string }> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download media: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const mimeType = response.headers.get("content-type") || "application/octet-stream";
+  const arrayBuffer = await response.arrayBuffer();
+  return { buffer: Buffer.from(arrayBuffer), mimeType };
+}
+
+export interface ProcessedMedia {
+  type: "image" | "video";
+  buffer?: Buffer;
+  url: string;
+  mimeType: string;
+  alt?: string;
+}
+
+/**
+ * Process media items for a specific platform:
+ * - Validate constraints
+ * - Download and resize images as needed
+ * - Return processed media ready for the provider's post() method
+ */
+export async function processMediaForPlatform(
+  platform: SocialPlatform,
+  media: PublishMediaItem[],
+): Promise<ProcessedMedia[]> {
+  const constraints = PLATFORM_MEDIA_CONSTRAINTS[platform];
+  const validation = validateMediaConstraints(platform, media);
+  if (!validation.valid) {
+    throw new MediaConstraintError(platform, validation.errors);
+  }
+
+  const processed: ProcessedMedia[] = [];
+
+  for (const item of media) {
+    if (item.type === "video") {
+      // Videos are passed through as-is (URL-based upload for most platforms)
+      processed.push({
+        type: "video",
+        url: item.url,
+        mimeType: item.mimeType || "video/mp4",
+        alt: item.alt,
+      });
+      continue;
+    }
+
+    // For images: download → resize → format convert
+    if (constraints.maxImageWidth > 0) {
+      const { buffer, mimeType } = await downloadToBuffer(item.url);
+      const resized = await resizeImage(
+        buffer,
+        constraints.maxImageWidth,
+        constraints.imageFormat,
+        constraints.imageQuality,
+      );
+
+      processed.push({
+        type: "image",
+        buffer: resized,
+        url: item.url,
+        mimeType: `image/${constraints.imageFormat}`,
+        alt: item.alt,
+      });
+    } else {
+      // Platform doesn't process images (e.g., YouTube)
+      processed.push({
+        type: "image",
+        url: item.url,
+        mimeType: item.mimeType || "image/jpeg",
+        alt: item.alt,
+      });
+    }
+  }
+
+  return processed;
+}
+
+export class MediaConstraintError extends Error {
+  platform: string;
+  violations: string[];
+
+  constructor(platform: string, violations: string[]) {
+    super(`Media constraints violated for ${platform}: ${violations.join("; ")}`);
+    this.name = "MediaConstraintError";
+    this.platform = platform;
+    this.violations = violations;
+  }
+}

--- a/src/lib/social/provider-interface.ts
+++ b/src/lib/social/provider-interface.ts
@@ -1,0 +1,193 @@
+import type { SocialPlatform } from "@/lib/db/schema";
+
+/**
+ * Error classification for social provider operations.
+ * Drives retry behavior in the Vercel Workflow publish pipeline.
+ */
+export type SocialErrorType =
+  | "refresh-token" // Token expired — refresh then retry
+  | "bad-body" // Invalid content — fail immediately (FatalError)
+  | "retry"; // Transient error — auto-retry (up to 3x)
+
+export interface SocialProviderError {
+  type: SocialErrorType;
+  message: string;
+  original?: unknown;
+}
+
+/**
+ * OAuth URL generation result.
+ */
+export interface GenerateAuthUrlResult {
+  url: string;
+  state: string;
+  codeVerifier?: string; // PKCE or OAuth 1.0a secret
+}
+
+/**
+ * Result from exchanging an OAuth code for tokens.
+ */
+export interface AuthenticateResult {
+  platformUserId: string;
+  accessToken: string;
+  refreshToken?: string;
+  accessTokenSecret?: string; // OAuth 1.0a (X/Twitter)
+  expiresIn?: number; // Seconds until token expiry
+  displayName: string;
+  username?: string;
+  avatarUrl?: string;
+  requiresPageSelection?: boolean; // True for Instagram, Facebook, YouTube, LinkedIn
+}
+
+/**
+ * Result from refreshing an expired token.
+ */
+export interface RefreshTokenResult {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+}
+
+/**
+ * Page/channel/account info for two-step auth flows.
+ */
+export interface PageInfo {
+  id: string;
+  name: string;
+  accessToken?: string;
+  picture?: string;
+  username?: string;
+}
+
+/**
+ * Media item to publish with a post.
+ */
+export interface PublishMediaItem {
+  type: "image" | "video";
+  url: string; // S3/R2 presigned URL or public URL
+  alt?: string;
+  mimeType?: string;
+}
+
+/**
+ * Request to publish a post to a social platform.
+ */
+export interface PublishRequest {
+  postId: string; // Our internal post ID
+  content: string;
+  media?: PublishMediaItem[];
+  platformSettings?: Record<string, unknown>;
+}
+
+/**
+ * Result after successfully publishing to a platform.
+ */
+export interface PublishResult {
+  postId: string; // Our internal post ID
+  platformPostId: string; // Platform-specific post ID
+  platformPostUrl: string; // Direct link to the published post
+  status: "published" | "processing"; // Some platforms (IG, TikTok) publish async
+}
+
+/**
+ * Provider capabilities exposed to the UI (e.g., provider list endpoint).
+ */
+export interface ProviderCapabilities {
+  identifier: SocialPlatform;
+  displayName: string;
+  maxContentLength: number;
+  supportsImages: boolean;
+  supportsVideo: boolean;
+  supportsCarousel: boolean;
+  requiresPageSelection: boolean;
+}
+
+/**
+ * Core interface that every social platform adapter must implement.
+ *
+ * Inspired by Postiz's SocialProvider but simplified for our stack:
+ * - No NestJS decorators or DI
+ * - Composition over inheritance (no abstract base class)
+ * - Explicit error classification for Vercel Workflow retry semantics
+ */
+export interface SocialProviderAdapter {
+  /** Platform identifier (matches socialPlatformEnum). */
+  readonly identifier: SocialPlatform;
+
+  /** Human-readable platform name. */
+  readonly displayName: string;
+
+  /** Maximum post text length for this platform. */
+  readonly maxContentLength: number;
+
+  /** Whether this platform supports image uploads. */
+  readonly supportsImages: boolean;
+
+  /** Whether this platform supports video uploads. */
+  readonly supportsVideo: boolean;
+
+  /** Whether this platform supports multi-image carousel posts. */
+  readonly supportsCarousel: boolean;
+
+  /** Maximum number of images per post. */
+  readonly maxImages: number;
+
+  /** Max concurrent publish jobs (for rate limiting). */
+  readonly maxConcurrentJobs: number;
+
+  /** Whether the OAuth flow requires page/channel selection after initial auth. */
+  readonly requiresPageSelection: boolean;
+
+  /**
+   * Generate the OAuth authorization URL for this platform.
+   * The user will be redirected here to grant access.
+   */
+  generateAuthUrl(callbackUrl: string): Promise<GenerateAuthUrlResult>;
+
+  /**
+   * Exchange an OAuth authorization code for access tokens.
+   * Called after the user approves the OAuth prompt.
+   */
+  authenticate(params: {
+    code: string;
+    codeVerifier?: string;
+    state?: string;
+  }): Promise<AuthenticateResult>;
+
+  /**
+   * Refresh an expired access token.
+   * Some platforms (X) have permanent tokens — their implementation is a no-op.
+   */
+  refreshToken(refreshToken: string): Promise<RefreshTokenResult>;
+
+  /**
+   * Publish one or more posts to the platform.
+   * Returns a result for each post in the request array.
+   */
+  post(
+    platformUserId: string,
+    accessToken: string,
+    requests: PublishRequest[],
+    options?: { accessTokenSecret?: string },
+  ): Promise<PublishResult[]>;
+
+  /**
+   * Classify a platform API error into a retry category.
+   * This drives Vercel Workflow's retry behavior:
+   * - "bad-body" → FatalError (no retry)
+   * - "refresh-token" → FatalError + mark account for re-auth
+   * - "retry" → auto-retry up to 3 times
+   */
+  classifyError(error: unknown): SocialProviderError;
+
+  /**
+   * Fetch available pages/channels/accounts for two-step auth flows.
+   * Only implemented by providers where requiresPageSelection is true.
+   */
+  fetchPageInformation?(accessToken: string): Promise<PageInfo[]>;
+
+  /**
+   * Get the provider's capabilities for UI display.
+   */
+  getCapabilities(): ProviderCapabilities;
+}

--- a/src/lib/social/provider-registry.ts
+++ b/src/lib/social/provider-registry.ts
@@ -1,0 +1,85 @@
+import type { SocialPlatform } from "@/lib/db/schema";
+import type {
+  ProviderCapabilities,
+  SocialProviderAdapter,
+} from "@/lib/social/provider-interface";
+
+const registry = new Map<string, SocialProviderAdapter>();
+
+/**
+ * Register a social provider adapter.
+ * Typically called at module load time from each provider file.
+ */
+export function registerProvider(provider: SocialProviderAdapter): void {
+  if (registry.has(provider.identifier)) {
+    throw new Error(
+      `Social provider "${provider.identifier}" is already registered.`,
+    );
+  }
+  registry.set(provider.identifier, provider);
+}
+
+/**
+ * Get a registered provider by platform identifier.
+ * Throws if the provider is not registered.
+ */
+export function getProvider(platform: string): SocialProviderAdapter {
+  const provider = registry.get(platform);
+  if (!provider) {
+    throw new SocialProviderNotFoundError(platform);
+  }
+  return provider;
+}
+
+/**
+ * List all registered providers.
+ */
+export function listProviders(): SocialProviderAdapter[] {
+  return Array.from(registry.values());
+}
+
+/**
+ * List capabilities of all registered providers (for API responses).
+ */
+export function listProviderCapabilities(): ProviderCapabilities[] {
+  return listProviders().map((provider) => provider.getCapabilities());
+}
+
+/**
+ * Check if a platform identifier is valid (registered).
+ */
+export function isProviderRegistered(platform: string): boolean {
+  return registry.has(platform);
+}
+
+/**
+ * Validate that a string is a known platform and has a registered provider.
+ * Returns the typed SocialPlatform if valid, throws otherwise.
+ */
+export function validatePlatform(platform: string): SocialPlatform {
+  if (!registry.has(platform)) {
+    throw new SocialProviderNotFoundError(platform);
+  }
+  return platform as SocialPlatform;
+}
+
+/**
+ * Clear the registry (for testing only).
+ */
+export function clearRegistry(): void {
+  registry.clear();
+}
+
+export class SocialProviderNotFoundError extends Error {
+  platform: string;
+
+  constructor(platform: string) {
+    super(
+      `Social provider "${platform}" is not available. Registered providers: ${
+        Array.from(registry.keys()).join(", ") || "(none)"
+      }`,
+    );
+    this.name = "SocialProviderNotFoundError";
+    this.platform = platform;
+  }
+}


### PR DESCRIPTION
## Summary

- Define `SocialProviderAdapter` interface with full OAuth, publishing, and error classification contract
- Create Map-based provider registry with `registerProvider()`, `getProvider()`, `listProviders()`, `validatePlatform()`
- Add per-platform media processing: `PLATFORM_MEDIA_CONSTRAINTS` for all 6 platforms, `resizeImage()` via sharp, `downloadToBuffer()`, `validateMediaConstraints()`, `processMediaForPlatform()`

## Test plan

- [x] 11 provider registry tests (register, retrieve, duplicate detection, listing, validation)
- [x] 16 media utility tests (constraint validation per platform, image resize, format conversion, YouTube video-only)
- [x] 2009 total tests pass (zero regression)
- [x] Production build succeeds

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)