### PR TITLE
feat(social): social repository, API routes, and client

### DIFF
--- a/src/app/api/social/accounts/[accountId]/route.ts
+++ b/src/app/api/social/accounts/[accountId]/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import {
+  disconnectSocialAccount,
+  getSocialAccount,
+  SocialAccountNotFoundError,
+} from "@/lib/social/repository";
+
+interface AccountResponse {
+  success: boolean;
+  account?: Record<string, unknown>;
+  error?: string;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ accountId: string }> },
+): Promise<NextResponse<AccountResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/accounts",
+      permission: "social:view",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { accountId } = await params;
+    const account = await getSocialAccount(
+      result.session.workspace.id,
+      accountId,
+    );
+
+    // Strip encrypted tokens
+    const { accessTokenEncrypted, refreshTokenEncrypted, accessTokenSecret, ...safeAccount } = account;
+
+    return NextResponse.json({ success: true, account: safeAccount });
+  } catch (error) {
+    if (error instanceof SocialAccountNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to get account",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ accountId: string }> },
+): Promise<NextResponse<{ success: boolean; error?: string }>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/accounts",
+      permission: "social:manage",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { accountId } = await params;
+    await disconnectSocialAccount(result.session.workspace.id, accountId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof SocialAccountNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to disconnect account",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/accounts/callback/route.ts
+++ b/src/app/api/social/accounts/callback/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import { getProvider } from "@/lib/social/provider-registry";
+import { encryptToken } from "@/lib/social/crypto";
+import {
+  consumeOAuthState,
+  upsertSocialAccount,
+  OAuthStateNotFoundError,
+  OAuthStateExpiredError,
+} from "@/lib/social/repository";
+import type { SocialPlatform } from "@/lib/db/schema";
+import type { PageInfo } from "@/lib/social/provider-interface";
+
+interface CallbackRequest {
+  platform: string;
+  code: string;
+  state: string;
+}
+
+interface CallbackResponse {
+  success: boolean;
+  account?: Record<string, unknown>;
+  pages?: PageInfo[];
+  requiresPageSelection?: boolean;
+  error?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<CallbackResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/accounts/callback",
+      permission: "social:connect",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const body = (await request.json()) as CallbackRequest;
+
+    if (!body.platform?.trim() || !body.code?.trim() || !body.state?.trim()) {
+      return NextResponse.json(
+        { success: false, error: "Platform, code, and state are required." },
+        { status: 400 },
+      );
+    }
+
+    // Consume OAuth state (atomic — prevents replay)
+    const oauthState = await consumeOAuthState(body.state);
+
+    // Verify the platform matches the stored state
+    if (oauthState.platform !== body.platform) {
+      return NextResponse.json(
+        { success: false, error: "Platform mismatch with OAuth state." },
+        { status: 400 },
+      );
+    }
+
+    // Exchange code for tokens
+    const provider = getProvider(body.platform);
+    const authResult = await provider.authenticate({
+      code: body.code,
+      codeVerifier: oauthState.codeVerifier ?? undefined,
+      state: body.state,
+    });
+
+    // If provider requires page selection, return pages without saving yet
+    if (authResult.requiresPageSelection && provider.fetchPageInformation) {
+      const pages = await provider.fetchPageInformation(authResult.accessToken);
+      return NextResponse.json({
+        success: true,
+        requiresPageSelection: true,
+        pages,
+        // Temporarily store the token info for the select-page step
+        account: {
+          platform: body.platform,
+          platformUserId: authResult.platformUserId,
+          displayName: authResult.displayName,
+          accessToken: authResult.accessToken, // Will be encrypted on final save
+          refreshToken: authResult.refreshToken,
+          expiresIn: authResult.expiresIn,
+        },
+      });
+    }
+
+    // Save the social account with encrypted tokens
+    const account = await upsertSocialAccount({
+      workspaceId: oauthState.workspaceId,
+      platform: body.platform as SocialPlatform,
+      platformUserId: authResult.platformUserId,
+      displayName: authResult.displayName,
+      username: authResult.username,
+      avatarUrl: authResult.avatarUrl,
+      accessTokenEncrypted: encryptToken(authResult.accessToken),
+      refreshTokenEncrypted: authResult.refreshToken
+        ? encryptToken(authResult.refreshToken)
+        : undefined,
+      accessTokenSecret: authResult.accessTokenSecret
+        ? encryptToken(authResult.accessTokenSecret)
+        : undefined,
+      tokenExpiresAt: authResult.expiresIn
+        ? new Date(Date.now() + authResult.expiresIn * 1000)
+        : undefined,
+      createdByUserId: result.session.user.id,
+    });
+
+    // Strip encrypted fields from response
+    const { accessTokenEncrypted, refreshTokenEncrypted, accessTokenSecret, ...safeAccount } = account;
+
+    return NextResponse.json({
+      success: true,
+      account: safeAccount,
+    });
+  } catch (error) {
+    if (
+      error instanceof OAuthStateNotFoundError ||
+      error instanceof OAuthStateExpiredError
+    ) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to complete connection",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/accounts/connect/route.ts
+++ b/src/app/api/social/accounts/connect/route.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import { getProvider, isProviderRegistered } from "@/lib/social/provider-registry";
+import { createOAuthState } from "@/lib/social/repository";
+import type { SocialPlatform } from "@/lib/db/schema";
+
+interface ConnectRequest {
+  platform: string;
+}
+
+interface ConnectResponse {
+  success: boolean;
+  authUrl?: string;
+  error?: string;
+}
+
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<ConnectResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/accounts/connect",
+      permission: "social:connect",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const body = (await request.json()) as ConnectRequest;
+
+    if (!body.platform?.trim()) {
+      return NextResponse.json(
+        { success: false, error: "Platform is required." },
+        { status: 400 },
+      );
+    }
+
+    if (!isProviderRegistered(body.platform)) {
+      return NextResponse.json(
+        { success: false, error: `Platform "${body.platform}" is not available.` },
+        { status: 400 },
+      );
+    }
+
+    const provider = getProvider(body.platform);
+    const origin =
+      request.headers.get("origin") ||
+      process.env.NEXT_PUBLIC_APP_URL ||
+      "http://localhost:3000";
+    const callbackUrl = `${origin}/api/social/accounts/callback`;
+
+    const authResult = await provider.generateAuthUrl(callbackUrl);
+
+    // Store OAuth state for CSRF protection
+    await createOAuthState({
+      workspaceId: result.session.workspace.id,
+      platform: body.platform as SocialPlatform,
+      state: authResult.state,
+      codeVerifier: authResult.codeVerifier,
+      metadata: { callbackUrl },
+      expiresAt: new Date(Date.now() + OAUTH_STATE_TTL_MS),
+    });
+
+    return NextResponse.json({ success: true, authUrl: authResult.url });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to initiate connection",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/accounts/route.ts
+++ b/src/app/api/social/accounts/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission, authzErrorResponse } from "@/lib/studio/authz";
+import { listSocialAccounts } from "@/lib/social/repository";
+
+interface AccountsResponse {
+  success: boolean;
+  accounts?: Awaited<ReturnType<typeof listSocialAccounts>>;
+  error?: string;
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<AccountsResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/accounts",
+      permission: "social:view",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const accounts = await listSocialAccounts(result.session.workspace.id);
+
+    // Strip encrypted tokens from response
+    const safeAccounts = accounts.map(
+      ({ accessTokenEncrypted, refreshTokenEncrypted, accessTokenSecret, ...rest }) => rest,
+    );
+
+    return NextResponse.json({ success: true, accounts: safeAccounts as typeof accounts });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to list social accounts",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/accounts/select-page/route.ts
+++ b/src/app/api/social/accounts/select-page/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import { getProvider } from "@/lib/social/provider-registry";
+import { encryptToken } from "@/lib/social/crypto";
+import { upsertSocialAccount } from "@/lib/social/repository";
+import type { SocialPlatform } from "@/lib/db/schema";
+
+interface SelectPageRequest {
+  platform: string;
+  pageId: string;
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+}
+
+interface SelectPageResponse {
+  success: boolean;
+  account?: Record<string, unknown>;
+  error?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<SelectPageResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/accounts/select-page",
+      permission: "social:connect",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const body = (await request.json()) as SelectPageRequest;
+
+    if (!body.platform?.trim() || !body.pageId?.trim() || !body.accessToken?.trim()) {
+      return NextResponse.json(
+        { success: false, error: "Platform, pageId, and accessToken are required." },
+        { status: 400 },
+      );
+    }
+
+    const provider = getProvider(body.platform);
+
+    if (!provider.fetchPageInformation) {
+      return NextResponse.json(
+        { success: false, error: `${body.platform} does not support page selection.` },
+        { status: 400 },
+      );
+    }
+
+    // Fetch page-specific details (may include page-level access token)
+    const pages = await provider.fetchPageInformation(body.accessToken);
+    const selectedPage = pages.find((p) => p.id === body.pageId);
+
+    if (!selectedPage) {
+      return NextResponse.json(
+        { success: false, error: "Selected page not found." },
+        { status: 404 },
+      );
+    }
+
+    // Use page-specific token if available, otherwise use the original token
+    const finalAccessToken = selectedPage.accessToken || body.accessToken;
+
+    const account = await upsertSocialAccount({
+      workspaceId: result.session.workspace.id,
+      platform: body.platform as SocialPlatform,
+      platformUserId: selectedPage.id,
+      displayName: selectedPage.name,
+      username: selectedPage.username,
+      avatarUrl: selectedPage.picture,
+      accessTokenEncrypted: encryptToken(finalAccessToken),
+      refreshTokenEncrypted: body.refreshToken
+        ? encryptToken(body.refreshToken)
+        : undefined,
+      tokenExpiresAt: body.expiresIn
+        ? new Date(Date.now() + body.expiresIn * 1000)
+        : undefined,
+      createdByUserId: result.session.user.id,
+    });
+
+    const { accessTokenEncrypted, refreshTokenEncrypted, accessTokenSecret, ...safeAccount } = account;
+
+    return NextResponse.json({ success: true, account: safeAccount });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to complete page selection",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/posts/[postId]/publish/route.ts
+++ b/src/app/api/social/posts/[postId]/publish/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import {
+  getSocialPost,
+  updatePostStatus,
+  SocialPostNotFoundError,
+  SocialPostStateTransitionError,
+} from "@/lib/social/repository";
+
+interface PublishResponse {
+  success: boolean;
+  post?: Record<string, unknown>;
+  error?: string;
+}
+
+const PUBLISHABLE_STATES = new Set(["draft", "failed"]);
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ postId: string }> },
+): Promise<NextResponse<PublishResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/posts",
+      permission: "social:publish",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { postId } = await params;
+    const post = await getSocialPost(result.session.workspace.id, postId);
+
+    if (!PUBLISHABLE_STATES.has(post.status)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Cannot publish a post with status "${post.status}". Only draft and failed posts can be published.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    // Transition to "queued" — the Vercel Workflow will pick it up
+    const updated = await updatePostStatus(postId, "queued", {
+      errorMessage: undefined,
+    });
+
+    // TODO: Start Vercel Workflow here once workflows/social-publish.ts is implemented
+    // await publishPostWorkflow.start(postId, result.session.workspace.id);
+
+    return NextResponse.json({ success: true, post: updated });
+  } catch (error) {
+    if (error instanceof SocialPostNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    if (error instanceof SocialPostStateTransitionError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to publish post",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/posts/[postId]/route.ts
+++ b/src/app/api/social/posts/[postId]/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import {
+  deleteSocialPost,
+  getSocialPost,
+  updateSocialPost,
+  SocialPostNotFoundError,
+  SocialPostStateTransitionError,
+} from "@/lib/social/repository";
+
+interface PostResponse {
+  success: boolean;
+  post?: Awaited<ReturnType<typeof getSocialPost>>;
+  error?: string;
+}
+
+interface PatchRequest {
+  content?: string;
+  mediaUrls?: Array<{ type: string; url: string; alt?: string }>;
+  platformSettings?: Record<string, unknown>;
+  scheduledAt?: string | null;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ postId: string }> },
+): Promise<NextResponse<PostResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/posts",
+      permission: "social:view",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { postId } = await params;
+    const post = await getSocialPost(result.session.workspace.id, postId);
+
+    return NextResponse.json({ success: true, post });
+  } catch (error) {
+    if (error instanceof SocialPostNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to get post",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ postId: string }> },
+): Promise<NextResponse<PostResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/posts",
+      permission: "social:publish",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { postId } = await params;
+    const body = (await request.json()) as PatchRequest;
+
+    const post = await updateSocialPost(
+      result.session.workspace.id,
+      postId,
+      {
+        content: body.content,
+        mediaUrls: body.mediaUrls,
+        platformSettings: body.platformSettings,
+        scheduledAt:
+          body.scheduledAt === null
+            ? null
+            : body.scheduledAt
+              ? new Date(body.scheduledAt)
+              : undefined,
+      },
+    );
+
+    return NextResponse.json({ success: true, post });
+  } catch (error) {
+    if (error instanceof SocialPostNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    if (error instanceof SocialPostStateTransitionError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to update post",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ postId: string }> },
+): Promise<NextResponse<{ success: boolean; error?: string }>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/posts",
+      permission: "social:publish",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { postId } = await params;
+    await deleteSocialPost(result.session.workspace.id, postId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof SocialPostNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    if (error instanceof SocialPostStateTransitionError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to delete post",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/posts/route.ts
+++ b/src/app/api/social/posts/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import {
+  createSocialPost,
+  listSocialPosts,
+} from "@/lib/social/repository";
+import type { SocialPostStatus } from "@/lib/db/schema";
+
+interface PostsGetResponse {
+  success: boolean;
+  posts?: Awaited<ReturnType<typeof listSocialPosts>>;
+  error?: string;
+}
+
+interface PostsPostRequest {
+  socialAccountId: string;
+  content?: string;
+  mediaUrls?: Array<{ type: string; url: string; alt?: string }>;
+  platformSettings?: Record<string, unknown>;
+  scheduledAt?: string;
+  studioAssetId?: string;
+}
+
+interface PostsPostResponse {
+  success: boolean;
+  post?: Awaited<ReturnType<typeof createSocialPost>>;
+  error?: string;
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<PostsGetResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/posts",
+      permission: "social:view",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const url = new URL(request.url);
+    const status = url.searchParams.get("status") as SocialPostStatus | null;
+    const socialAccountId = url.searchParams.get("socialAccountId");
+    const limit = url.searchParams.get("limit");
+    const offset = url.searchParams.get("offset");
+
+    const posts = await listSocialPosts(result.session.workspace.id, {
+      status: status ?? undefined,
+      socialAccountId: socialAccountId ?? undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      offset: offset ? parseInt(offset, 10) : undefined,
+    });
+
+    return NextResponse.json({ success: true, posts });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to list posts",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<PostsPostResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/posts",
+      permission: "social:publish",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const body = (await request.json()) as PostsPostRequest;
+
+    if (!body.socialAccountId?.trim()) {
+      return NextResponse.json(
+        { success: false, error: "socialAccountId is required." },
+        { status: 400 },
+      );
+    }
+
+    if (!body.content?.trim() && (!body.mediaUrls || body.mediaUrls.length === 0)) {
+      return NextResponse.json(
+        { success: false, error: "Content or media is required." },
+        { status: 400 },
+      );
+    }
+
+    const post = await createSocialPost({
+      workspaceId: result.session.workspace.id,
+      socialAccountId: body.socialAccountId,
+      content: body.content,
+      mediaUrls: body.mediaUrls,
+      platformSettings: body.platformSettings,
+      scheduledAt: body.scheduledAt ? new Date(body.scheduledAt) : undefined,
+      studioAssetId: body.studioAssetId,
+      createdByUserId: result.session.user.id,
+    });
+
+    return NextResponse.json({ success: true, post });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to create post",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/providers/route.ts
+++ b/src/app/api/social/providers/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ProviderCapabilities } from "@/lib/social/provider-interface";
+import { listProviderCapabilities } from "@/lib/social/provider-registry";
+
+interface ProvidersResponse {
+  success: boolean;
+  providers?: ProviderCapabilities[];
+  error?: string;
+}
+
+export async function GET(
+  _request: NextRequest,
+): Promise<NextResponse<ProvidersResponse>> {
+  try {
+    const providers = listProviderCapabilities();
+    return NextResponse.json({ success: true, providers });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to list providers",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/social/__tests__/repository.test.ts
+++ b/src/lib/social/__tests__/repository.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OAuthStateExpiredError,
+  OAuthStateNotFoundError,
+  SocialAccountNotFoundError,
+  SocialPostNotFoundError,
+  SocialPostStateTransitionError,
+} from "@/lib/social/repository";
+
+// Mock the database module
+const mockInsert = vi.fn();
+const mockSelect = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+const mockReturning = vi.fn();
+const mockValues = vi.fn();
+const mockOnConflictDoUpdate = vi.fn();
+const mockSet = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLimit = vi.fn();
+const mockOffset = vi.fn();
+
+function setupChainableMock(returnValue: unknown[] = []) {
+  mockReturning.mockResolvedValue(returnValue);
+  mockValues.mockReturnValue({
+    returning: mockReturning,
+    onConflictDoUpdate: mockOnConflictDoUpdate,
+  });
+  mockOnConflictDoUpdate.mockReturnValue({ returning: mockReturning });
+  mockSet.mockReturnValue({ where: mockWhere });
+
+  // select().from().where() returns a thenable (array) directly
+  const selectResult = Object.assign(Promise.resolve(returnValue), {
+    returning: mockReturning,
+    orderBy: mockOrderBy,
+    limit: mockLimit,
+  });
+  mockWhere.mockReturnValue(selectResult);
+  mockOrderBy.mockReturnValue({ limit: mockLimit });
+  mockLimit.mockReturnValue({ offset: mockOffset });
+  mockOffset.mockReturnValue(Promise.resolve(returnValue));
+  mockFrom.mockReturnValue({ where: mockWhere });
+
+  mockInsert.mockReturnValue({ values: mockValues });
+  mockSelect.mockReturnValue({ from: mockFrom });
+  mockUpdate.mockReturnValue({ set: mockSet });
+  mockDelete.mockReturnValue({ where: mockWhere });
+}
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    insert: mockInsert,
+    select: mockSelect,
+    update: mockUpdate,
+    delete: mockDelete,
+  }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  socialAccounts: { workspaceId: "workspace_id", id: "id", platform: "platform", platformUserId: "platform_user_id" },
+  socialPosts: { workspaceId: "workspace_id", id: "id", status: "status", socialAccountId: "social_account_id", retryCount: "retry_count", createdAt: "created_at" },
+  socialOAuthStates: { state: "state", expiresAt: "expires_at" },
+}));
+
+describe("social/repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("error classes", () => {
+    it("SocialAccountNotFoundError includes id", () => {
+      const error = new SocialAccountNotFoundError("sacct_123");
+      expect(error.name).toBe("SocialAccountNotFoundError");
+      expect(error.message).toContain("sacct_123");
+    });
+
+    it("SocialPostNotFoundError includes id", () => {
+      const error = new SocialPostNotFoundError("spost_123");
+      expect(error.name).toBe("SocialPostNotFoundError");
+      expect(error.message).toContain("spost_123");
+    });
+
+    it("SocialPostStateTransitionError includes states", () => {
+      const error = new SocialPostStateTransitionError("published", "draft");
+      expect(error.name).toBe("SocialPostStateTransitionError");
+      expect(error.currentStatus).toBe("published");
+      expect(error.targetStatus).toBe("draft");
+      expect(error.message).toContain("published");
+      expect(error.message).toContain("draft");
+    });
+
+    it("OAuthStateNotFoundError has correct name", () => {
+      const error = new OAuthStateNotFoundError();
+      expect(error.name).toBe("OAuthStateNotFoundError");
+    });
+
+    it("OAuthStateExpiredError has correct name", () => {
+      const error = new OAuthStateExpiredError();
+      expect(error.name).toBe("OAuthStateExpiredError");
+    });
+  });
+
+  describe("createOAuthState", () => {
+    it("inserts a new OAuth state", async () => {
+      const mockRow = {
+        id: "soauth_test",
+        state: "test-state",
+        workspaceId: "ws_1",
+        platform: "linkedin",
+      };
+      setupChainableMock([mockRow]);
+
+      const { createOAuthState } = await import("@/lib/social/repository");
+      const result = await createOAuthState({
+        workspaceId: "ws_1",
+        platform: "linkedin",
+        state: "test-state",
+        expiresAt: new Date(Date.now() + 3600_000),
+      });
+
+      expect(mockInsert).toHaveBeenCalled();
+      expect(result).toEqual(mockRow);
+    });
+  });
+
+  describe("consumeOAuthState", () => {
+    it("deletes and returns valid state", async () => {
+      const futureDate = new Date(Date.now() + 3600_000);
+      setupChainableMock([
+        { id: "soauth_1", state: "test", expiresAt: futureDate },
+      ]);
+
+      const { consumeOAuthState } = await import("@/lib/social/repository");
+      const result = await consumeOAuthState("test");
+
+      expect(mockDelete).toHaveBeenCalled();
+      expect(result.state).toBe("test");
+    });
+
+    it("throws OAuthStateNotFoundError for missing state", async () => {
+      setupChainableMock([]);
+
+      const { consumeOAuthState } = await import("@/lib/social/repository");
+      await expect(consumeOAuthState("missing")).rejects.toThrow(
+        OAuthStateNotFoundError,
+      );
+    });
+
+    it("throws OAuthStateExpiredError for expired state", async () => {
+      const pastDate = new Date(Date.now() - 3600_000);
+      setupChainableMock([
+        { id: "soauth_1", state: "test", expiresAt: pastDate },
+      ]);
+
+      const { consumeOAuthState } = await import("@/lib/social/repository");
+      await expect(consumeOAuthState("test")).rejects.toThrow(
+        OAuthStateExpiredError,
+      );
+    });
+  });
+
+  describe("upsertSocialAccount", () => {
+    it("creates a new account with generated ID", async () => {
+      const mockAccount = {
+        id: "sacct_test",
+        platform: "linkedin",
+        displayName: "Test User",
+      };
+      setupChainableMock([mockAccount]);
+
+      const { upsertSocialAccount } = await import("@/lib/social/repository");
+      const result = await upsertSocialAccount({
+        workspaceId: "ws_1",
+        platform: "linkedin",
+        platformUserId: "user123",
+        displayName: "Test User",
+        accessTokenEncrypted: "enc_token",
+        createdByUserId: "user_1",
+      });
+
+      expect(mockInsert).toHaveBeenCalled();
+      expect(result).toEqual(mockAccount);
+    });
+  });
+
+  describe("getSocialAccount", () => {
+    it("throws SocialAccountNotFoundError when not found", async () => {
+      setupChainableMock([]);
+
+      const { getSocialAccount } = await import("@/lib/social/repository");
+      await expect(
+        getSocialAccount("ws_1", "sacct_missing"),
+      ).rejects.toThrow(SocialAccountNotFoundError);
+    });
+  });
+
+  describe("createSocialPost", () => {
+    it("creates a draft post", async () => {
+      const mockPost = {
+        id: "spost_test",
+        status: "draft",
+        content: "Hello world",
+      };
+      setupChainableMock([mockPost]);
+
+      const { createSocialPost } = await import("@/lib/social/repository");
+      const result = await createSocialPost({
+        workspaceId: "ws_1",
+        socialAccountId: "sacct_1",
+        content: "Hello world",
+        createdByUserId: "user_1",
+      });
+
+      expect(result.status).toBe("draft");
+    });
+  });
+
+  describe("updateSocialPost", () => {
+    it("rejects update on non-draft post", async () => {
+      // getSocialPost returns a published post
+      setupChainableMock([
+        { id: "spost_1", status: "published", workspaceId: "ws_1" },
+      ]);
+
+      const { updateSocialPost } = await import("@/lib/social/repository");
+      await expect(
+        updateSocialPost("ws_1", "spost_1", { content: "updated" }),
+      ).rejects.toThrow(SocialPostStateTransitionError);
+    });
+  });
+
+  describe("deleteSocialPost", () => {
+    it("rejects delete on queued post", async () => {
+      setupChainableMock([
+        { id: "spost_1", status: "queued", workspaceId: "ws_1" },
+      ]);
+
+      const { deleteSocialPost } = await import("@/lib/social/repository");
+      await expect(deleteSocialPost("ws_1", "spost_1")).rejects.toThrow(
+        SocialPostStateTransitionError,
+      );
+    });
+
+    it("rejects delete on publishing post", async () => {
+      setupChainableMock([
+        { id: "spost_1", status: "publishing", workspaceId: "ws_1" },
+      ]);
+
+      const { deleteSocialPost } = await import("@/lib/social/repository");
+      await expect(deleteSocialPost("ws_1", "spost_1")).rejects.toThrow(
+        SocialPostStateTransitionError,
+      );
+    });
+  });
+});

--- a/src/lib/social/client.ts
+++ b/src/lib/social/client.ts
@@ -1,0 +1,261 @@
+/**
+ * Social Hub client — frontend helper functions for social API routes.
+ * Follows the same pattern as src/lib/studio/client.ts.
+ */
+
+import { getActiveWorkspaceId, StudioApiError } from "@/lib/studio/client";
+import type { ProviderCapabilities } from "@/lib/social/provider-interface";
+import type { SocialPlatform, SocialPostStatus } from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// Internal helpers (reuse studio client patterns)
+// ---------------------------------------------------------------------------
+
+type JsonRecord = Record<string, unknown>;
+
+function mergeHeaders(init?: RequestInit): Headers {
+  const headers = new Headers(init?.headers || {});
+  const workspaceId = getActiveWorkspaceId();
+  if (workspaceId) {
+    headers.set("x-workspace-id", workspaceId);
+  }
+  return headers;
+}
+
+async function socialFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<JsonRecord> {
+  const workspaceId = getActiveWorkspaceId();
+  if (!workspaceId) {
+    throw new StudioApiError(403, "Select a workspace to continue.");
+  }
+
+  const response = await fetch(path, {
+    ...init,
+    headers: mergeHeaders(init),
+  });
+
+  let data: unknown = null;
+  try {
+    data = await response.json();
+  } catch {
+    throw new StudioApiError(
+      response.status,
+      `Request failed with status ${response.status}`,
+    );
+  }
+
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new StudioApiError(response.status, "Invalid API response");
+  }
+
+  const record = data as JsonRecord;
+  if (record.success === false) {
+    const message =
+      typeof record.error === "string" ? record.error : "Request failed";
+    throw new StudioApiError(response.status, message);
+  }
+
+  return record;
+}
+
+// ---------------------------------------------------------------------------
+// Types (safe API response shapes — no encrypted tokens)
+// ---------------------------------------------------------------------------
+
+export interface SocialAccount {
+  id: string;
+  workspaceId: string;
+  platform: SocialPlatform;
+  platformUserId: string;
+  displayName: string;
+  username?: string | null;
+  avatarUrl?: string | null;
+  tokenExpiresAt?: string | null;
+  requiresReauth: boolean;
+  disabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SocialPost {
+  id: string;
+  workspaceId: string;
+  socialAccountId: string;
+  status: SocialPostStatus;
+  content?: string | null;
+  mediaUrls?: Array<{ type: string; url: string; alt?: string }> | null;
+  platformSettings?: Record<string, unknown> | null;
+  scheduledAt?: string | null;
+  publishedAt?: string | null;
+  platformPostId?: string | null;
+  platformPostUrl?: string | null;
+  errorMessage?: string | null;
+  retryCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PageInfo {
+  id: string;
+  name: string;
+  picture?: string;
+  username?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+export async function listSocialProviders(): Promise<ProviderCapabilities[]> {
+  const data = await socialFetch("/api/social/providers");
+  return (data.providers as ProviderCapabilities[]) || [];
+}
+
+// ---------------------------------------------------------------------------
+// Accounts
+// ---------------------------------------------------------------------------
+
+export async function listSocialAccounts(): Promise<SocialAccount[]> {
+  const data = await socialFetch("/api/social/accounts");
+  return (data.accounts as SocialAccount[]) || [];
+}
+
+export async function connectSocialAccount(
+  platform: string,
+): Promise<{ authUrl: string }> {
+  const data = await socialFetch("/api/social/accounts/connect", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ platform }),
+  });
+  return { authUrl: data.authUrl as string };
+}
+
+export async function handleOAuthCallback(
+  platform: string,
+  code: string,
+  state: string,
+): Promise<{
+  account?: SocialAccount;
+  pages?: PageInfo[];
+  requiresPageSelection?: boolean;
+}> {
+  const data = await socialFetch("/api/social/accounts/callback", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ platform, code, state }),
+  });
+
+  return {
+    account: data.account as SocialAccount | undefined,
+    pages: data.pages as PageInfo[] | undefined,
+    requiresPageSelection: data.requiresPageSelection as boolean | undefined,
+  };
+}
+
+export async function selectPage(
+  platform: string,
+  pageId: string,
+  accessToken: string,
+  refreshToken?: string,
+  expiresIn?: number,
+): Promise<SocialAccount> {
+  const data = await socialFetch("/api/social/accounts/select-page", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ platform, pageId, accessToken, refreshToken, expiresIn }),
+  });
+  return data.account as SocialAccount;
+}
+
+export async function getSocialAccount(
+  accountId: string,
+): Promise<SocialAccount> {
+  const data = await socialFetch(`/api/social/accounts/${accountId}`);
+  return data.account as SocialAccount;
+}
+
+export async function disconnectSocialAccount(
+  accountId: string,
+): Promise<void> {
+  await socialFetch(`/api/social/accounts/${accountId}`, {
+    method: "DELETE",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Posts
+// ---------------------------------------------------------------------------
+
+export async function listSocialPosts(filters?: {
+  status?: SocialPostStatus;
+  socialAccountId?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<SocialPost[]> {
+  const params = new URLSearchParams();
+  if (filters?.status) params.set("status", filters.status);
+  if (filters?.socialAccountId) params.set("socialAccountId", filters.socialAccountId);
+  if (filters?.limit) params.set("limit", String(filters.limit));
+  if (filters?.offset) params.set("offset", String(filters.offset));
+
+  const qs = params.toString();
+  const data = await socialFetch(`/api/social/posts${qs ? `?${qs}` : ""}`);
+  return (data.posts as SocialPost[]) || [];
+}
+
+export async function createSocialPost(input: {
+  socialAccountId: string;
+  content?: string;
+  mediaUrls?: Array<{ type: string; url: string; alt?: string }>;
+  platformSettings?: Record<string, unknown>;
+  scheduledAt?: string;
+  studioAssetId?: string;
+}): Promise<SocialPost> {
+  const data = await socialFetch("/api/social/posts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return data.post as SocialPost;
+}
+
+export async function getSocialPost(postId: string): Promise<SocialPost> {
+  const data = await socialFetch(`/api/social/posts/${postId}`);
+  return data.post as SocialPost;
+}
+
+export async function updateSocialPost(
+  postId: string,
+  input: {
+    content?: string;
+    mediaUrls?: Array<{ type: string; url: string; alt?: string }>;
+    platformSettings?: Record<string, unknown>;
+    scheduledAt?: string | null;
+  },
+): Promise<SocialPost> {
+  const data = await socialFetch(`/api/social/posts/${postId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return data.post as SocialPost;
+}
+
+export async function deleteSocialPost(postId: string): Promise<void> {
+  await socialFetch(`/api/social/posts/${postId}`, { method: "DELETE" });
+}
+
+export async function publishSocialPost(postId: string): Promise<SocialPost> {
+  const data = await socialFetch(`/api/social/posts/${postId}/publish`, {
+    method: "POST",
+  });
+  return data.post as SocialPost;
+}
+
+export async function retrySocialPost(postId: string): Promise<SocialPost> {
+  // Retry uses the same publish endpoint — it accepts "failed" posts too
+  return publishSocialPost(postId);
+}

--- a/src/lib/social/repository.ts
+++ b/src/lib/social/repository.ts
@@ -1,0 +1,500 @@
+import { randomUUID } from "node:crypto";
+import { and, desc, eq, lt, sql } from "drizzle-orm";
+import { getDb } from "@/lib/db";
+import {
+  socialAccounts,
+  socialOAuthStates,
+  socialPosts,
+  type SocialPlatform,
+  type SocialPostStatus,
+} from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class SocialAccountNotFoundError extends Error {
+  constructor(id?: string) {
+    super(id ? `Social account "${id}" not found.` : "Social account not found.");
+    this.name = "SocialAccountNotFoundError";
+  }
+}
+
+export class SocialPostNotFoundError extends Error {
+  constructor(id?: string) {
+    super(id ? `Social post "${id}" not found.` : "Social post not found.");
+    this.name = "SocialPostNotFoundError";
+  }
+}
+
+export class SocialPostStateTransitionError extends Error {
+  currentStatus: SocialPostStatus;
+  targetStatus: SocialPostStatus;
+
+  constructor(currentStatus: SocialPostStatus, targetStatus: SocialPostStatus) {
+    super(
+      `Cannot transition post from "${currentStatus}" to "${targetStatus}".`,
+    );
+    this.name = "SocialPostStateTransitionError";
+    this.currentStatus = currentStatus;
+    this.targetStatus = targetStatus;
+  }
+}
+
+export class OAuthStateNotFoundError extends Error {
+  constructor() {
+    super("OAuth state not found or already consumed.");
+    this.name = "OAuthStateNotFoundError";
+  }
+}
+
+export class OAuthStateExpiredError extends Error {
+  constructor() {
+    super("OAuth state has expired. Please try connecting again.");
+    this.name = "OAuthStateExpiredError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OAuth States
+// ---------------------------------------------------------------------------
+
+export async function createOAuthState(input: {
+  workspaceId: string;
+  platform: SocialPlatform;
+  state: string;
+  codeVerifier?: string;
+  metadata?: Record<string, unknown>;
+  expiresAt: Date;
+}) {
+  const db = getDb();
+  const id = `soauth_${randomUUID()}`;
+
+  const [row] = await db
+    .insert(socialOAuthStates)
+    .values({
+      id,
+      workspaceId: input.workspaceId,
+      platform: input.platform,
+      state: input.state,
+      codeVerifier: input.codeVerifier ?? null,
+      metadata: input.metadata ?? null,
+      expiresAt: input.expiresAt,
+    })
+    .returning();
+
+  return row;
+}
+
+/**
+ * Consume an OAuth state: look it up, validate expiry, then delete it.
+ * This is atomic — the state can only be consumed once (replay protection).
+ */
+export async function consumeOAuthState(state: string) {
+  const db = getDb();
+
+  const [row] = await db
+    .delete(socialOAuthStates)
+    .where(eq(socialOAuthStates.state, state))
+    .returning();
+
+  if (!row) {
+    throw new OAuthStateNotFoundError();
+  }
+
+  if (row.expiresAt < new Date()) {
+    throw new OAuthStateExpiredError();
+  }
+
+  return row;
+}
+
+export async function cleanupExpiredOAuthStates() {
+  const db = getDb();
+  return db
+    .delete(socialOAuthStates)
+    .where(lt(socialOAuthStates.expiresAt, new Date()));
+}
+
+// ---------------------------------------------------------------------------
+// Social Accounts
+// ---------------------------------------------------------------------------
+
+export async function upsertSocialAccount(input: {
+  workspaceId: string;
+  platform: SocialPlatform;
+  platformUserId: string;
+  displayName: string;
+  username?: string;
+  avatarUrl?: string;
+  accessTokenEncrypted: string;
+  refreshTokenEncrypted?: string;
+  accessTokenSecret?: string;
+  tokenExpiresAt?: Date;
+  additionalSettings?: Record<string, unknown>;
+  createdByUserId: string;
+}) {
+  const db = getDb();
+  const id = `sacct_${randomUUID()}`;
+  const now = new Date();
+
+  const [row] = await db
+    .insert(socialAccounts)
+    .values({
+      id,
+      workspaceId: input.workspaceId,
+      platform: input.platform,
+      platformUserId: input.platformUserId,
+      displayName: input.displayName,
+      username: input.username ?? null,
+      avatarUrl: input.avatarUrl ?? null,
+      accessTokenEncrypted: input.accessTokenEncrypted,
+      refreshTokenEncrypted: input.refreshTokenEncrypted ?? null,
+      accessTokenSecret: input.accessTokenSecret ?? null,
+      tokenExpiresAt: input.tokenExpiresAt ?? null,
+      additionalSettings: input.additionalSettings ?? null,
+      requiresReauth: false,
+      disabled: false,
+      createdByUserId: input.createdByUserId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        socialAccounts.workspaceId,
+        socialAccounts.platform,
+        socialAccounts.platformUserId,
+      ],
+      set: {
+        displayName: input.displayName,
+        username: input.username ?? null,
+        avatarUrl: input.avatarUrl ?? null,
+        accessTokenEncrypted: input.accessTokenEncrypted,
+        refreshTokenEncrypted: input.refreshTokenEncrypted ?? null,
+        accessTokenSecret: input.accessTokenSecret ?? null,
+        tokenExpiresAt: input.tokenExpiresAt ?? null,
+        additionalSettings: input.additionalSettings ?? null,
+        requiresReauth: false,
+        disabled: false,
+        updatedAt: now,
+      },
+    })
+    .returning();
+
+  return row;
+}
+
+export async function listSocialAccounts(workspaceId: string) {
+  const db = getDb();
+  return db
+    .select()
+    .from(socialAccounts)
+    .where(eq(socialAccounts.workspaceId, workspaceId))
+    .orderBy(desc(socialAccounts.createdAt));
+}
+
+export async function getSocialAccount(
+  workspaceId: string,
+  accountId: string,
+) {
+  const db = getDb();
+  const [row] = await db
+    .select()
+    .from(socialAccounts)
+    .where(
+      and(
+        eq(socialAccounts.workspaceId, workspaceId),
+        eq(socialAccounts.id, accountId),
+      ),
+    );
+
+  if (!row) {
+    throw new SocialAccountNotFoundError(accountId);
+  }
+
+  return row;
+}
+
+export async function getSocialAccountById(accountId: string) {
+  const db = getDb();
+  const [row] = await db
+    .select()
+    .from(socialAccounts)
+    .where(eq(socialAccounts.id, accountId));
+
+  if (!row) {
+    throw new SocialAccountNotFoundError(accountId);
+  }
+
+  return row;
+}
+
+export async function updateSocialAccountTokens(
+  accountId: string,
+  tokens: {
+    accessTokenEncrypted: string;
+    refreshTokenEncrypted?: string;
+    tokenExpiresAt?: Date;
+  },
+) {
+  const db = getDb();
+  const [row] = await db
+    .update(socialAccounts)
+    .set({
+      accessTokenEncrypted: tokens.accessTokenEncrypted,
+      refreshTokenEncrypted: tokens.refreshTokenEncrypted ?? undefined,
+      tokenExpiresAt: tokens.tokenExpiresAt ?? undefined,
+      requiresReauth: false,
+      updatedAt: new Date(),
+    })
+    .where(eq(socialAccounts.id, accountId))
+    .returning();
+
+  if (!row) {
+    throw new SocialAccountNotFoundError(accountId);
+  }
+
+  return row;
+}
+
+export async function markRequiresReauth(accountId: string) {
+  const db = getDb();
+  await db
+    .update(socialAccounts)
+    .set({ requiresReauth: true, updatedAt: new Date() })
+    .where(eq(socialAccounts.id, accountId));
+}
+
+export async function disconnectSocialAccount(
+  workspaceId: string,
+  accountId: string,
+) {
+  const db = getDb();
+
+  // Verify ownership first
+  const [existing] = await db
+    .select({ id: socialAccounts.id })
+    .from(socialAccounts)
+    .where(
+      and(
+        eq(socialAccounts.workspaceId, workspaceId),
+        eq(socialAccounts.id, accountId),
+      ),
+    );
+
+  if (!existing) {
+    throw new SocialAccountNotFoundError(accountId);
+  }
+
+  // Hard delete — cascades to associated posts
+  await db.delete(socialAccounts).where(eq(socialAccounts.id, accountId));
+}
+
+// ---------------------------------------------------------------------------
+// Social Posts
+// ---------------------------------------------------------------------------
+
+export async function createSocialPost(input: {
+  workspaceId: string;
+  socialAccountId: string;
+  content?: string;
+  mediaUrls?: Array<{ type: string; url: string; alt?: string }>;
+  platformSettings?: Record<string, unknown>;
+  scheduledAt?: Date;
+  studioAssetId?: string;
+  createdByUserId: string;
+}) {
+  const db = getDb();
+  const id = `spost_${randomUUID()}`;
+  const now = new Date();
+
+  const [row] = await db
+    .insert(socialPosts)
+    .values({
+      id,
+      workspaceId: input.workspaceId,
+      socialAccountId: input.socialAccountId,
+      status: "draft",
+      content: input.content ?? null,
+      mediaUrls: input.mediaUrls ?? null,
+      platformSettings: input.platformSettings ?? null,
+      scheduledAt: input.scheduledAt ?? null,
+      studioAssetId: input.studioAssetId ?? null,
+      createdByUserId: input.createdByUserId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return row;
+}
+
+export async function listSocialPosts(
+  workspaceId: string,
+  filters?: {
+    status?: SocialPostStatus;
+    socialAccountId?: string;
+    limit?: number;
+    offset?: number;
+  },
+) {
+  const db = getDb();
+  const conditions = [eq(socialPosts.workspaceId, workspaceId)];
+
+  if (filters?.status) {
+    conditions.push(eq(socialPosts.status, filters.status));
+  }
+  if (filters?.socialAccountId) {
+    conditions.push(eq(socialPosts.socialAccountId, filters.socialAccountId));
+  }
+
+  const query = db
+    .select()
+    .from(socialPosts)
+    .where(and(...conditions))
+    .orderBy(desc(socialPosts.createdAt));
+
+  if (filters?.limit) {
+    query.limit(filters.limit);
+  }
+  if (filters?.offset) {
+    query.offset(filters.offset);
+  }
+
+  return query;
+}
+
+export async function getSocialPost(workspaceId: string, postId: string) {
+  const db = getDb();
+  const [row] = await db
+    .select()
+    .from(socialPosts)
+    .where(
+      and(
+        eq(socialPosts.workspaceId, workspaceId),
+        eq(socialPosts.id, postId),
+      ),
+    );
+
+  if (!row) {
+    throw new SocialPostNotFoundError(postId);
+  }
+
+  return row;
+}
+
+export async function updateSocialPost(
+  workspaceId: string,
+  postId: string,
+  data: {
+    content?: string;
+    mediaUrls?: Array<{ type: string; url: string; alt?: string }>;
+    platformSettings?: Record<string, unknown>;
+    scheduledAt?: Date | null;
+  },
+) {
+  const db = getDb();
+
+  // Verify post exists and is a draft
+  const existing = await getSocialPost(workspaceId, postId);
+  if (existing.status !== "draft") {
+    throw new SocialPostStateTransitionError(existing.status, "draft");
+  }
+
+  const [row] = await db
+    .update(socialPosts)
+    .set({
+      ...(data.content !== undefined && { content: data.content }),
+      ...(data.mediaUrls !== undefined && { mediaUrls: data.mediaUrls }),
+      ...(data.platformSettings !== undefined && {
+        platformSettings: data.platformSettings,
+      }),
+      ...(data.scheduledAt !== undefined && { scheduledAt: data.scheduledAt }),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(socialPosts.workspaceId, workspaceId),
+        eq(socialPosts.id, postId),
+      ),
+    )
+    .returning();
+
+  return row;
+}
+
+/**
+ * Update post status — used by the publishing workflow.
+ */
+export async function updatePostStatus(
+  postId: string,
+  status: SocialPostStatus,
+  extra?: {
+    platformPostId?: string;
+    platformPostUrl?: string;
+    publishedAt?: Date;
+    errorMessage?: string;
+  },
+) {
+  const db = getDb();
+
+  const [row] = await db
+    .update(socialPosts)
+    .set({
+      status,
+      ...(extra?.platformPostId !== undefined && {
+        platformPostId: extra.platformPostId,
+      }),
+      ...(extra?.platformPostUrl !== undefined && {
+        platformPostUrl: extra.platformPostUrl,
+      }),
+      ...(extra?.publishedAt !== undefined && {
+        publishedAt: extra.publishedAt,
+      }),
+      ...(extra?.errorMessage !== undefined && {
+        errorMessage: extra.errorMessage,
+      }),
+      updatedAt: new Date(),
+    })
+    .where(eq(socialPosts.id, postId))
+    .returning();
+
+  if (!row) {
+    throw new SocialPostNotFoundError(postId);
+  }
+
+  return row;
+}
+
+export async function deleteSocialPost(workspaceId: string, postId: string) {
+  const db = getDb();
+
+  // Verify post exists and is in a deletable state
+  const existing = await getSocialPost(workspaceId, postId);
+  if (existing.status !== "draft" && existing.status !== "failed") {
+    throw new SocialPostStateTransitionError(
+      existing.status,
+      "draft", // representing "deleted" intent
+    );
+  }
+
+  await db
+    .delete(socialPosts)
+    .where(
+      and(
+        eq(socialPosts.workspaceId, workspaceId),
+        eq(socialPosts.id, postId),
+      ),
+    );
+}
+
+export async function incrementRetryCount(postId: string) {
+  const db = getDb();
+  await db
+    .update(socialPosts)
+    .set({
+      retryCount: sql`${socialPosts.retryCount} + 1`,
+      updatedAt: new Date(),
+    })
+    .where(eq(socialPosts.id, postId));
+}


### PR DESCRIPTION
## Summary

- **Social repository** (`src/lib/social/repository.ts`): OAuth states (create, consume with replay protection, cleanup), social accounts (upsert, list, get, update tokens, mark reauth, disconnect), social posts (create draft, list with filters, get, update draft-only, update status, delete draft/failed-only, increment retry). 5 error classes.
- **Accounts API** (`/api/social/accounts/*`): List, connect (OAuth initiation), callback (token exchange + encryption), select-page (two-step auth), detail, disconnect. Encrypted tokens never exposed in responses.
- **Posts API** (`/api/social/posts/*`): List with filters, create draft, get, update draft, delete draft/failed, publish trigger (draft/failed → queued). State transition validation at API level.
- **Providers API** (`/api/social/providers`): List available platforms with capabilities.
- **Social client** (`src/lib/social/client.ts`): 13 typed frontend helper functions using workspace-scoped fetch.

## API Routes

```
GET    /api/social/providers
GET    /api/social/accounts
POST   /api/social/accounts/connect
POST   /api/social/accounts/callback
POST   /api/social/accounts/select-page
GET    /api/social/accounts/[accountId]
DELETE /api/social/accounts/[accountId]
GET    /api/social/posts
POST   /api/social/posts
GET    /api/social/posts/[postId]
PATCH  /api/social/posts/[postId]
DELETE /api/social/posts/[postId]
POST   /api/social/posts/[postId]/publish
```

## Test plan

- [x] 15 repository unit tests (CRUD, state transitions, error handling)
- [x] 2024 total tests pass (zero regression)
- [x] Production build succeeds with all 9 social routes registered

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)