### PR TITLE
feat(social): posts API tests, accounts tests, retry fix, gate-a integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "next lint",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:gate-a": "vitest run src/app/api/studio/workspaces/__tests__/route.test.ts src/app/api/studio/projects/__tests__/route.test.ts src/app/api/studio/projects/[projectId]/__tests__/route.test.ts src/app/api/studio/assets/__tests__/route.test.ts src/app/api/studio/assets/[assetId]/__tests__/route.test.ts src/app/api/studio/assets/presign/__tests__/route.test.ts src/components/__tests__/Header.test.tsx",
+    "test:gate-a": "vitest run src/app/api/studio/workspaces/__tests__/route.test.ts src/app/api/studio/projects/__tests__/route.test.ts src/app/api/studio/projects/[projectId]/__tests__/route.test.ts src/app/api/studio/assets/__tests__/route.test.ts src/app/api/studio/assets/[assetId]/__tests__/route.test.ts src/app/api/studio/assets/presign/__tests__/route.test.ts src/app/api/social/accounts/__tests__/route.test.ts src/app/api/social/posts/__tests__/route.test.ts src/components/__tests__/Header.test.tsx",
     "test:coverage": "vitest run --coverage",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",

--- a/src/app/api/social/accounts/__tests__/route.test.ts
+++ b/src/app/api/social/accounts/__tests__/route.test.ts
@@ -1,0 +1,340 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockWithApiPermission = vi.fn();
+const mockListSocialAccounts = vi.fn();
+const mockGetSocialAccount = vi.fn();
+const mockDisconnectSocialAccount = vi.fn();
+const mockCreateOAuthState = vi.fn();
+const mockConsumeOAuthState = vi.fn();
+const mockUpsertSocialAccount = vi.fn();
+const mockGetProvider = vi.fn();
+const mockIsProviderRegistered = vi.fn();
+const mockEncryptToken = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json({ success: false, error: result.error }, { status: result.status }),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  listSocialAccounts: (...args: unknown[]) => mockListSocialAccounts(...args),
+  getSocialAccount: (...args: unknown[]) => mockGetSocialAccount(...args),
+  disconnectSocialAccount: (...args: unknown[]) => mockDisconnectSocialAccount(...args),
+  createOAuthState: (...args: unknown[]) => mockCreateOAuthState(...args),
+  consumeOAuthState: (...args: unknown[]) => mockConsumeOAuthState(...args),
+  upsertSocialAccount: (...args: unknown[]) => mockUpsertSocialAccount(...args),
+  SocialAccountNotFoundError: class extends Error {
+    constructor(id?: string) { super(`Account "${id}" not found.`); this.name = "SocialAccountNotFoundError"; }
+  },
+  OAuthStateNotFoundError: class extends Error {
+    constructor() { super("OAuth state not found."); this.name = "OAuthStateNotFoundError"; }
+  },
+  OAuthStateExpiredError: class extends Error {
+    constructor() { super("OAuth state expired."); this.name = "OAuthStateExpiredError"; }
+  },
+}));
+
+vi.mock("@/lib/social/provider-registry", () => ({
+  getProvider: (...args: unknown[]) => mockGetProvider(...args),
+  isProviderRegistered: (...args: unknown[]) => mockIsProviderRegistered(...args),
+}));
+
+vi.mock("@/lib/social/crypto", () => ({
+  encryptToken: (...args: unknown[]) => mockEncryptToken(...args),
+}));
+
+const mockSession = {
+  user: { id: "user_1", name: "Test", email: "test@example.com" },
+  workspace: { id: "ws_1", organizationId: "org_1" },
+  role: "owner" as const,
+  planTier: "free" as const,
+  permissions: ["social:view", "social:connect", "social:manage"],
+};
+
+function authorized() {
+  mockWithApiPermission.mockResolvedValue({ authorized: true, session: mockSession });
+}
+
+function unauthorized(status: 401 | 403) {
+  mockWithApiPermission.mockResolvedValue({
+    authorized: false,
+    response: NextResponse.json(
+      { success: false, error: status === 401 ? "Unauthenticated" : "Forbidden" },
+      { status },
+    ),
+  });
+}
+
+function createRequest(
+  url = "http://localhost:3000/api/social/accounts",
+  init?: RequestInit,
+): NextRequest {
+  return new NextRequest(url, init);
+}
+
+describe("/api/social/accounts GET", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    unauthorized(401);
+    const { GET } = await import("../../accounts/route");
+    const response = await GET(createRequest());
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for unauthorized requests", async () => {
+    unauthorized(403);
+    const { GET } = await import("../../accounts/route");
+    const response = await GET(createRequest());
+    expect(response.status).toBe(403);
+  });
+
+  it("lists accounts for workspace (strips tokens)", async () => {
+    authorized();
+    mockListSocialAccounts.mockResolvedValue([
+      {
+        id: "sacct_1",
+        platform: "linkedin",
+        displayName: "Test",
+        accessTokenEncrypted: "enc_secret",
+        refreshTokenEncrypted: "enc_refresh",
+        accessTokenSecret: null,
+      },
+    ]);
+    const { GET } = await import("../../accounts/route");
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.accounts).toHaveLength(1);
+    // Encrypted tokens should be stripped
+    expect(data.accounts[0]).not.toHaveProperty("accessTokenEncrypted");
+    expect(data.accounts[0]).not.toHaveProperty("refreshTokenEncrypted");
+    expect(data.accounts[0]).not.toHaveProperty("accessTokenSecret");
+  });
+});
+
+describe("/api/social/accounts/connect POST", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    unauthorized(401);
+    const { POST } = await import("../../accounts/connect/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/accounts/connect", {
+        method: "POST",
+        body: JSON.stringify({ platform: "linkedin" }),
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 for missing platform", async () => {
+    authorized();
+    const { POST } = await import("../../accounts/connect/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/accounts/connect", {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("Platform is required");
+  });
+
+  it("returns 400 for unregistered platform", async () => {
+    authorized();
+    mockIsProviderRegistered.mockReturnValue(false);
+    const { POST } = await import("../../accounts/connect/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/accounts/connect", {
+        method: "POST",
+        body: JSON.stringify({ platform: "unknown" }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("not available");
+  });
+
+  it("returns authUrl for valid platform", async () => {
+    authorized();
+    mockIsProviderRegistered.mockReturnValue(true);
+    mockGetProvider.mockReturnValue({
+      generateAuthUrl: vi.fn().mockResolvedValue({
+        url: "https://linkedin.com/oauth?...",
+        state: "test-state",
+        codeVerifier: "test-verifier",
+      }),
+    });
+    mockCreateOAuthState.mockResolvedValue({ id: "soauth_1" });
+
+    const { POST } = await import("../../accounts/connect/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/accounts/connect", {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+        body: JSON.stringify({ platform: "linkedin" }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.authUrl).toBe("https://linkedin.com/oauth?...");
+    expect(mockCreateOAuthState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        platform: "linkedin",
+        state: "test-state",
+        codeVerifier: "test-verifier",
+      }),
+    );
+  });
+});
+
+describe("/api/social/accounts/callback POST", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for missing fields", async () => {
+    authorized();
+    const { POST } = await import("../../accounts/callback/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/accounts/callback", {
+        method: "POST",
+        body: JSON.stringify({ platform: "linkedin" }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("required");
+  });
+
+  it("returns 400 for expired OAuth state", async () => {
+    authorized();
+    const { OAuthStateExpiredError } = await import("@/lib/social/repository");
+    mockConsumeOAuthState.mockRejectedValue(new OAuthStateExpiredError());
+
+    const { POST } = await import("../../accounts/callback/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/accounts/callback", {
+        method: "POST",
+        body: JSON.stringify({ platform: "linkedin", code: "abc", state: "expired-state" }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("expired");
+  });
+
+  it("creates account on successful OAuth callback", async () => {
+    authorized();
+    mockConsumeOAuthState.mockResolvedValue({
+      id: "soauth_1",
+      workspaceId: "ws_1",
+      platform: "linkedin",
+      codeVerifier: "test-verifier",
+    });
+    mockGetProvider.mockReturnValue({
+      authenticate: vi.fn().mockResolvedValue({
+        platformUserId: "li_user_123",
+        accessToken: "access_tok",
+        refreshToken: "refresh_tok",
+        expiresIn: 3600,
+        displayName: "Test User",
+        username: "testuser",
+        requiresPageSelection: false,
+      }),
+    });
+    mockEncryptToken.mockImplementation((t: string) => `enc_${t}`);
+    mockUpsertSocialAccount.mockResolvedValue({
+      id: "sacct_1",
+      platform: "linkedin",
+      displayName: "Test User",
+      accessTokenEncrypted: "enc_access_tok",
+      refreshTokenEncrypted: "enc_refresh_tok",
+      accessTokenSecret: null,
+    });
+
+    const { POST } = await import("../../accounts/callback/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/accounts/callback", {
+        method: "POST",
+        body: JSON.stringify({ platform: "linkedin", code: "auth_code", state: "valid-state" }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.account).toBeDefined();
+    // Tokens should be stripped from response
+    expect(data.account).not.toHaveProperty("accessTokenEncrypted");
+    expect(mockEncryptToken).toHaveBeenCalledWith("access_tok");
+    expect(mockEncryptToken).toHaveBeenCalledWith("refresh_tok");
+  });
+});
+
+describe("/api/social/accounts/[accountId] DELETE", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    unauthorized(401);
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.DELETE(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", { method: "DELETE" }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("disconnects account successfully", async () => {
+    authorized();
+    mockDisconnectSocialAccount.mockResolvedValue(undefined);
+
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.DELETE(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", { method: "DELETE" }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockDisconnectSocialAccount).toHaveBeenCalledWith("ws_1", "sacct_1");
+  });
+
+  it("returns 404 for unknown account", async () => {
+    authorized();
+    const { SocialAccountNotFoundError } = await import("@/lib/social/repository");
+    mockDisconnectSocialAccount.mockRejectedValue(new SocialAccountNotFoundError("sacct_missing"));
+
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.DELETE(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_missing", { method: "DELETE" }),
+      { params: Promise.resolve({ accountId: "sacct_missing" }) },
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/social/posts/[postId]/publish/route.ts
+++ b/src/app/api/social/posts/[postId]/publish/route.ts
@@ -51,8 +51,10 @@ export async function POST(
     }
 
     // Transition to "queued" — the Vercel Workflow will pick it up
+    // On retry (failed → queued), reset retryCount and clear error
     const updated = await updatePostStatus(postId, "queued", {
       errorMessage: undefined,
+      retryCount: post.status === "failed" ? 0 : undefined,
     });
 
     // TODO: Start Vercel Workflow here once workflows/social-publish.ts is implemented

--- a/src/app/api/social/posts/__tests__/route.test.ts
+++ b/src/app/api/social/posts/__tests__/route.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockWithApiPermission = vi.fn();
+const mockCreateSocialPost = vi.fn();
+const mockListSocialPosts = vi.fn();
+const mockGetSocialPost = vi.fn();
+const mockUpdateSocialPost = vi.fn();
+const mockDeleteSocialPost = vi.fn();
+const mockUpdatePostStatus = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json({ success: false, error: result.error }, { status: result.status }),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  createSocialPost: (...args: unknown[]) => mockCreateSocialPost(...args),
+  listSocialPosts: (...args: unknown[]) => mockListSocialPosts(...args),
+  getSocialPost: (...args: unknown[]) => mockGetSocialPost(...args),
+  updateSocialPost: (...args: unknown[]) => mockUpdateSocialPost(...args),
+  deleteSocialPost: (...args: unknown[]) => mockDeleteSocialPost(...args),
+  updatePostStatus: (...args: unknown[]) => mockUpdatePostStatus(...args),
+  SocialPostNotFoundError: class extends Error {
+    constructor(id?: string) { super(`Post "${id}" not found.`); this.name = "SocialPostNotFoundError"; }
+  },
+  SocialPostStateTransitionError: class extends Error {
+    constructor(from: string, to: string) {
+      super(`Cannot transition from "${from}" to "${to}".`);
+      this.name = "SocialPostStateTransitionError";
+    }
+  },
+}));
+
+const mockSession = {
+  user: { id: "user_1", name: "Test", email: "test@example.com" },
+  workspace: { id: "ws_1", organizationId: "org_1" },
+  role: "owner" as const,
+  planTier: "free" as const,
+  permissions: ["social:view", "social:publish"],
+};
+
+function authorized() {
+  mockWithApiPermission.mockResolvedValue({ authorized: true, session: mockSession });
+}
+
+function unauthorized(status: 401 | 403) {
+  mockWithApiPermission.mockResolvedValue({
+    authorized: false,
+    response: NextResponse.json(
+      { success: false, error: status === 401 ? "Unauthenticated" : "Forbidden" },
+      { status },
+    ),
+  });
+}
+
+function createRequest(
+  url = "http://localhost:3000/api/social/posts",
+  init?: RequestInit,
+): NextRequest {
+  return new NextRequest(url, init);
+}
+
+describe("/api/social/posts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/social/posts", () => {
+    it("returns 401 for unauthenticated requests", async () => {
+      unauthorized(401);
+      const { GET } = await import("../../posts/route");
+      const response = await GET(createRequest());
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 403 for unauthorized requests", async () => {
+      unauthorized(403);
+      const { GET } = await import("../../posts/route");
+      const response = await GET(createRequest());
+      expect(response.status).toBe(403);
+    });
+
+    it("lists posts for workspace", async () => {
+      authorized();
+      mockListSocialPosts.mockResolvedValue([
+        { id: "spost_1", status: "draft", content: "Hello" },
+      ]);
+      const { GET } = await import("../../posts/route");
+      const response = await GET(createRequest());
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.posts).toHaveLength(1);
+      expect(mockListSocialPosts).toHaveBeenCalledWith("ws_1", {
+        status: undefined,
+        socialAccountId: undefined,
+        limit: undefined,
+        offset: undefined,
+      });
+    });
+
+    it("passes filter params to repository", async () => {
+      authorized();
+      mockListSocialPosts.mockResolvedValue([]);
+      const { GET } = await import("../../posts/route");
+      const response = await GET(
+        createRequest("http://localhost:3000/api/social/posts?status=draft&socialAccountId=sacct_1&limit=10&offset=5"),
+      );
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(mockListSocialPosts).toHaveBeenCalledWith("ws_1", {
+        status: "draft",
+        socialAccountId: "sacct_1",
+        limit: 10,
+        offset: 5,
+      });
+    });
+  });
+
+  describe("POST /api/social/posts", () => {
+    it("creates a draft post", async () => {
+      authorized();
+      mockCreateSocialPost.mockResolvedValue({
+        id: "spost_1",
+        status: "draft",
+        content: "Hello world",
+      });
+      const { POST } = await import("../../posts/route");
+      const response = await POST(
+        createRequest("http://localhost:3000/api/social/posts", {
+          method: "POST",
+          body: JSON.stringify({
+            socialAccountId: "sacct_1",
+            content: "Hello world",
+          }),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.post.status).toBe("draft");
+    });
+
+    it("returns 400 when socialAccountId is missing", async () => {
+      authorized();
+      const { POST } = await import("../../posts/route");
+      const response = await POST(
+        createRequest("http://localhost:3000/api/social/posts", {
+          method: "POST",
+          body: JSON.stringify({ content: "Hello" }),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("socialAccountId");
+    });
+
+    it("returns 400 when both content and media are empty", async () => {
+      authorized();
+      const { POST } = await import("../../posts/route");
+      const response = await POST(
+        createRequest("http://localhost:3000/api/social/posts", {
+          method: "POST",
+          body: JSON.stringify({ socialAccountId: "sacct_1" }),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain("Content or media");
+    });
+  });
+});
+
+describe("/api/social/posts/[postId]/publish", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    unauthorized(401);
+    const { POST } = await import("../../posts/[postId]/publish/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/posts/spost_1/publish", { method: "POST" }),
+      { params: Promise.resolve({ postId: "spost_1" }) },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("transitions draft → queued", async () => {
+    authorized();
+    mockGetSocialPost.mockResolvedValue({ id: "spost_1", status: "draft" });
+    mockUpdatePostStatus.mockResolvedValue({ id: "spost_1", status: "queued" });
+
+    const { POST } = await import("../../posts/[postId]/publish/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/posts/spost_1/publish", { method: "POST" }),
+      { params: Promise.resolve({ postId: "spost_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.post.status).toBe("queued");
+    expect(mockUpdatePostStatus).toHaveBeenCalledWith("spost_1", "queued", {
+      errorMessage: undefined,
+      retryCount: undefined,
+    });
+  });
+
+  it("resets retryCount when retrying a failed post", async () => {
+    authorized();
+    mockGetSocialPost.mockResolvedValue({ id: "spost_1", status: "failed", retryCount: 3 });
+    mockUpdatePostStatus.mockResolvedValue({ id: "spost_1", status: "queued", retryCount: 0 });
+
+    const { POST } = await import("../../posts/[postId]/publish/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/posts/spost_1/publish", { method: "POST" }),
+      { params: Promise.resolve({ postId: "spost_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockUpdatePostStatus).toHaveBeenCalledWith("spost_1", "queued", {
+      errorMessage: undefined,
+      retryCount: 0,
+    });
+  });
+
+  it("returns 400 for published post", async () => {
+    authorized();
+    mockGetSocialPost.mockResolvedValue({ id: "spost_1", status: "published" });
+
+    const { POST } = await import("../../posts/[postId]/publish/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/posts/spost_1/publish", { method: "POST" }),
+      { params: Promise.resolve({ postId: "spost_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("published");
+  });
+
+  it("returns 400 for queued post", async () => {
+    authorized();
+    mockGetSocialPost.mockResolvedValue({ id: "spost_1", status: "queued" });
+
+    const { POST } = await import("../../posts/[postId]/publish/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/posts/spost_1/publish", { method: "POST" }),
+      { params: Promise.resolve({ postId: "spost_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("queued");
+  });
+
+  it("returns 400 for publishing post", async () => {
+    authorized();
+    mockGetSocialPost.mockResolvedValue({ id: "spost_1", status: "publishing" });
+
+    const { POST } = await import("../../posts/[postId]/publish/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/posts/spost_1/publish", { method: "POST" }),
+      { params: Promise.resolve({ postId: "spost_1" }) },
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/lib/social/repository.ts
+++ b/src/lib/social/repository.ts
@@ -434,6 +434,7 @@ export async function updatePostStatus(
     platformPostUrl?: string;
     publishedAt?: Date;
     errorMessage?: string;
+    retryCount?: number;
   },
 ) {
   const db = getDb();
@@ -453,6 +454,9 @@ export async function updatePostStatus(
       }),
       ...(extra?.errorMessage !== undefined && {
         errorMessage: extra.errorMessage,
+      }),
+      ...(extra?.retryCount !== undefined && {
+        retryCount: extra.retryCount,
       }),
       updatedAt: new Date(),
     })


### PR DESCRIPTION
## Summary

- **Fix:** Publish endpoint now resets `retryCount` to 0 when retrying a failed post (failed → queued)
- **Posts API tests** (13 tests): auth hardening (401/403), draft creation with validation, filter passthrough, publish state transitions (draft→queued, failed→queued with retry reset), rejects publish on published/queued/publishing
- **Accounts API tests** (13 tests): auth hardening, list with token stripping, connect flow (validates platform, returns authUrl), callback (validates fields, handles expired state, encrypts tokens), disconnect (404 for unknown)
- **Gate-A updated**: now includes social API tests (100 tests across 9 files, up from 74/7)

## Test plan

- [x] 26 new social API route tests (13 posts + 13 accounts)
- [x] Gate-A: 100 tests, 9 files, all green
- [x] Full suite: 2050 tests, 100 files, all green
- [x] Build succeeds

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)