### PR TITLE
feat(social): all 6 social platform provider adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,42 @@ S3_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_FORCE_PATH_STYLE=false
+
+# ------------------------------------------------------------------------------
+# Social Hub — Token Encryption
+# ------------------------------------------------------------------------------
+
+# AES-256-GCM encryption key for social account OAuth tokens at rest.
+# Generate with: openssl rand -hex 32
+# Required in production. In dev with DEV_AUTH_BYPASS=true, tokens are stored in plaintext.
+SOCIAL_TOKEN_ENCRYPTION_KEY=
+
+# ------------------------------------------------------------------------------
+# Social Hub — Platform Credentials
+# ------------------------------------------------------------------------------
+# Each platform requires a developer app. Only configure the platforms you plan to use.
+
+# X (Twitter) — OAuth 1.0a
+# Create app at: https://developer.x.com/en/portal/dashboard
+X_API_KEY=
+X_API_SECRET=
+
+# LinkedIn — OAuth 2.0
+# Create app at: https://www.linkedin.com/developers/apps
+LINKEDIN_CLIENT_ID=
+LINKEDIN_CLIENT_SECRET=
+
+# Meta (Instagram + Facebook) — shared OAuth app
+# Create app at: https://developers.facebook.com/apps/
+META_APP_ID=
+META_APP_SECRET=
+
+# TikTok — OAuth 2.0
+# Create app at: https://developers.tiktok.com/apps/
+TIKTOK_CLIENT_KEY=
+TIKTOK_CLIENT_SECRET=
+
+# YouTube — Google OAuth 2.0 (may share with Better Auth Google OAuth)
+# Create credentials at: https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/src/lib/social/providers/__tests__/facebook.test.ts
+++ b/src/lib/social/providers/__tests__/facebook.test.ts
@@ -1,0 +1,588 @@
+/**
+ * Facebook provider tests.
+ *
+ * All Graph API calls are mocked via vi.stubGlobal("fetch", ...) so no
+ * network access is required.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SocialProviderAdapter } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// Environment stubs
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.stubEnv("META_APP_ID", "test-app-id");
+  vi.stubEnv("META_APP_SECRET", "test-app-secret");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchSequence(
+  responses: Array<Record<string, unknown>>,
+): ReturnType<typeof vi.fn> {
+  let callIndex = 0;
+  const mockFetch = vi.fn().mockImplementation(async () => {
+    const body = responses[callIndex] ?? responses[responses.length - 1];
+    callIndex++;
+    return {
+      json: async () => body,
+      ok: !("error" in body),
+    };
+  });
+  vi.stubGlobal("fetch", mockFetch);
+  return mockFetch;
+}
+
+async function loadProvider(): Promise<SocialProviderAdapter> {
+  const mod = await import("@/lib/social/providers/facebook");
+  return mod.facebookProvider;
+}
+
+// ---------------------------------------------------------------------------
+// generateAuthUrl
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.generateAuthUrl", () => {
+  it("returns a valid Facebook OAuth dialog URL", async () => {
+    const provider = await loadProvider();
+    const result = await provider.generateAuthUrl(
+      "https://example.com/callback/facebook",
+    );
+
+    expect(result.url).toContain("https://www.facebook.com/v20.0/dialog/oauth");
+    expect(result.url).toContain("client_id=test-app-id");
+    expect(result.url).toContain(
+      encodeURIComponent("https://example.com/callback/facebook"),
+    );
+    expect(result.state).toBeTruthy();
+    expect(result.state.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("includes all required Facebook page-management scopes", async () => {
+    const provider = await loadProvider();
+    const { url } = await provider.generateAuthUrl("https://example.com/cb");
+
+    const expectedScopes = [
+      "pages_show_list",
+      "business_management",
+      "pages_manage_posts",
+      "pages_manage_engagement",
+      "pages_read_engagement",
+      "read_insights",
+    ];
+
+    for (const scope of expectedScopes) {
+      expect(url).toContain(scope);
+    }
+  });
+
+  it("does not include Instagram-specific scopes", async () => {
+    const provider = await loadProvider();
+    const { url } = await provider.generateAuthUrl("https://example.com/cb");
+
+    expect(url).not.toContain("instagram_content_publish");
+    expect(url).not.toContain("instagram_basic");
+  });
+
+  it("generates a unique state on each call", async () => {
+    const provider = await loadProvider();
+    const a = await provider.generateAuthUrl("https://example.com/cb");
+    const b = await provider.generateAuthUrl("https://example.com/cb");
+    expect(a.state).not.toBe(b.state);
+  });
+
+  it("throws when META_APP_ID is missing", async () => {
+    vi.stubEnv("META_APP_ID", "");
+    vi.resetModules();
+    const provider = await loadProvider();
+    await expect(
+      provider.generateAuthUrl("https://example.com/cb"),
+    ).rejects.toThrow("META_APP_ID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// authenticate
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.authenticate", () => {
+  it("exchanges code for long-lived token and returns profile data", async () => {
+    mockFetchSequence([
+      // 1. Short-lived token
+      { access_token: "short-token", token_type: "bearer" },
+      // 2. Long-lived token
+      { access_token: "long-token", token_type: "bearer", expires_in: 5097600 },
+      // 3. Permission check
+      {
+        data: [
+          { permission: "pages_show_list", status: "granted" },
+          { permission: "business_management", status: "granted" },
+          { permission: "pages_manage_posts", status: "granted" },
+          { permission: "pages_manage_engagement", status: "granted" },
+          { permission: "pages_read_engagement", status: "granted" },
+          { permission: "read_insights", status: "granted" },
+        ],
+      },
+      // 4. /me?fields=id,name,picture
+      {
+        id: "fb-user-123",
+        name: "Test Page Admin",
+        picture: { data: { url: "https://example.com/avatar.jpg" } },
+      },
+    ]);
+
+    const provider = await loadProvider();
+    const result = await provider.authenticate({
+      code: "auth-code",
+      codeVerifier: "https://example.com/callback",
+    });
+
+    expect(result.platformUserId).toBe("fb-user-123");
+    expect(result.accessToken).toBe("long-token");
+    expect(result.displayName).toBe("Test Page Admin");
+    expect(result.avatarUrl).toBe("https://example.com/avatar.jpg");
+    expect(result.requiresPageSelection).toBe(true);
+    expect(result.expiresIn).toBe(5097600);
+  });
+
+  it("throws when a required permission is missing", async () => {
+    mockFetchSequence([
+      { access_token: "short-token", token_type: "bearer" },
+      { access_token: "long-token", token_type: "bearer", expires_in: 5097600 },
+      // Missing pages_manage_posts
+      {
+        data: [
+          { permission: "pages_show_list", status: "granted" },
+          { permission: "business_management", status: "granted" },
+        ],
+      },
+    ]);
+
+    const provider = await loadProvider();
+    await expect(
+      provider.authenticate({ code: "auth-code", codeVerifier: "https://example.com/cb" }),
+    ).rejects.toThrow(/pages_manage_posts/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPageInformation
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.fetchPageInformation", () => {
+  it("returns list of pages with access tokens", async () => {
+    mockFetchSequence([
+      // /me/accounts
+      {
+        data: [
+          {
+            id: "page-1",
+            name: "My Business Page",
+            username: "mybizpage",
+            access_token: "page-token-1",
+            picture: { data: { url: "https://example.com/page.jpg" } },
+          },
+        ],
+        paging: {},
+      },
+      // /me/businesses
+      { data: [], paging: {} },
+    ]);
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("user-token");
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].id).toBe("page-1");
+    expect(pages[0].name).toBe("My Business Page");
+    expect(pages[0].username).toBe("mybizpage");
+    expect(pages[0].accessToken).toBe("page-token-1");
+    expect(pages[0].picture).toBe("https://example.com/page.jpg");
+  });
+
+  it("returns empty list when user has no pages", async () => {
+    mockFetchSequence([
+      { data: [], paging: {} },
+      { data: [], paging: {} },
+    ]);
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("user-token");
+    expect(pages).toHaveLength(0);
+  });
+
+  it("deduplicates pages seen in both /me/accounts and Business Manager", async () => {
+    mockFetchSequence([
+      // /me/accounts
+      {
+        data: [
+          {
+            id: "page-1",
+            name: "Page 1",
+            access_token: "tok-1",
+            picture: { data: { url: "" } },
+          },
+        ],
+        paging: {},
+      },
+      // /me/businesses
+      {
+        data: [{ id: "biz-1" }],
+        paging: {},
+      },
+      // owned_pages — returns the same page-1 again
+      {
+        data: [
+          {
+            id: "page-1",
+            name: "Page 1 duplicate",
+            access_token: "tok-1",
+            picture: { data: { url: "" } },
+          },
+        ],
+        paging: {},
+      },
+      // client_pages — empty
+      { data: [], paging: {} },
+    ]);
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("user-token");
+
+    // Should deduplicate by page id
+    const uniqueIds = new Set(pages.map((p) => p.id));
+    expect(uniqueIds.size).toBe(pages.length);
+    expect(pages.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — text only
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.post — text only", () => {
+  it("publishes a text-only post to the page feed", async () => {
+    mockFetchSequence([
+      // /feed response
+      {
+        id: "post-123",
+        permalink_url: "https://www.facebook.com/mybizpage/posts/post-123",
+      },
+    ]);
+
+    const provider = await loadProvider();
+    const results = await provider.post("page-id", "page-access-token", [
+      {
+        postId: "our-post-1",
+        content: "Hello Facebook!",
+      },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].postId).toBe("our-post-1");
+    expect(results[0].platformPostId).toBe("post-123");
+    expect(results[0].platformPostUrl).toBe(
+      "https://www.facebook.com/mybizpage/posts/post-123",
+    );
+    expect(results[0].status).toBe("published");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — single photo
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.post — single photo", () => {
+  it("uploads photo as unpublished then publishes feed post with attached_media", async () => {
+    mockFetchSequence([
+      // Upload photo (unpublished)
+      { id: "photo-456" },
+      // Feed post
+      {
+        id: "feed-post-789",
+        permalink_url: "https://www.facebook.com/mybizpage/posts/789",
+      },
+    ]);
+
+    const provider = await loadProvider();
+    const results = await provider.post("page-id", "page-access-token", [
+      {
+        postId: "our-photo-post",
+        content: "Look at this!",
+        media: [{ type: "image", url: "https://cdn.example.com/photo.jpg" }],
+      },
+    ]);
+
+    expect(results[0].platformPostId).toBe("feed-post-789");
+    expect(results[0].status).toBe("published");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — multi-photo
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.post — multi-photo", () => {
+  it("uploads each photo separately then creates a feed post with all attached", async () => {
+    mockFetchSequence([
+      // Upload photo 1
+      { id: "photo-1" },
+      // Upload photo 2
+      { id: "photo-2" },
+      // Upload photo 3
+      { id: "photo-3" },
+      // Feed post
+      {
+        id: "multi-post",
+        permalink_url: "https://www.facebook.com/page/posts/multi-post",
+      },
+    ]);
+
+    const provider = await loadProvider();
+    const results = await provider.post("page-id", "page-access-token", [
+      {
+        postId: "our-multi-post",
+        content: "Multi-photo post",
+        media: [
+          { type: "image", url: "https://cdn.example.com/1.jpg" },
+          { type: "image", url: "https://cdn.example.com/2.jpg" },
+          { type: "image", url: "https://cdn.example.com/3.jpg" },
+        ],
+      },
+    ]);
+
+    expect(results[0].platformPostId).toBe("multi-post");
+
+    // Verify each photo was uploaded
+    const mockFetch = vi.mocked(global.fetch);
+    const photoCalls = mockFetch.mock.calls.filter((call) =>
+      String(call[0]).includes("/photos"),
+    );
+    expect(photoCalls).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — video
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.post — video", () => {
+  it("posts video to /{page-id}/videos", async () => {
+    mockFetchSequence([
+      // /videos response
+      {
+        id: "video-id-999",
+        permalink_url: undefined, // Facebook doesn't always return this
+      },
+    ]);
+
+    const provider = await loadProvider();
+    const results = await provider.post("page-id", "page-access-token", [
+      {
+        postId: "video-post",
+        content: "Check out this video",
+        media: [{ type: "video", url: "https://cdn.example.com/video.mp4" }],
+      },
+    ]);
+
+    expect(results[0].platformPostId).toBe("video-id-999");
+    // Falls back to reel URL when permalink_url not returned
+    expect(results[0].platformPostUrl).toContain("video-id-999");
+    expect(results[0].status).toBe("published");
+
+    // Verify it used /videos endpoint
+    const mockFetch = vi.mocked(global.fetch);
+    const videoCall = mockFetch.mock.calls.find((call) =>
+      String(call[0]).includes("/videos"),
+    );
+    expect(videoCall).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — link attachment
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.post — link attachment", () => {
+  it("includes link from platformSettings in feed body", async () => {
+    mockFetchSequence([
+      {
+        id: "link-post",
+        permalink_url: "https://www.facebook.com/page/posts/link-post",
+      },
+    ]);
+
+    const provider = await loadProvider();
+    await provider.post("page-id", "page-access-token", [
+      {
+        postId: "link-post",
+        content: "Check this out",
+        platformSettings: { link: "https://example.com/article" },
+      },
+    ]);
+
+    const mockFetch = vi.mocked(global.fetch);
+    const feedCall = mockFetch.mock.calls.find((call) =>
+      String(call[0]).includes("/feed"),
+    );
+    expect(feedCall).toBeDefined();
+    const body = JSON.parse(feedCall?.[1]?.body as string);
+    expect(body.link).toBe("https://example.com/article");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — empty request
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.post — empty request array", () => {
+  it("returns empty results for empty request array", async () => {
+    const provider = await loadProvider();
+    const results = await provider.post("page-id", "token", []);
+    expect(results).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyError
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.classifyError", () => {
+  it("classifies Error validating access token as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error("Error validating access token: session has been invalidated"),
+    );
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies 490 error as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":490,"message":"Token expired"}}'),
+    );
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies REVOKED_ACCESS_TOKEN as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError("REVOKED_ACCESS_TOKEN has occurred");
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies 1366046 (photo too large) as bad-body", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":1366046,"message":"Photo too large"}}'),
+    );
+    expect(result.type).toBe("bad-body");
+    expect(result.message).toContain("4 MB");
+  });
+
+  it("classifies 1390008 (posting too fast) as bad-body", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":1390008,"message":"Posting too fast"}}'),
+    );
+    expect(result.type).toBe("bad-body");
+    expect(result.message).toContain("too fast");
+  });
+
+  it("classifies 1346003 (abusive content) as bad-body", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":1346003,"message":"Abusive content"}}'),
+    );
+    expect(result.type).toBe("bad-body");
+    expect(result.message).toContain("abusive");
+  });
+
+  it("classifies 1609008 (cannot post FB links) as bad-body", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":1609008,"message":"Cannot post Facebook.com links"}}'),
+    );
+    expect(result.type).toBe("bad-body");
+  });
+
+  it("classifies temporary unavailability (1363047) as retry", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":1363047,"message":"Service temporarily unavailable"}}'),
+    );
+    expect(result.type).toBe("retry");
+  });
+
+  it("classifies 1404078 (page authorization) as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":1404078,"message":"Page publishing authorization required"}}'),
+    );
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies unknown error as retry", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(new Error("Something unusual happened"));
+    expect(result.type).toBe("retry");
+    expect(result.message).toContain("Something unusual happened");
+  });
+
+  it("classifies non-Error objects as retry", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError({ weird: "object" });
+    expect(result.type).toBe("retry");
+  });
+
+  it("handles string errors", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError("1404102 community standards");
+    expect(result.type).toBe("bad-body");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCapabilities
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider.getCapabilities", () => {
+  it("returns correct capabilities", async () => {
+    const provider = await loadProvider();
+    const caps = provider.getCapabilities();
+    expect(caps.identifier).toBe("facebook");
+    expect(caps.displayName).toBe("Facebook");
+    expect(caps.maxContentLength).toBe(63206);
+    expect(caps.supportsImages).toBe(true);
+    expect(caps.supportsVideo).toBe(true);
+    expect(caps.supportsCarousel).toBe(true);
+    expect(caps.requiresPageSelection).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider interface conformance
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider interface conformance", () => {
+  it("has all required interface properties", async () => {
+    const provider = await loadProvider();
+    expect(provider.identifier).toBe("facebook");
+    expect(provider.maxImages).toBe(10);
+    expect(provider.maxConcurrentJobs).toBeGreaterThan(0);
+    expect(typeof provider.generateAuthUrl).toBe("function");
+    expect(typeof provider.authenticate).toBe("function");
+    expect(typeof provider.refreshToken).toBe("function");
+    expect(typeof provider.post).toBe("function");
+    expect(typeof provider.classifyError).toBe("function");
+    expect(typeof provider.fetchPageInformation).toBe("function");
+    expect(typeof provider.getCapabilities).toBe("function");
+  });
+});

--- a/src/lib/social/providers/__tests__/instagram.test.ts
+++ b/src/lib/social/providers/__tests__/instagram.test.ts
@@ -1,0 +1,580 @@
+/**
+ * Instagram provider tests.
+ *
+ * All Graph API calls are mocked via vi.stubGlobal("fetch", ...) so no
+ * network access is required and we can exercise every branch in isolation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SocialProviderAdapter } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// Environment stubs
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.stubEnv("META_APP_ID", "test-app-id");
+  vi.stubEnv("META_APP_SECRET", "test-app-secret");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchSequence(
+  responses: Array<Record<string, unknown>>,
+): ReturnType<typeof vi.fn> {
+  let callIndex = 0;
+  const mockFetch = vi.fn().mockImplementation(async () => {
+    const body = responses[callIndex] ?? responses[responses.length - 1];
+    callIndex++;
+    return {
+      json: async () => body,
+      ok: !("error" in body),
+    };
+  });
+  vi.stubGlobal("fetch", mockFetch);
+  return mockFetch;
+}
+
+async function loadProvider(): Promise<SocialProviderAdapter> {
+  const mod = await import("@/lib/social/providers/instagram");
+  return mod.instagramProvider;
+}
+
+// ---------------------------------------------------------------------------
+// generateAuthUrl
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.generateAuthUrl", () => {
+  it("returns a valid Facebook OAuth dialog URL", async () => {
+    const provider = await loadProvider();
+    const result = await provider.generateAuthUrl(
+      "https://example.com/callback/instagram",
+    );
+
+    expect(result.url).toContain("https://www.facebook.com/v20.0/dialog/oauth");
+    expect(result.url).toContain("client_id=test-app-id");
+    expect(result.url).toContain(encodeURIComponent("https://example.com/callback/instagram"));
+    expect(result.url).toContain("instagram_basic");
+    expect(result.url).toContain("instagram_content_publish");
+    expect(result.state).toBeTruthy();
+    expect(result.state.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("includes all required Instagram scopes", async () => {
+    const provider = await loadProvider();
+    const { url } = await provider.generateAuthUrl("https://example.com/cb");
+
+    const expectedScopes = [
+      "instagram_basic",
+      "pages_show_list",
+      "pages_read_engagement",
+      "business_management",
+      "instagram_content_publish",
+      "instagram_manage_comments",
+      "instagram_manage_insights",
+    ];
+
+    for (const scope of expectedScopes) {
+      expect(url).toContain(scope);
+    }
+  });
+
+  it("generates a unique state on each call", async () => {
+    const provider = await loadProvider();
+    const a = await provider.generateAuthUrl("https://example.com/cb");
+    const b = await provider.generateAuthUrl("https://example.com/cb");
+    expect(a.state).not.toBe(b.state);
+  });
+
+  it("throws when META_APP_ID is missing", async () => {
+    vi.stubEnv("META_APP_ID", "");
+    // Re-import so the env variable is re-read
+    vi.resetModules();
+    const provider = await loadProvider();
+    await expect(
+      provider.generateAuthUrl("https://example.com/cb"),
+    ).rejects.toThrow("META_APP_ID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// authenticate (token exchange)
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.authenticate", () => {
+  it("exchanges code for long-lived token and returns profile data", async () => {
+    mockFetchSequence([
+      // 1. Short-lived token exchange
+      { access_token: "short-token", token_type: "bearer" },
+      // 2. Long-lived token exchange
+      { access_token: "long-token", token_type: "bearer", expires_in: 5097600 },
+      // 3. Permission check
+      {
+        data: [
+          { permission: "instagram_basic", status: "granted" },
+          { permission: "pages_show_list", status: "granted" },
+          { permission: "pages_read_engagement", status: "granted" },
+          { permission: "business_management", status: "granted" },
+          { permission: "instagram_content_publish", status: "granted" },
+          { permission: "instagram_manage_comments", status: "granted" },
+          { permission: "instagram_manage_insights", status: "granted" },
+        ],
+      },
+      // 4. /me?fields=id,name,picture
+      {
+        id: "123456",
+        name: "Test User",
+        picture: { data: { url: "https://example.com/pic.jpg" } },
+      },
+    ]);
+
+    const provider = await loadProvider();
+    const result = await provider.authenticate({
+      code: "auth-code",
+      codeVerifier: "https://example.com/callback",
+    });
+
+    expect(result.platformUserId).toBe("123456");
+    expect(result.accessToken).toBe("long-token");
+    expect(result.displayName).toBe("Test User");
+    expect(result.avatarUrl).toBe("https://example.com/pic.jpg");
+    expect(result.requiresPageSelection).toBe(true);
+    expect(result.expiresIn).toBe(5097600);
+  });
+
+  it("throws when a required permission is missing", async () => {
+    mockFetchSequence([
+      { access_token: "short-token", token_type: "bearer" },
+      { access_token: "long-token", token_type: "bearer", expires_in: 5097600 },
+      // Missing instagram_content_publish
+      {
+        data: [
+          { permission: "instagram_basic", status: "granted" },
+          { permission: "pages_show_list", status: "granted" },
+          { permission: "pages_read_engagement", status: "granted" },
+          { permission: "business_management", status: "granted" },
+        ],
+      },
+    ]);
+
+    const provider = await loadProvider();
+    await expect(
+      provider.authenticate({ code: "auth-code", codeVerifier: "https://example.com/cb" }),
+    ).rejects.toThrow(/instagram_content_publish/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPageInformation
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.fetchPageInformation", () => {
+  it("returns list of Instagram Business accounts linked to FB Pages", async () => {
+    mockFetchSequence([
+      // /me/accounts
+      {
+        data: [
+          {
+            id: "fb-page-1",
+            name: "My FB Page",
+            instagram_business_account: { id: "ig-biz-1" },
+          },
+        ],
+        paging: {},
+      },
+      // /me/businesses
+      { data: [], paging: {} },
+      // IG user details for ig-biz-1
+      {
+        id: "ig-biz-1",
+        name: "My IG Account",
+        username: "myigaccount",
+        profile_picture_url: "https://example.com/ig.jpg",
+      },
+      // Page access token
+      { access_token: "page-access-token" },
+    ]);
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("user-token");
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].id).toBe("ig-biz-1");
+    expect(pages[0].name).toBe("My IG Account");
+    expect(pages[0].username).toBe("myigaccount");
+    expect(pages[0].accessToken).toBe("page-access-token");
+  });
+
+  it("returns empty list when no pages have IG business accounts", async () => {
+    mockFetchSequence([
+      // /me/accounts — page without IG business account
+      {
+        data: [{ id: "fb-page-no-ig", name: "Personal Page" }],
+        paging: {},
+      },
+      // /me/businesses
+      { data: [], paging: {} },
+    ]);
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("user-token");
+    expect(pages).toHaveLength(0);
+  });
+
+  it("handles pagination across multiple pages", async () => {
+    let callCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async (url: string) => {
+        callCount++;
+        if (callCount === 1) {
+          // First /me/accounts page — has next
+          return {
+            json: async () => ({
+              data: [
+                {
+                  id: "fb-page-1",
+                  name: "Page 1",
+                  instagram_business_account: { id: "ig-1" },
+                },
+              ],
+              paging: { next: "https://graph.facebook.com/v20.0/me/accounts?cursor=2" },
+            }),
+          };
+        }
+        if (callCount === 2) {
+          // Second /me/accounts page — no next
+          return {
+            json: async () => ({
+              data: [
+                {
+                  id: "fb-page-2",
+                  name: "Page 2",
+                  instagram_business_account: { id: "ig-2" },
+                },
+              ],
+              paging: {},
+            }),
+          };
+        }
+        if (callCount === 3) {
+          // /me/businesses
+          return { json: async () => ({ data: [], paging: {} }) };
+        }
+        // IG details + page token for ig-1 and ig-2
+        if (url.includes("ig-1")) {
+          return {
+            json: async () => ({
+              id: "ig-1",
+              name: "IG Acct 1",
+              username: "igacct1",
+              profile_picture_url: "",
+            }),
+          };
+        }
+        if (url.includes("ig-2")) {
+          return {
+            json: async () => ({
+              id: "ig-2",
+              name: "IG Acct 2",
+              username: "igacct2",
+              profile_picture_url: "",
+            }),
+          };
+        }
+        // Page token calls
+        return { json: async () => ({ access_token: "page-token" }) };
+      }),
+    );
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("user-token");
+    expect(pages.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — single image
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.post — single image", () => {
+  it("creates container, polls until FINISHED, publishes, and returns permalink", async () => {
+    mockFetchSequence([
+      // 1. POST /ig-user/media → container
+      { id: "container-1" },
+      // 2. GET /container-1?fields=status_code → FINISHED
+      { status_code: "FINISHED" },
+      // 3. POST /ig-user/media_publish → media id
+      { id: "media-1" },
+      // 4. GET /media-1?fields=permalink
+      { permalink: "https://www.instagram.com/p/ABC123/" },
+    ]);
+
+    const provider = await loadProvider();
+    const results = await provider.post("ig-user-id", "access-token", [
+      {
+        postId: "our-post-1",
+        content: "Hello Instagram!",
+        media: [{ type: "image", url: "https://cdn.example.com/photo.jpg" }],
+      },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].postId).toBe("our-post-1");
+    expect(results[0].platformPostId).toBe("media-1");
+    expect(results[0].platformPostUrl).toBe("https://www.instagram.com/p/ABC123/");
+    expect(results[0].status).toBe("published");
+  });
+
+  it("polls until FINISHED after IN_PROGRESS states", async () => {
+    mockFetchSequence([
+      // Container creation
+      { id: "container-2" },
+      // First poll: IN_PROGRESS
+      { status_code: "IN_PROGRESS" },
+      // Second poll: FINISHED
+      { status_code: "FINISHED" },
+      // Publish
+      { id: "media-2" },
+      // Permalink
+      { permalink: "https://www.instagram.com/p/XYZ/" },
+    ]);
+
+    // Override setTimeout so the test doesn't actually wait 30 s
+    vi.useFakeTimers();
+    const provider = await loadProvider();
+
+    const postPromise = provider.post("ig-user-id", "access-token", [
+      {
+        postId: "post-2",
+        content: "Test",
+        media: [{ type: "image", url: "https://cdn.example.com/img.jpg" }],
+      },
+    ]);
+
+    // Advance timers past the 30s poll interval
+    await vi.runAllTimersAsync();
+    const results = await postPromise;
+
+    expect(results[0].status).toBe("published");
+    vi.useRealTimers();
+  });
+
+  it("throws when container processing returns ERROR status", async () => {
+    mockFetchSequence([
+      { id: "container-err" },
+      { status_code: "ERROR" },
+    ]);
+
+    const provider = await loadProvider();
+
+    await expect(
+      provider.post("ig-user-id", "access-token", [
+        {
+          postId: "post-err",
+          content: "Test",
+          media: [{ type: "image", url: "https://cdn.example.com/img.jpg" }],
+        },
+      ]),
+    ).rejects.toThrow(/ERROR/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — carousel
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.post — carousel", () => {
+  it("creates item containers, polls them, creates carousel container, publishes", async () => {
+    mockFetchSequence([
+      // Item container 1
+      { id: "item-1" },
+      // Item container 2
+      { id: "item-2" },
+      // Poll item-1
+      { status_code: "FINISHED" },
+      // Poll item-2
+      { status_code: "FINISHED" },
+      // Carousel container
+      { id: "carousel-1" },
+      // Poll carousel
+      { status_code: "FINISHED" },
+      // Publish
+      { id: "final-media" },
+      // Permalink
+      { permalink: "https://www.instagram.com/p/CAROUSEL/" },
+    ]);
+
+    const provider = await loadProvider();
+    const results = await provider.post("ig-user-id", "access-token", [
+      {
+        postId: "our-post-carousel",
+        content: "Carousel caption",
+        media: [
+          { type: "image", url: "https://cdn.example.com/img1.jpg" },
+          { type: "image", url: "https://cdn.example.com/img2.jpg" },
+        ],
+      },
+    ]);
+
+    expect(results[0].platformPostUrl).toBe("https://www.instagram.com/p/CAROUSEL/");
+    expect(results[0].status).toBe("published");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — video
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.post — video", () => {
+  it("creates a REELS container and publishes", async () => {
+    mockFetchSequence([
+      // Video container
+      { id: "video-container" },
+      // Poll
+      { status_code: "FINISHED" },
+      // Publish
+      { id: "video-media" },
+      // Permalink
+      { permalink: "https://www.instagram.com/reel/XYZ/" },
+    ]);
+
+    const provider = await loadProvider();
+    const results = await provider.post("ig-user-id", "access-token", [
+      {
+        postId: "post-video",
+        content: "My reel",
+        media: [{ type: "video", url: "https://cdn.example.com/video.mp4" }],
+      },
+    ]);
+
+    expect(results[0].platformPostId).toBe("video-media");
+    expect(results[0].status).toBe("published");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post — no media
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.post — no media", () => {
+  it("throws because Instagram requires at least one media item", async () => {
+    const provider = await loadProvider();
+    await expect(
+      provider.post("ig-user-id", "access-token", [
+        { postId: "post-no-media", content: "Text only" },
+      ]),
+    ).rejects.toThrow(/at least one image or video/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyError
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.classifyError", () => {
+  it("classifies REVOKED_ACCESS_TOKEN as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"message":"REVOKED_ACCESS_TOKEN"}}'),
+    );
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies unknown error as retry", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(new Error("Something went wrong"));
+    expect(result.type).toBe("retry");
+    expect(result.message).toContain("Something went wrong");
+  });
+
+  it("classifies An unknown error occurred as retry", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError("An unknown error occurred while processing");
+    expect(result.type).toBe("retry");
+  });
+
+  it("classifies 2207081 as bad-body", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":2207081,"message":"Trial Reels not supported"}}'),
+    );
+    expect(result.type).toBe("bad-body");
+    expect(result.message).toContain("Trial Reels");
+  });
+
+  it("classifies 2207009 (aspect ratio) as bad-body", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error('{"error":{"code":2207009,"message":"Aspect ratio error"}}'),
+    );
+    expect(result.type).toBe("bad-body");
+    expect(result.message).toContain("Aspect ratio");
+  });
+
+  it("classifies session invalidated as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      "session has been invalidated",
+    );
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies non-IG-business account error as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      "the user is not an instagram business account",
+    );
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies non-Error objects", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError({ code: 99999, message: "unknown" });
+    expect(result.type).toBe("retry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCapabilities
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider.getCapabilities", () => {
+  it("returns correct capabilities", async () => {
+    const provider = await loadProvider();
+    const caps = provider.getCapabilities();
+    expect(caps.identifier).toBe("instagram");
+    expect(caps.displayName).toBe("Instagram");
+    expect(caps.maxContentLength).toBe(2200);
+    expect(caps.supportsImages).toBe(true);
+    expect(caps.supportsVideo).toBe(true);
+    expect(caps.supportsCarousel).toBe(true);
+    expect(caps.requiresPageSelection).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider interface conformance
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider interface conformance", () => {
+  it("has all required interface properties", async () => {
+    const provider = await loadProvider();
+    expect(provider.identifier).toBe("instagram");
+    expect(provider.maxImages).toBe(10);
+    expect(provider.maxConcurrentJobs).toBeGreaterThan(0);
+    expect(typeof provider.generateAuthUrl).toBe("function");
+    expect(typeof provider.authenticate).toBe("function");
+    expect(typeof provider.refreshToken).toBe("function");
+    expect(typeof provider.post).toBe("function");
+    expect(typeof provider.classifyError).toBe("function");
+    expect(typeof provider.fetchPageInformation).toBe("function");
+    expect(typeof provider.getCapabilities).toBe("function");
+  });
+});

--- a/src/lib/social/providers/__tests__/linkedin.test.ts
+++ b/src/lib/social/providers/__tests__/linkedin.test.ts
@@ -1,0 +1,549 @@
+/**
+ * LinkedIn provider tests.
+ *
+ * All HTTP calls are mocked via vi.stubGlobal("fetch", ...) — no network
+ * access required. Each test describes exactly which fetch responses it needs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRegistry } from "@/lib/social/provider-registry";
+
+// ---------------------------------------------------------------------------
+// Environment stubs — set before loading the module so env-reading code sees them
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  clearRegistry();
+  vi.stubEnv("LINKEDIN_CLIENT_ID", "test-client-id");
+  vi.stubEnv("LINKEDIN_CLIENT_SECRET", "test-client-secret");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Sequence-based fetch mock: each call consumes the next response in the list. */
+function mockFetchSequence(
+  responses: Array<{ body?: Record<string, unknown>; status?: number; headers?: Record<string, string> }>,
+) {
+  let i = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(async () => {
+      const entry = responses[i] ?? responses[responses.length - 1];
+      i++;
+      const { body = {}, status = 200, headers = {} } = entry;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: {
+          get: (name: string) => headers[name.toLowerCase()] ?? null,
+        },
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+        arrayBuffer: async () => Buffer.from("fake-image-bytes").buffer,
+      };
+    }),
+  );
+}
+
+async function loadProvider() {
+  // Fresh import so registerProvider() fires against a cleared registry
+  vi.resetModules();
+  const mod = await import("@/lib/social/providers/linkedin");
+  return mod.linkedInProvider;
+}
+
+// ---------------------------------------------------------------------------
+// generateAuthUrl
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider.generateAuthUrl", () => {
+  it("returns a valid LinkedIn authorization URL", async () => {
+    const provider = await loadProvider();
+    const result = await provider.generateAuthUrl(
+      "https://example.com/callback/linkedin",
+    );
+
+    expect(result.url).toContain(
+      "https://www.linkedin.com/oauth/v2/authorization",
+    );
+    expect(result.url).toContain("client_id=test-client-id");
+    expect(result.url).toContain(
+      encodeURIComponent("https://example.com/callback/linkedin"),
+    );
+    expect(result.state).toBeTruthy();
+    expect(result.state.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("includes all 7 required LinkedIn scopes", async () => {
+    const provider = await loadProvider();
+    const { url } = await provider.generateAuthUrl("https://example.com/cb");
+
+    const expectedScopes = [
+      "openid",
+      "profile",
+      "w_member_social",
+      "r_basicprofile",
+      "rw_organization_admin",
+      "w_organization_social",
+      "r_organization_social",
+    ];
+
+    for (const scope of expectedScopes) {
+      expect(url).toContain(scope);
+    }
+  });
+
+  it("generates a unique state on each call", async () => {
+    const provider = await loadProvider();
+    const a = await provider.generateAuthUrl("https://example.com/cb");
+    const b = await provider.generateAuthUrl("https://example.com/cb");
+    expect(a.state).not.toBe(b.state);
+  });
+
+  it("throws when LINKEDIN_CLIENT_ID is missing", async () => {
+    vi.stubEnv("LINKEDIN_CLIENT_ID", "");
+    vi.resetModules();
+    const provider = await loadProvider();
+    await expect(
+      provider.generateAuthUrl("https://example.com/cb"),
+    ).rejects.toThrow("LINKEDIN_CLIENT_ID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// authenticate
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider.authenticate", () => {
+  it("exchanges code for tokens and fetches user profile", async () => {
+    mockFetchSequence([
+      // 1. Token exchange
+      {
+        body: {
+          access_token: "access-123",
+          refresh_token: "refresh-456",
+          expires_in: 5184000,
+        },
+      },
+      // 2. /v2/userinfo
+      {
+        body: {
+          sub: "user-sub-001",
+          name: "Jane Doe",
+          picture: "https://example.com/avatar.jpg",
+        },
+      },
+    ]);
+
+    const provider = await loadProvider();
+    const result = await provider.authenticate({
+      code: "auth-code",
+      codeVerifier: "https://example.com/callback/linkedin",
+    });
+
+    expect(result.platformUserId).toBe("user-sub-001");
+    expect(result.accessToken).toBe("access-123");
+    expect(result.refreshToken).toBe("refresh-456");
+    expect(result.expiresIn).toBe(5184000);
+    expect(result.displayName).toBe("Jane Doe");
+    expect(result.avatarUrl).toBe("https://example.com/avatar.jpg");
+    expect(result.requiresPageSelection).toBe(true);
+  });
+
+  it("throws when the token exchange returns an error", async () => {
+    mockFetchSequence([
+      {
+        body: {
+          error: "invalid_grant",
+          error_description: "Authorization code expired",
+        },
+        status: 400,
+      },
+    ]);
+
+    const provider = await loadProvider();
+    await expect(
+      provider.authenticate({ code: "bad-code", codeVerifier: "https://example.com/cb" }),
+    ).rejects.toThrow(/Authorization code expired/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshToken
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider.refreshToken", () => {
+  it("calls the token endpoint with grant_type=refresh_token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        expires_in: 5184000,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = await loadProvider();
+    const result = await provider.refreshToken("old-refresh-token");
+
+    expect(result.accessToken).toBe("new-access");
+    expect(result.refreshToken).toBe("new-refresh");
+    expect(result.expiresIn).toBe(5184000);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("old-refresh-token");
+    expect(body.get("client_id")).toBe("test-client-id");
+    expect(body.get("client_secret")).toBe("test-client-secret");
+  });
+
+  it("throws when the refresh response contains an error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: "invalid_grant",
+          error_description: "Refresh token expired",
+        }),
+      }),
+    );
+
+    const provider = await loadProvider();
+    await expect(provider.refreshToken("expired-token")).rejects.toThrow(
+      /Refresh token expired/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyError
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider.classifyError", () => {
+  it("classifies 401 / Unauthorized as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(new Error("401 Unauthorized"));
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies token expired message as refresh-token", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(new Error("access token expired"));
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies 429 / Too Many Requests as retry", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(new Error("429 Too Many Requests"));
+    expect(result.type).toBe("retry");
+  });
+
+  it("classifies INVALID_REQUEST as bad-body", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error("INVALID_REQUEST: content violates policy"),
+    );
+    expect(result.type).toBe("bad-body");
+  });
+
+  it("classifies Unable to obtain activity as retry", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error("Unable to obtain activity"),
+    );
+    expect(result.type).toBe("retry");
+  });
+
+  it("classifies unknown errors as retry", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError(
+      new Error("Something completely unexpected"),
+    );
+    expect(result.type).toBe("retry");
+    expect(result.message).toContain("Something completely unexpected");
+  });
+
+  it("classifies non-Error objects", async () => {
+    const provider = await loadProvider();
+    const result = provider.classifyError({ code: 500, msg: "server error" });
+    expect(result.type).toBe("retry");
+  });
+
+  it("preserves the original error in the result", async () => {
+    const provider = await loadProvider();
+    const original = new Error("boom");
+    const result = provider.classifyError(original);
+    expect(result.original).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider.post", () => {
+  it("posts text-only content without uploading media", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      headers: { get: () => "urn:li:share:987654321" },
+      json: async () => ({}),
+      text: async () => "",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = await loadProvider();
+    const results = await provider.post("person-001", "access-token", [
+      { postId: "post-1", content: "Hello LinkedIn!" },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].postId).toBe("post-1");
+    expect(results[0].platformPostId).toBe("urn:li:share:987654321");
+    expect(results[0].platformPostUrl).toContain(
+      encodeURIComponent("urn:li:share:987654321"),
+    );
+    expect(results[0].status).toBe("published");
+
+    // Only 1 fetch call (the POST /rest/posts)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/rest/posts");
+    const body = JSON.parse(init.body as string);
+    expect(body.author).toBe("urn:li:person:person-001");
+    expect(body.commentary).toContain("Hello LinkedIn");
+    expect(body.lifecycleState).toBe("PUBLISHED");
+  });
+
+  it("uploads images before posting and includes them in the payload", async () => {
+    let callIndex = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async (url: string) => {
+        callIndex++;
+        // 1. initializeUpload for image
+        if (url.includes("initializeUpload")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              value: {
+                uploadUrl: "https://linkedin-uploads.example.com/upload/img",
+                image: "urn:li:image:abc123",
+              },
+            }),
+          };
+        }
+        // 2. Fetch image from external URL
+        if (url.includes("cdn.example.com")) {
+          return {
+            ok: true,
+            status: 200,
+            arrayBuffer: async () => Buffer.from("fake-jpeg-bytes").buffer,
+          };
+        }
+        // 3. PUT binary upload
+        if (url.includes("linkedin-uploads")) {
+          return { ok: true, status: 200 };
+        }
+        // 4. POST /rest/posts
+        if (url.includes("/rest/posts")) {
+          return {
+            ok: true,
+            status: 201,
+            headers: { get: () => "urn:li:share:111" },
+            text: async () => "",
+          };
+        }
+        return { ok: true, status: 200, json: async () => ({}) };
+      }),
+    );
+
+    const provider = await loadProvider();
+    const results = await provider.post("person-001", "access-token", [
+      {
+        postId: "post-img",
+        content: "Check this out",
+        media: [
+          { type: "image", url: "https://cdn.example.com/photo.jpg" },
+        ],
+      },
+    ]);
+
+    expect(results[0].status).toBe("published");
+    expect(results[0].platformPostId).toBe("urn:li:share:111");
+  });
+
+  it("returns empty array when requests array is empty", async () => {
+    const provider = await loadProvider();
+    const results = await provider.post("person-001", "access-token", []);
+    expect(results).toHaveLength(0);
+  });
+
+  it("throws when LinkedIn returns a non-2xx status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        headers: { get: () => null },
+        text: async () => "Unprocessable Entity",
+      }),
+    );
+
+    const provider = await loadProvider();
+    await expect(
+      provider.post("person-001", "access-token", [
+        { postId: "post-fail", content: "Will fail" },
+      ]),
+    ).rejects.toThrow(/422/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPageInformation
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider.fetchPageInformation", () => {
+  it("returns org pages the user administers", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          elements: [
+            {
+              "organization~": {
+                id: 12345,
+                localizedName: "Acme Corp",
+                logoV2: {
+                  "original~": {
+                    elements: [
+                      {
+                        identifiers: [
+                          { identifier: "https://example.com/logo.png" },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        }),
+      }),
+    );
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("access-token");
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].id).toBe("12345");
+    expect(pages[0].name).toBe("Acme Corp");
+    expect(pages[0].picture).toBe("https://example.com/logo.png");
+  });
+
+  it("returns empty array when user has no admin orgs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ elements: [] }),
+      }),
+    );
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("access-token");
+    expect(pages).toHaveLength(0);
+  });
+
+  it("returns empty array on missing elements field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ message: "No orgs found" }),
+      }),
+    );
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("access-token");
+    expect(pages).toHaveLength(0);
+  });
+
+  it("filters out elements without an org id", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          elements: [
+            { "organization~": { id: 99, localizedName: "Valid Org" } },
+            { "organization~": { localizedName: "No ID Org" } }, // no id
+            { noOrgTilde: true }, // missing organization~
+          ],
+        }),
+      }),
+    );
+
+    const provider = await loadProvider();
+    const pages = await provider.fetchPageInformation!("access-token");
+    expect(pages).toHaveLength(1);
+    expect(pages[0].id).toBe("99");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCapabilities
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider.getCapabilities", () => {
+  it("returns correct capabilities", async () => {
+    const provider = await loadProvider();
+    const caps = provider.getCapabilities();
+    expect(caps.identifier).toBe("linkedin");
+    expect(caps.displayName).toBe("LinkedIn");
+    expect(caps.maxContentLength).toBe(3000);
+    expect(caps.supportsImages).toBe(true);
+    expect(caps.supportsVideo).toBe(false);
+    expect(caps.supportsCarousel).toBe(true);
+    expect(caps.requiresPageSelection).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interface conformance
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider interface conformance", () => {
+  it("has all required interface properties and methods", async () => {
+    const provider = await loadProvider();
+    expect(provider.identifier).toBe("linkedin");
+    expect(provider.maxImages).toBe(9);
+    expect(provider.maxConcurrentJobs).toBe(2);
+    expect(provider.requiresPageSelection).toBe(true);
+    expect(typeof provider.generateAuthUrl).toBe("function");
+    expect(typeof provider.authenticate).toBe("function");
+    expect(typeof provider.refreshToken).toBe("function");
+    expect(typeof provider.post).toBe("function");
+    expect(typeof provider.classifyError).toBe("function");
+    expect(typeof provider.fetchPageInformation).toBe("function");
+    expect(typeof provider.getCapabilities).toBe("function");
+  });
+});

--- a/src/lib/social/providers/__tests__/tiktok.test.ts
+++ b/src/lib/social/providers/__tests__/tiktok.test.ts
@@ -1,0 +1,599 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRegistry } from "@/lib/social/provider-registry";
+
+// ---------------------------------------------------------------------------
+// Mock global fetch before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Import the module under test and the exported poll helper
+import {
+  pollTikTokPublishStatus,
+  tikTokProvider,
+} from "@/lib/social/providers/tiktok";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchOk(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  };
+}
+
+function mockFetchError(status: number, text = "error") {
+  return {
+    ok: false,
+    status,
+    json: vi.fn().mockResolvedValue({}),
+    text: vi.fn().mockResolvedValue(text),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TikTok provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearRegistry();
+
+    process.env.TIKTOK_CLIENT_KEY = "test-client-key";
+    process.env.TIKTOK_CLIENT_SECRET = "test-client-secret";
+  });
+
+  afterEach(() => {
+    delete process.env.TIKTOK_CLIENT_KEY;
+    delete process.env.TIKTOK_CLIENT_SECRET;
+  });
+
+  // -------------------------------------------------------------------------
+  // generateAuthUrl
+  // -------------------------------------------------------------------------
+
+  describe("generateAuthUrl", () => {
+    it("generates a TikTok OAuth URL with required scopes", async () => {
+      const result = await tikTokProvider.generateAuthUrl(
+        "https://app.example.com/callback/tiktok",
+      );
+
+      expect(result.url).toContain("tiktok.com/v2/auth/authorize");
+      expect(result.url).toContain("video.publish");
+      expect(result.url).toContain("video.upload");
+      expect(result.url).toContain("user.info.basic");
+      expect(result.state).toBeTruthy();
+    });
+
+    it("returns a unique state on each call", async () => {
+      const r1 = await tikTokProvider.generateAuthUrl("https://example.com/cb");
+      const r2 = await tikTokProvider.generateAuthUrl("https://example.com/cb");
+      expect(r1.state).not.toBe(r2.state);
+    });
+
+    it("throws if TIKTOK_CLIENT_KEY is not set", async () => {
+      delete process.env.TIKTOK_CLIENT_KEY;
+      await expect(
+        tikTokProvider.generateAuthUrl("https://example.com/cb"),
+      ).rejects.toThrow("TIKTOK_CLIENT_KEY");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // authenticate
+  // -------------------------------------------------------------------------
+
+  describe("authenticate", () => {
+    it("exchanges code for tokens and returns user info with 23h expiry", async () => {
+      // Token exchange call
+      mockFetch
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            access_token: "tiktok-access-token",
+            refresh_token: "tiktok-refresh-token",
+          }),
+        )
+        // User info call
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              user: {
+                open_id: "open-id-123",
+                display_name: "Test TikToker",
+                avatar_url: "https://p16.tiktokcdn.com/avatar.jpg",
+                username: "testtiktoker",
+              },
+            },
+          }),
+        );
+
+      const result = await tikTokProvider.authenticate({
+        code: "auth-code",
+        state: "https://app.example.com/callback",
+      });
+
+      expect(result.platformUserId).toBe("openid123"); // dashes stripped
+      expect(result.accessToken).toBe("tiktok-access-token");
+      expect(result.refreshToken).toBe("tiktok-refresh-token");
+      expect(result.expiresIn).toBe(23 * 60 * 60); // 23 hours in seconds
+      expect(result.displayName).toBe("Test TikToker");
+      expect(result.username).toBe("testtiktoker");
+      expect(result.requiresPageSelection).toBe(false);
+    });
+
+    it("sends grant_type=authorization_code in token request", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockFetchOk({ access_token: "token", refresh_token: "refresh" }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              user: {
+                open_id: "id-1",
+                display_name: "User",
+                avatar_url: "",
+                username: "user",
+              },
+            },
+          }),
+        );
+
+      await tikTokProvider.authenticate({ code: "code" });
+
+      const tokenBody = new URLSearchParams(
+        mockFetch.mock.calls[0][1].body as string,
+      );
+      expect(tokenBody.get("grant_type")).toBe("authorization_code");
+    });
+
+    it("strips dashes from open_id to form platformUserId", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockFetchOk({ access_token: "tok", refresh_token: "ref" }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              user: {
+                open_id: "abcd-ef01-2345-6789",
+                display_name: "User",
+                avatar_url: "",
+                username: "u",
+              },
+            },
+          }),
+        );
+
+      const result = await tikTokProvider.authenticate({ code: "code" });
+      expect(result.platformUserId).toBe("abcdef0123456789");
+    });
+
+    it("throws when token exchange fails with non-200", async () => {
+      mockFetch.mockResolvedValueOnce(mockFetchError(400, "bad_request"));
+
+      await expect(
+        tikTokProvider.authenticate({ code: "bad-code" }),
+      ).rejects.toThrow("TikTok token exchange failed: 400");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refreshToken
+  // -------------------------------------------------------------------------
+
+  describe("refreshToken", () => {
+    it("exchanges refresh token for a new access token with 23h expiry", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOk({
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+        }),
+      );
+
+      const result = await tikTokProvider.refreshToken("old-refresh-token");
+
+      expect(result.accessToken).toBe("new-access-token");
+      expect(result.refreshToken).toBe("new-refresh-token");
+      expect(result.expiresIn).toBe(23 * 60 * 60);
+    });
+
+    it("falls back to old refresh token if API does not return a new one", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOk({ access_token: "new-token" }), // no refresh_token
+      );
+
+      const result = await tikTokProvider.refreshToken("original-refresh");
+      expect(result.refreshToken).toBe("original-refresh");
+    });
+
+    it("sends grant_type=refresh_token in the request body", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOk({ access_token: "tok", refresh_token: "ref" }),
+      );
+
+      await tikTokProvider.refreshToken("my-refresh-token");
+
+      const body = new URLSearchParams(
+        mockFetch.mock.calls[0][1].body as string,
+      );
+      expect(body.get("grant_type")).toBe("refresh_token");
+      expect(body.get("refresh_token")).toBe("my-refresh-token");
+    });
+
+    it("throws on a 400 response", async () => {
+      mockFetch.mockResolvedValueOnce(mockFetchError(400, "invalid_grant"));
+      await expect(
+        tikTokProvider.refreshToken("expired-token"),
+      ).rejects.toThrow("TikTok token refresh failed: 400");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // pollTikTokPublishStatus
+  // -------------------------------------------------------------------------
+
+  describe("pollTikTokPublishStatus", () => {
+    it("returns post URL when status is PUBLISH_COMPLETE with public post id", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOk({
+          data: {
+            status: "PUBLISH_COMPLETE",
+            publicaly_available_post_id: ["7312345678901234567"],
+          },
+        }),
+      );
+
+      const result = await pollTikTokPublishStatus(
+        "mytiktokuser",
+        "publish-id-1",
+        "access-token",
+        0,
+      );
+
+      expect(result.platformPostId).toBe("7312345678901234567");
+      expect(result.platformPostUrl).toBe(
+        "https://www.tiktok.com/@mytiktokuser/video/7312345678901234567",
+      );
+    });
+
+    it("returns publishId as fallback when publicaly_available_post_id is absent", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOk({
+          data: {
+            status: "PUBLISH_COMPLETE",
+            publicaly_available_post_id: [],
+          },
+        }),
+      );
+
+      const result = await pollTikTokPublishStatus(
+        "user",
+        "fallback-publish-id",
+        "tok",
+        0,
+      );
+
+      expect(result.platformPostId).toBe("fallback-publish-id");
+      expect(result.platformPostUrl).toBe("https://www.tiktok.com/@user");
+    });
+
+    it("returns inbox URL when status is SEND_TO_USER_INBOX", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOk({ data: { status: "SEND_TO_USER_INBOX" } }),
+      );
+
+      const result = await pollTikTokPublishStatus("u", "pid", "tok", 0);
+      expect(result.platformPostId).toBe("inbox");
+      expect(result.platformPostUrl).toContain("tiktok.com/messages");
+    });
+
+    it("retries on intermediate status before resolving PUBLISH_COMPLETE", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockFetchOk({ data: { status: "PROCESSING_UPLOAD" } }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchOk({ data: { status: "PROCESSING_UPLOAD" } }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              status: "PUBLISH_COMPLETE",
+              publicaly_available_post_id: ["9999"],
+            },
+          }),
+        );
+
+      const result = await pollTikTokPublishStatus("user", "pid", "tok", 0);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result.platformPostId).toBe("9999");
+    });
+
+    it("throws when status is FAILED", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchOk({
+          data: {
+            status: "FAILED",
+            fail_reason: "spam_risk_too_many_posts",
+          },
+        }),
+      );
+
+      await expect(
+        pollTikTokPublishStatus("u", "pid", "tok", 0),
+      ).rejects.toThrow("TikTok publish failed");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // post — video and photo dispatch
+  // -------------------------------------------------------------------------
+
+  describe("post", () => {
+    it("initiates a video post and polls for publish status", async () => {
+      // 1. video init call
+      mockFetch
+        .mockResolvedValueOnce(
+          mockFetchOk({ data: { publish_id: "video-publish-id" } }),
+        )
+        // 2. user info (for username resolution)
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              user: {
+                open_id: "oid",
+                display_name: "User",
+                avatar_url: "",
+                username: "videotiktoker",
+              },
+            },
+          }),
+        )
+        // 3. poll status
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              status: "PUBLISH_COMPLETE",
+              publicaly_available_post_id: ["vid123"],
+            },
+          }),
+        );
+
+      const results = await tikTokProvider.post(
+        "platform-user-id",
+        "access-token",
+        [
+          {
+            postId: "internal-post-1",
+            content: "Check out my new video!",
+            media: [{ type: "video", url: "https://cdn.example.com/video.mp4" }],
+          },
+        ],
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].postId).toBe("internal-post-1");
+      expect(results[0].platformPostId).toBe("vid123");
+      expect(results[0].status).toBe("processing");
+    });
+
+    it("uses PULL_FROM_URL source_info for video posts", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockFetchOk({ data: { publish_id: "pid" } }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              user: {
+                open_id: "oid",
+                display_name: "U",
+                avatar_url: "",
+                username: "u",
+              },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              status: "PUBLISH_COMPLETE",
+              publicaly_available_post_id: ["vid"],
+            },
+          }),
+        );
+
+      await tikTokProvider.post("uid", "tok", [
+        {
+          postId: "p",
+          content: "test",
+          media: [{ type: "video", url: "https://example.com/v.mp4" }],
+        },
+      ]);
+
+      const initBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      expect(initBody.source_info.source).toBe("PULL_FROM_URL");
+      expect(initBody.source_info.video_url).toBe("https://example.com/v.mp4");
+    });
+
+    it("initiates a photo carousel post with image URLs", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockFetchOk({ data: { publish_id: "photo-publish-id" } }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              user: {
+                open_id: "oid",
+                display_name: "User",
+                avatar_url: "",
+                username: "phototiktoker",
+              },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchOk({
+            data: {
+              status: "PUBLISH_COMPLETE",
+              publicaly_available_post_id: ["photo123"],
+            },
+          }),
+        );
+
+      const results = await tikTokProvider.post(
+        "platform-user-id",
+        "access-token",
+        [
+          {
+            postId: "internal-post-2",
+            content: "My photo carousel",
+            media: [
+              { type: "image", url: "https://cdn.example.com/img1.jpg" },
+              { type: "image", url: "https://cdn.example.com/img2.jpg" },
+            ],
+          },
+        ],
+      );
+
+      expect(results[0].postId).toBe("internal-post-2");
+      expect(results[0].platformPostId).toBe("photo123");
+
+      // Should have called the photo content init endpoint
+      const initBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      expect(initBody.media_type).toBe("PHOTO");
+      expect(initBody.source_info.photo_images).toEqual([
+        "https://cdn.example.com/img1.jpg",
+        "https://cdn.example.com/img2.jpg",
+      ]);
+    });
+
+    it("throws when no media is provided", async () => {
+      await expect(
+        tikTokProvider.post("uid", "tok", [
+          { postId: "p1", content: "no media" },
+        ]),
+      ).rejects.toThrow("TikTok requires at least one media item");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // classifyError
+  // -------------------------------------------------------------------------
+
+  describe("classifyError", () => {
+    it("classifies access_token_invalid as refresh-token", () => {
+      const err = new Error("access_token_invalid");
+      expect(tikTokProvider.classifyError(err).type).toBe("refresh-token");
+    });
+
+    it("classifies scope_not_authorized as refresh-token", () => {
+      const err = new Error("scope_not_authorized: missing scopes");
+      expect(tikTokProvider.classifyError(err).type).toBe("refresh-token");
+    });
+
+    it("classifies scope_permission_missed as refresh-token", () => {
+      const err = new Error("scope_permission_missed");
+      expect(tikTokProvider.classifyError(err).type).toBe("refresh-token");
+    });
+
+    it("classifies spam_risk as bad-body", () => {
+      const err = new Error("spam_risk_too_many_posts");
+      expect(tikTokProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies spam_risk_text as bad-body", () => {
+      const err = new Error("spam_risk_text detected");
+      expect(tikTokProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies spam_risk_user_banned_from_posting as bad-body", () => {
+      const err = new Error("spam_risk_user_banned_from_posting");
+      expect(tikTokProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies file_format_check_failed as bad-body", () => {
+      const err = new Error("file_format_check_failed: unsupported codec");
+      expect(tikTokProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies duration_check_failed as bad-body", () => {
+      const err = new Error("duration_check_failed: too long");
+      expect(tikTokProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies frame_rate_check_failed as bad-body", () => {
+      const err = new Error("frame_rate_check_failed");
+      expect(tikTokProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies video_pull_failed as retry", () => {
+      const err = new Error("video_pull_failed: network error");
+      expect(tikTokProvider.classifyError(err).type).toBe("retry");
+    });
+
+    it("classifies photo_pull_failed as retry", () => {
+      const err = new Error("photo_pull_failed: timeout");
+      expect(tikTokProvider.classifyError(err).type).toBe("retry");
+    });
+
+    it("classifies rate_limit_exceeded as retry", () => {
+      const err = new Error("rate_limit_exceeded");
+      expect(tikTokProvider.classifyError(err).type).toBe("retry");
+    });
+
+    it("classifies url_ownership_unverified as bad-body", () => {
+      const err = new Error("url_ownership_unverified");
+      expect(tikTokProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies unaudited_client_can_only_post_to_private_accounts as bad-body", () => {
+      const err = new Error(
+        "unaudited_client_can_only_post_to_private_accounts",
+      );
+      expect(tikTokProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies unknown errors as retry", () => {
+      const err = new Error("some random network failure");
+      expect(tikTokProvider.classifyError(err).type).toBe("retry");
+    });
+
+    it("includes the original error in the result", () => {
+      const err = new Error("something");
+      const classified = tikTokProvider.classifyError(err);
+      expect(classified.original).toBe(err);
+    });
+
+    it("handles non-Error objects", () => {
+      const classified = tikTokProvider.classifyError("raw string error");
+      expect(classified.type).toBe("retry");
+      expect(classified.message).toBe("raw string error");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getCapabilities
+  // -------------------------------------------------------------------------
+
+  describe("getCapabilities", () => {
+    it("returns the expected TikTok capabilities", () => {
+      const caps = tikTokProvider.getCapabilities();
+      expect(caps.identifier).toBe("tiktok");
+      expect(caps.displayName).toBe("TikTok");
+      expect(caps.supportsImages).toBe(true);
+      expect(caps.supportsVideo).toBe(true);
+      expect(caps.supportsCarousel).toBe(true);
+      expect(caps.requiresPageSelection).toBe(false);
+      expect(caps.maxContentLength).toBe(2200);
+    });
+  });
+});

--- a/src/lib/social/providers/__tests__/x.test.ts
+++ b/src/lib/social/providers/__tests__/x.test.ts
@@ -1,0 +1,372 @@
+/**
+ * X (Twitter) provider tests.
+ *
+ * The `twitter-api-v2` package is fully mocked so no network calls are made.
+ * sharp is mocked to return a fixed buffer without actual image processing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRegistry } from "@/lib/social/provider-registry";
+
+// ---------------------------------------------------------------------------
+// Hoist mock state so vi.mock factories can reference it
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  // TwitterApi instance methods used in various flows
+  generateAuthLink: vi.fn(),
+  login: vi.fn(),
+  me: vi.fn(),
+  uploadMedia: vi.fn(),
+  tweet: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock twitter-api-v2
+//
+// The provider does:
+//   new TwitterApi({ appKey, appSecret })              → for generateAuthUrl
+//   new TwitterApi({ appKey, appSecret, accessToken, accessSecret }) → for post
+//   startingClient.login(oauthVerifier)                → returns { accessToken, accessSecret, client }
+//   client.v2.me()                                     → returns user info
+//   client.v2.uploadMedia()                            → returns media id
+//   client.v2.tweet()                                  → returns { data: { id } }
+// ---------------------------------------------------------------------------
+
+vi.mock("twitter-api-v2", () => {
+  class TwitterApiV2Mock {
+    me = mocks.me;
+    uploadMedia = mocks.uploadMedia;
+    tweet = mocks.tweet;
+  }
+
+  class TwitterApiMock {
+    generateAuthLink = mocks.generateAuthLink;
+    login = mocks.login;
+    v2 = new TwitterApiV2Mock();
+  }
+
+  return { TwitterApi: TwitterApiMock };
+});
+
+// ---------------------------------------------------------------------------
+// Mock sharp to avoid real image processing
+// ---------------------------------------------------------------------------
+
+vi.mock("sharp", () => {
+  const sharpMock = vi.fn().mockReturnValue({
+    resize: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from("resized-image-bytes")),
+  });
+  return { default: sharpMock };
+});
+
+// ---------------------------------------------------------------------------
+// Mock global fetch (used by fetchAndResizeImage)
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ---------------------------------------------------------------------------
+// Import provider after all mocks are set up
+// ---------------------------------------------------------------------------
+
+import { xProvider } from "@/lib/social/providers/x";
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  clearRegistry();
+  vi.clearAllMocks();
+  process.env.X_API_KEY = "test-api-key";
+  process.env.X_API_SECRET = "test-api-secret";
+});
+
+afterEach(() => {
+  delete process.env.X_API_KEY;
+  delete process.env.X_API_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// generateAuthUrl
+// ---------------------------------------------------------------------------
+
+describe("xProvider.generateAuthUrl", () => {
+  it("calls generateAuthLink and returns url, state, and codeVerifier", async () => {
+    mocks.generateAuthLink.mockResolvedValue({
+      url: "https://api.twitter.com/oauth/authenticate?oauth_token=tok123",
+      oauth_token: "tok123",
+      oauth_token_secret: "sec456",
+    });
+
+    const result = await xProvider.generateAuthUrl(
+      "https://example.com/callback/x",
+    );
+
+    expect(mocks.generateAuthLink).toHaveBeenCalledWith(
+      "https://example.com/callback/x",
+      expect.objectContaining({ authAccessType: "write" }),
+    );
+
+    expect(result.url).toContain("oauth_token=tok123");
+    expect(result.state).toBe("tok123");
+    expect(result.codeVerifier).toBe("tok123:sec456");
+  });
+
+  it("throws when X_API_KEY is not set", async () => {
+    delete process.env.X_API_KEY;
+    await expect(
+      xProvider.generateAuthUrl("https://example.com/cb"),
+    ).rejects.toThrow("X_API_KEY");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// authenticate
+// ---------------------------------------------------------------------------
+
+describe("xProvider.authenticate", () => {
+  it("calls login with the verifier and returns permanent tokens", async () => {
+    const mockClient = {
+      v2: {
+        me: vi.fn().mockResolvedValue({
+          data: {
+            id: "user-111",
+            name: "Alice",
+            username: "alice",
+            profile_image_url: "https://example.com/alice.jpg",
+          },
+        }),
+      },
+    };
+
+    mocks.login.mockResolvedValue({
+      accessToken: "perm-access",
+      accessSecret: "perm-secret",
+      client: mockClient,
+    });
+
+    const result = await xProvider.authenticate({
+      code: "oauth-verifier-xyz",
+      codeVerifier: "tok123:sec456",
+    });
+
+    expect(mocks.login).toHaveBeenCalledWith("oauth-verifier-xyz");
+
+    expect(result.platformUserId).toBe("user-111");
+    // Token is stored as "accessToken:accessSecret"
+    expect(result.accessToken).toBe("perm-access:perm-secret");
+    expect(result.displayName).toBe("Alice");
+    expect(result.username).toBe("alice");
+    expect(result.avatarUrl).toBe("https://example.com/alice.jpg");
+    // No expiry for OAuth 1.0a
+    expect(result.expiresIn).toBeUndefined();
+    expect(result.refreshToken).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshToken
+// ---------------------------------------------------------------------------
+
+describe("xProvider.refreshToken", () => {
+  it("is a no-op — returns the same token unchanged", async () => {
+    const result = await xProvider.refreshToken("my-permanent-token:my-secret");
+    expect(result.accessToken).toBe("my-permanent-token:my-secret");
+  });
+
+  it("does not make any network calls", async () => {
+    await xProvider.refreshToken("tok:sec");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post
+// ---------------------------------------------------------------------------
+
+describe("xProvider.post", () => {
+  it("posts text-only tweet without uploading media", async () => {
+    mocks.tweet.mockResolvedValue({ data: { id: "tweet-999" } });
+    mocks.me.mockResolvedValue({ data: { username: "alice" } });
+
+    const results = await xProvider.post("user-111", "tok:sec", [
+      { postId: "our-post-1", content: "Hello X!" },
+    ]);
+
+    expect(mocks.tweet).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hello X!" }),
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].postId).toBe("our-post-1");
+    expect(results[0].platformPostId).toBe("tweet-999");
+    expect(results[0].platformPostUrl).toContain("alice");
+    expect(results[0].platformPostUrl).toContain("tweet-999");
+    expect(results[0].status).toBe("published");
+  });
+
+  it("downloads, resizes, and uploads images before tweeting", async () => {
+    // Mock fetch for image download
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => Buffer.from("raw-image").buffer,
+    });
+
+    mocks.uploadMedia.mockResolvedValue("media-id-001");
+    mocks.tweet.mockResolvedValue({ data: { id: "tweet-with-img" } });
+    mocks.me.mockResolvedValue({ data: { username: "alice" } });
+
+    const results = await xProvider.post("user-111", "tok:sec", [
+      {
+        postId: "post-img",
+        content: "Look at this!",
+        media: [{ type: "image", url: "https://cdn.example.com/photo.jpg" }],
+      },
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://cdn.example.com/photo.jpg",
+    );
+    expect(mocks.uploadMedia).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      expect.objectContaining({ media_type: "image/jpeg" }),
+    );
+    expect(mocks.tweet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        media: { media_ids: ["media-id-001"] },
+      }),
+    );
+    expect(results[0].platformPostId).toBe("tweet-with-img");
+  });
+
+  it("caps media uploads at 4 images", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Buffer.from("img").buffer,
+    });
+    mocks.uploadMedia.mockResolvedValue("media-id");
+    mocks.tweet.mockResolvedValue({ data: { id: "tweet-capped" } });
+    mocks.me.mockResolvedValue({ data: { username: "alice" } });
+
+    await xProvider.post("user-111", "tok:sec", [
+      {
+        postId: "post-5imgs",
+        content: "Five images",
+        media: [
+          { type: "image", url: "https://cdn.example.com/1.jpg" },
+          { type: "image", url: "https://cdn.example.com/2.jpg" },
+          { type: "image", url: "https://cdn.example.com/3.jpg" },
+          { type: "image", url: "https://cdn.example.com/4.jpg" },
+          { type: "image", url: "https://cdn.example.com/5.jpg" }, // should be dropped
+        ],
+      },
+    ]);
+
+    // Only 4 upload calls despite 5 images
+    expect(mocks.uploadMedia).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns empty array when requests array is empty", async () => {
+    const results = await xProvider.post("user-111", "tok:sec", []);
+    expect(results).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyError
+// ---------------------------------------------------------------------------
+
+describe("xProvider.classifyError", () => {
+  it("classifies 429 / rate limit as retry", () => {
+    const result = xProvider.classifyError(new Error("429 Too Many Requests"));
+    expect(result.type).toBe("retry");
+  });
+
+  it("classifies Rate limit exceeded string as retry", () => {
+    const result = xProvider.classifyError("Rate limit exceeded");
+    expect(result.type).toBe("retry");
+  });
+
+  it("classifies 401 as refresh-token", () => {
+    const result = xProvider.classifyError(new Error("401 Unauthorized"));
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies Unsupported Authentication as refresh-token", () => {
+    const result = xProvider.classifyError(
+      new Error("Unsupported Authentication"),
+    );
+    expect(result.type).toBe("refresh-token");
+  });
+
+  it("classifies duplicate tweet as bad-body", () => {
+    const result = xProvider.classifyError(
+      new Error("duplicate tweet content"),
+    );
+    expect(result.type).toBe("bad-body");
+  });
+
+  it("classifies usage-capped as bad-body", () => {
+    const result = xProvider.classifyError(new Error("usage-capped reached"));
+    expect(result.type).toBe("bad-body");
+  });
+
+  it("classifies unknown errors as retry", () => {
+    const result = xProvider.classifyError(new Error("Something random"));
+    expect(result.type).toBe("retry");
+    expect(result.message).toContain("Something random");
+  });
+
+  it("classifies non-Error objects", () => {
+    const result = xProvider.classifyError({ code: 500, detail: "oops" });
+    expect(result.type).toBe("retry");
+  });
+
+  it("preserves the original error", () => {
+    const original = new Error("X error");
+    const result = xProvider.classifyError(original);
+    expect(result.original).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCapabilities
+// ---------------------------------------------------------------------------
+
+describe("xProvider.getCapabilities", () => {
+  it("returns correct capabilities", () => {
+    const caps = xProvider.getCapabilities();
+    expect(caps.identifier).toBe("x");
+    expect(caps.displayName).toBe("X (Twitter)");
+    expect(caps.maxContentLength).toBe(280);
+    expect(caps.supportsImages).toBe(true);
+    expect(caps.supportsVideo).toBe(false);
+    expect(caps.supportsCarousel).toBe(false);
+    expect(caps.requiresPageSelection).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interface conformance
+// ---------------------------------------------------------------------------
+
+describe("xProvider interface conformance", () => {
+  it("has all required interface properties and methods", () => {
+    expect(xProvider.identifier).toBe("x");
+    expect(xProvider.maxImages).toBe(4);
+    expect(xProvider.maxConcurrentJobs).toBe(1);
+    expect(xProvider.requiresPageSelection).toBe(false);
+    expect(typeof xProvider.generateAuthUrl).toBe("function");
+    expect(typeof xProvider.authenticate).toBe("function");
+    expect(typeof xProvider.refreshToken).toBe("function");
+    expect(typeof xProvider.post).toBe("function");
+    expect(typeof xProvider.classifyError).toBe("function");
+    expect(typeof xProvider.getCapabilities).toBe("function");
+    // fetchPageInformation is optional and should NOT be defined for X
+    expect(xProvider.fetchPageInformation).toBeUndefined();
+  });
+});

--- a/src/lib/social/providers/__tests__/youtube.test.ts
+++ b/src/lib/social/providers/__tests__/youtube.test.ts
@@ -1,0 +1,574 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRegistry } from "@/lib/social/provider-registry";
+
+// ---------------------------------------------------------------------------
+// Mock the googleapis module before importing the provider.
+//
+// The googleapis OAuth2 class is instantiated via `new google.auth.OAuth2()`.
+// We use vi.hoisted() to declare per-test callable stubs and wire them into a
+// proper ES6 class constructor in the vi.mock() factory so `new` works.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  getToken: vi.fn(),
+  setCredentials: vi.fn(),
+  refreshAccessToken: vi.fn(),
+  generateAuthUrl: vi.fn(),
+  userinfoGet: vi.fn(),
+  channelsList: vi.fn(),
+  videosInsert: vi.fn(),
+  thumbnailsSet: vi.fn(),
+}));
+
+vi.mock("googleapis", () => {
+  // OAuth2 must be a real constructor (class/function) because the provider
+  // calls `new google.auth.OAuth2(...)`.
+  class OAuth2Mock {
+    getToken = mocks.getToken;
+    setCredentials = mocks.setCredentials;
+    refreshAccessToken = mocks.refreshAccessToken;
+    generateAuthUrl = mocks.generateAuthUrl;
+  }
+
+  return {
+    google: {
+      auth: { OAuth2: OAuth2Mock },
+      youtube: vi.fn().mockReturnValue({
+        channels: { list: mocks.channelsList },
+        videos: { insert: mocks.videosInsert },
+        thumbnails: { set: mocks.thumbnailsSet },
+      }),
+      oauth2: vi.fn().mockReturnValue({
+        userinfo: { get: mocks.userinfoGet },
+      }),
+    },
+  };
+});
+
+// Mock global fetch for video/thumbnail URL downloads
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Import the module under test after mocks are set up
+import { youTubeProvider } from "@/lib/social/providers/youtube";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReadableStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array([0, 1, 2, 3]));
+      controller.close();
+    },
+  });
+}
+
+function videoFetchResponse() {
+  return {
+    ok: true,
+    status: 200,
+    body: makeReadableStream(),
+  };
+}
+
+const FAKE_ACCESS_TOKEN = "google-access-token";
+const FAKE_REFRESH_TOKEN = "google-refresh-token";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("YouTube provider", () => {
+  beforeEach(() => {
+    // clearAllMocks preserves mock implementations set up by vi.mock() but
+    // resets per-test return values and recorded calls.
+    vi.clearAllMocks();
+    clearRegistry();
+
+    process.env.GOOGLE_CLIENT_ID = "test-google-client-id";
+    process.env.GOOGLE_CLIENT_SECRET = "test-google-client-secret";
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+  });
+
+  // -------------------------------------------------------------------------
+  // generateAuthUrl
+  // -------------------------------------------------------------------------
+
+  describe("generateAuthUrl", () => {
+    it("generates an auth URL with offline access and consent prompt", async () => {
+      mocks.generateAuthUrl.mockReturnValue(
+        "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent",
+      );
+
+      const result = await youTubeProvider.generateAuthUrl(
+        "https://app.example.com/callback/youtube",
+      );
+
+      expect(result.url).toContain("accounts.google.com");
+      expect(result.url).toContain("access_type=offline");
+      expect(result.url).toContain("prompt=consent");
+      expect(result.state).toBeTruthy();
+    });
+
+    it("calls generateAuthUrl with access_type=offline and prompt=consent", async () => {
+      mocks.generateAuthUrl.mockReturnValue("https://accounts.google.com/auth");
+
+      await youTubeProvider.generateAuthUrl("https://example.com/cb");
+
+      expect(mocks.generateAuthUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          access_type: "offline",
+          prompt: "consent",
+        }),
+      );
+    });
+
+    it("includes YouTube upload scope in the auth URL parameters", async () => {
+      mocks.generateAuthUrl.mockReturnValue("https://accounts.google.com/auth");
+
+      await youTubeProvider.generateAuthUrl("https://example.com/cb");
+
+      const callArgs = mocks.generateAuthUrl.mock.calls[0][0];
+      expect(callArgs.scope).toContain(
+        "https://www.googleapis.com/auth/youtube.upload",
+      );
+    });
+
+    it("generates a unique state on each call", async () => {
+      mocks.generateAuthUrl.mockReturnValue("https://accounts.google.com/auth");
+
+      const r1 = await youTubeProvider.generateAuthUrl("https://example.com/cb");
+      const r2 = await youTubeProvider.generateAuthUrl("https://example.com/cb");
+
+      expect(r1.state).not.toBe(r2.state);
+    });
+
+    it("throws if GOOGLE_CLIENT_ID is not set", async () => {
+      delete process.env.GOOGLE_CLIENT_ID;
+      await expect(
+        youTubeProvider.generateAuthUrl("https://example.com/cb"),
+      ).rejects.toThrow("GOOGLE_CLIENT_ID");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // authenticate
+  // -------------------------------------------------------------------------
+
+  describe("authenticate", () => {
+    it("exchanges code for tokens and returns user info", async () => {
+      const expiryDate = Date.now() + 3600 * 1000; // 1 hour from now
+
+      mocks.getToken.mockResolvedValue({
+        tokens: {
+          access_token: FAKE_ACCESS_TOKEN,
+          refresh_token: FAKE_REFRESH_TOKEN,
+          expiry_date: expiryDate,
+        },
+      });
+
+      mocks.userinfoGet.mockResolvedValue({
+        data: {
+          id: "google-user-123",
+          name: "Test User",
+          picture: "https://lh3.googleusercontent.com/photo.jpg",
+        },
+      });
+
+      const result = await youTubeProvider.authenticate({ code: "auth-code" });
+
+      expect(result.platformUserId).toBe("google-user-123");
+      expect(result.accessToken).toBe(FAKE_ACCESS_TOKEN);
+      expect(result.refreshToken).toBe(FAKE_REFRESH_TOKEN);
+      expect(result.displayName).toBe("Test User");
+      expect(result.avatarUrl).toBe(
+        "https://lh3.googleusercontent.com/photo.jpg",
+      );
+      expect(result.requiresPageSelection).toBe(true);
+      // expiresIn must be a positive number of seconds
+      expect(result.expiresIn).toBeGreaterThan(0);
+    });
+
+    it("sets credentials on the OAuth2 client after token exchange", async () => {
+      mocks.getToken.mockResolvedValue({
+        tokens: {
+          access_token: FAKE_ACCESS_TOKEN,
+          refresh_token: FAKE_REFRESH_TOKEN,
+        },
+      });
+      mocks.userinfoGet.mockResolvedValue({
+        data: { id: "uid", name: "User", picture: null },
+      });
+
+      await youTubeProvider.authenticate({ code: "code" });
+
+      expect(mocks.setCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({ access_token: FAKE_ACCESS_TOKEN }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refreshToken
+  // -------------------------------------------------------------------------
+
+  describe("refreshToken", () => {
+    it("refreshes the access token using the OAuth2 client", async () => {
+      const expiryDate = Date.now() + 3600 * 1000;
+      mocks.refreshAccessToken.mockResolvedValue({
+        credentials: {
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expiry_date: expiryDate,
+        },
+      });
+
+      const result = await youTubeProvider.refreshToken(FAKE_REFRESH_TOKEN);
+
+      expect(mocks.setCredentials).toHaveBeenCalledWith({
+        refresh_token: FAKE_REFRESH_TOKEN,
+      });
+      expect(result.accessToken).toBe("new-access-token");
+      expect(result.refreshToken).toBe("new-refresh-token");
+      expect(result.expiresIn).toBeGreaterThan(0);
+    });
+
+    it("falls back to old refresh token if API does not return a new one", async () => {
+      mocks.refreshAccessToken.mockResolvedValue({
+        credentials: {
+          access_token: "new-token",
+          expiry_date: Date.now() + 3_600_000,
+        },
+      });
+
+      const result = await youTubeProvider.refreshToken(FAKE_REFRESH_TOKEN);
+      expect(result.refreshToken).toBe(FAKE_REFRESH_TOKEN);
+    });
+
+    it("throws if GOOGLE_CLIENT_ID is missing", async () => {
+      delete process.env.GOOGLE_CLIENT_ID;
+      await expect(
+        youTubeProvider.refreshToken(FAKE_REFRESH_TOKEN),
+      ).rejects.toThrow("GOOGLE_CLIENT_ID");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fetchPageInformation (channel listing)
+  // -------------------------------------------------------------------------
+
+  describe("fetchPageInformation", () => {
+    it("returns a list of YouTube channels for the account", async () => {
+      mocks.channelsList.mockResolvedValue({
+        data: {
+          items: [
+            {
+              id: "UC_channel_id_1",
+              snippet: {
+                title: "My Channel",
+                customUrl: "@mychannel",
+                thumbnails: {
+                  default: { url: "https://yt3.ggpht.com/thumb.jpg" },
+                },
+              },
+            },
+            {
+              id: "UC_channel_id_2",
+              snippet: {
+                title: "Brand Channel",
+                customUrl: "@brand",
+                thumbnails: { default: null },
+              },
+            },
+          ],
+        },
+      });
+
+      const pages = await youTubeProvider.fetchPageInformation!(
+        FAKE_ACCESS_TOKEN,
+      );
+
+      expect(pages).toHaveLength(2);
+      expect(pages[0].id).toBe("UC_channel_id_1");
+      expect(pages[0].name).toBe("My Channel");
+      expect(pages[0].username).toBe("@mychannel");
+      expect(pages[0].picture).toBe("https://yt3.ggpht.com/thumb.jpg");
+      expect(pages[1].id).toBe("UC_channel_id_2");
+    });
+
+    it("returns an empty array when no channels found", async () => {
+      mocks.channelsList.mockResolvedValue({ data: { items: [] } });
+
+      const pages = await youTubeProvider.fetchPageInformation!(
+        FAKE_ACCESS_TOKEN,
+      );
+      expect(pages).toHaveLength(0);
+    });
+
+    it("calls channels.list with part=['snippet'] and mine=true", async () => {
+      mocks.channelsList.mockResolvedValue({ data: { items: [] } });
+
+      await youTubeProvider.fetchPageInformation!(FAKE_ACCESS_TOKEN);
+
+      expect(mocks.channelsList).toHaveBeenCalledWith({
+        part: ["snippet"],
+        mine: true,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // post (video upload)
+  // -------------------------------------------------------------------------
+
+  describe("post", () => {
+    it("uploads a video and returns a YouTube watch URL", async () => {
+      mockFetch.mockResolvedValue(videoFetchResponse());
+      mocks.videosInsert.mockResolvedValue({ data: { id: "dQw4w9WgXcQ" } });
+
+      const results = await youTubeProvider.post(
+        "google-user-123",
+        FAKE_ACCESS_TOKEN,
+        [
+          {
+            postId: "internal-post-1",
+            content: "My awesome video description",
+            media: [
+              {
+                type: "video",
+                url: "https://cdn.example.com/video.mp4",
+              },
+            ],
+            platformSettings: {
+              title: "My Awesome Video",
+              privacyStatus: "public",
+            },
+          },
+        ],
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].postId).toBe("internal-post-1");
+      expect(results[0].platformPostId).toBe("dQw4w9WgXcQ");
+      expect(results[0].platformPostUrl).toBe(
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      );
+      expect(results[0].status).toBe("published");
+    });
+
+    it("calls videos.insert with snippet and status parts", async () => {
+      mockFetch.mockResolvedValue(videoFetchResponse());
+      mocks.videosInsert.mockResolvedValue({ data: { id: "abc123" } });
+
+      await youTubeProvider.post(
+        "uid",
+        FAKE_ACCESS_TOKEN,
+        [
+          {
+            postId: "p1",
+            content: "Description text",
+            media: [{ type: "video", url: "https://example.com/v.mp4" }],
+            platformSettings: {
+              title: "My Title",
+              privacyStatus: "unlisted",
+              tags: ["tag1", "tag2"],
+            },
+          },
+        ],
+      );
+
+      expect(mocks.videosInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          part: expect.arrayContaining(["id", "snippet", "status"]),
+          requestBody: expect.objectContaining({
+            snippet: expect.objectContaining({
+              title: "My Title",
+              description: "Description text",
+              tags: ["tag1", "tag2"],
+            }),
+            status: expect.objectContaining({
+              privacyStatus: "unlisted",
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("uses content as description and first 100 chars as title if no title given", async () => {
+      mockFetch.mockResolvedValue(videoFetchResponse());
+      mocks.videosInsert.mockResolvedValue({ data: { id: "xyz" } });
+
+      const content = "This is a long description for a video";
+
+      await youTubeProvider.post(
+        "uid",
+        FAKE_ACCESS_TOKEN,
+        [
+          {
+            postId: "p1",
+            content,
+            media: [{ type: "video", url: "https://example.com/v.mp4" }],
+          },
+        ],
+      );
+
+      const callArgs = mocks.videosInsert.mock.calls[0][0];
+      expect(callArgs.requestBody.snippet.title).toBe(content.slice(0, 100));
+      expect(callArgs.requestBody.snippet.description).toBe(content);
+    });
+
+    it("throws when no video media item is provided", async () => {
+      await expect(
+        youTubeProvider.post(
+          "uid",
+          FAKE_ACCESS_TOKEN,
+          [
+            {
+              postId: "p1",
+              content: "No video",
+              media: [{ type: "image", url: "https://example.com/img.jpg" }],
+            },
+          ],
+        ),
+      ).rejects.toThrow("YouTube requires exactly one video media item");
+    });
+
+    it("uploads a thumbnail when thumbnailUrl is provided in platformSettings", async () => {
+      mockFetch.mockResolvedValue(videoFetchResponse());
+      mocks.videosInsert.mockResolvedValue({ data: { id: "vid-with-thumb" } });
+      mocks.thumbnailsSet.mockResolvedValue({});
+
+      await youTubeProvider.post(
+        "uid",
+        FAKE_ACCESS_TOKEN,
+        [
+          {
+            postId: "p1",
+            content: "Video with thumbnail",
+            media: [{ type: "video", url: "https://example.com/v.mp4" }],
+            platformSettings: {
+              title: "Title",
+              thumbnailUrl: "https://example.com/thumb.jpg",
+            },
+          },
+        ],
+      );
+
+      expect(mocks.thumbnailsSet).toHaveBeenCalledWith(
+        expect.objectContaining({ videoId: "vid-with-thumb" }),
+      );
+    });
+
+    it("continues if thumbnail upload fails (best-effort)", async () => {
+      mockFetch.mockResolvedValue(videoFetchResponse());
+      mocks.videosInsert.mockResolvedValue({ data: { id: "vid-no-thumb" } });
+      mocks.thumbnailsSet.mockRejectedValue(new Error("failedPrecondition"));
+
+      // Should not throw — thumbnail failure is non-fatal
+      const results = await youTubeProvider.post(
+        "uid",
+        FAKE_ACCESS_TOKEN,
+        [
+          {
+            postId: "p1",
+            content: "Test",
+            media: [{ type: "video", url: "https://example.com/v.mp4" }],
+            platformSettings: {
+              thumbnailUrl: "https://example.com/thumb.jpg",
+            },
+          },
+        ],
+      );
+
+      expect(results[0].platformPostId).toBe("vid-no-thumb");
+      expect(results[0].status).toBe("published");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // classifyError
+  // -------------------------------------------------------------------------
+
+  describe("classifyError", () => {
+    it("classifies Unauthorized as refresh-token", () => {
+      const err = new Error("Unauthorized access");
+      expect(youTubeProvider.classifyError(err).type).toBe("refresh-token");
+    });
+
+    it("classifies UNAUTHENTICATED as refresh-token", () => {
+      const err = new Error("UNAUTHENTICATED: token expired");
+      expect(youTubeProvider.classifyError(err).type).toBe("refresh-token");
+    });
+
+    it("classifies invalid_grant as refresh-token", () => {
+      const err = new Error("invalid_grant: token has been expired");
+      expect(youTubeProvider.classifyError(err).type).toBe("refresh-token");
+    });
+
+    it("classifies invalidTitle as bad-body", () => {
+      const err = new Error("YouTube videos.insert failed: 400 invalidTitle");
+      expect(youTubeProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies youtubeSignupRequired as bad-body", () => {
+      const err = new Error("youtubeSignupRequired: link your account");
+      expect(youTubeProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies uploadLimitExceeded as bad-body", () => {
+      const err = new Error("uploadLimitExceeded daily quota");
+      expect(youTubeProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies failedPrecondition (thumbnail) as bad-body", () => {
+      const err = new Error(
+        "youtube.thumbnail failedPrecondition: file too large",
+      );
+      expect(youTubeProvider.classifyError(err).type).toBe("bad-body");
+    });
+
+    it("classifies quotaExceeded as retry", () => {
+      const err = new Error("quotaExceeded: API quota limit reached");
+      expect(youTubeProvider.classifyError(err).type).toBe("retry");
+    });
+
+    it("classifies rateLimitExceeded as retry", () => {
+      const err = new Error("rateLimitExceeded");
+      expect(youTubeProvider.classifyError(err).type).toBe("retry");
+    });
+
+    it("classifies unknown errors as retry", () => {
+      const err = new Error("Some transient network error");
+      expect(youTubeProvider.classifyError(err).type).toBe("retry");
+    });
+
+    it("includes the original error in the result", () => {
+      const err = new Error("some error");
+      const classified = youTubeProvider.classifyError(err);
+      expect(classified.original).toBe(err);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getCapabilities
+  // -------------------------------------------------------------------------
+
+  describe("getCapabilities", () => {
+    it("returns the expected YouTube capabilities", () => {
+      const caps = youTubeProvider.getCapabilities();
+      expect(caps.identifier).toBe("youtube");
+      expect(caps.displayName).toBe("YouTube");
+      expect(caps.supportsImages).toBe(false);
+      expect(caps.supportsVideo).toBe(true);
+      expect(caps.supportsCarousel).toBe(false);
+      expect(caps.requiresPageSelection).toBe(true);
+      expect(caps.maxContentLength).toBe(5000);
+    });
+  });
+});

--- a/src/lib/social/providers/facebook.ts
+++ b/src/lib/social/providers/facebook.ts
@@ -1,0 +1,421 @@
+/**
+ * Facebook provider adapter.
+ *
+ * Posts to a Facebook Page (not a personal profile). The OAuth flow uses
+ * Facebook Login with page-management scopes. After the initial code exchange
+ * the caller must call fetchPageInformation() to list the user's Pages and
+ * obtain a page-scoped access token for each.
+ *
+ * Publishing modes:
+ *   - Text-only: POST /{page-id}/feed  { message }
+ *   - Photos:    Upload each as unpublished via /{page-id}/photos,
+ *                then POST /{page-id}/feed { attached_media: [...] }
+ *   - Video:     POST /{page-id}/videos  { file_url, description }
+ *
+ * Env vars: META_APP_ID, META_APP_SECRET
+ */
+
+import type {
+  AuthenticateResult,
+  GenerateAuthUrlResult,
+  PageInfo,
+  PublishRequest,
+  PublishResult,
+  RefreshTokenResult,
+  SocialProviderAdapter,
+  SocialProviderError,
+} from "@/lib/social/provider-interface";
+import {
+  classifyMetaError,
+  exchangeCodeForToken,
+  exchangeForLongLivedToken,
+  getMetaAppId,
+  GRAPH_BASE,
+  makeOAuthState,
+  MetaApiError,
+  verifyGrantedScopes,
+} from "@/lib/social/providers/meta-common";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SCOPES = [
+  "pages_show_list",
+  "business_management",
+  "pages_manage_posts",
+  "pages_manage_engagement",
+  "pages_read_engagement",
+  "read_insights",
+];
+
+// ---------------------------------------------------------------------------
+// Publishing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Upload a single photo as an unpublished attachment on a Page.
+ * Returns the photo's media_fbid for use in attached_media.
+ */
+async function uploadUnpublishedPhoto(
+  pageId: string,
+  pageAccessToken: string,
+  imageUrl: string,
+): Promise<string> {
+  const response = await fetch(
+    `${GRAPH_BASE}/${pageId}/photos?access_token=${encodeURIComponent(pageAccessToken)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: imageUrl, published: false }),
+    },
+  );
+
+  const data = (await response.json()) as {
+    id?: string;
+    error?: { message: string; code: number };
+  };
+
+  if (data.error || !data.id) {
+    throw new MetaApiError(
+      data.error?.message ?? "Failed to upload photo",
+      data.error?.code,
+      JSON.stringify(data),
+    );
+  }
+
+  return data.id;
+}
+
+// ---------------------------------------------------------------------------
+// Provider implementation
+// ---------------------------------------------------------------------------
+
+export const facebookProvider: SocialProviderAdapter = {
+  identifier: "facebook",
+  displayName: "Facebook",
+  maxContentLength: 63206,
+  supportsImages: true,
+  supportsVideo: true,
+  supportsCarousel: true,
+  maxImages: 10,
+  maxConcurrentJobs: 5,
+  requiresPageSelection: true,
+
+  // -------------------------------------------------------------------------
+  // OAuth
+  // -------------------------------------------------------------------------
+
+  async generateAuthUrl(callbackUrl: string): Promise<GenerateAuthUrlResult> {
+    const state = makeOAuthState(16);
+    const url =
+      "https://www.facebook.com/v20.0/dialog/oauth" +
+      `?client_id=${encodeURIComponent(getMetaAppId())}` +
+      `&redirect_uri=${encodeURIComponent(callbackUrl)}` +
+      `&state=${state}` +
+      `&scope=${SCOPES.join(",")}`;
+
+    return { url, state, codeVerifier: makeOAuthState(10) };
+  },
+
+  async authenticate(params: {
+    code: string;
+    codeVerifier?: string;
+    state?: string;
+  }): Promise<AuthenticateResult> {
+    const redirectUri = params.codeVerifier ?? "";
+
+    const shortToken = await exchangeCodeForToken(params.code, redirectUri);
+    const longToken = await exchangeForLongLivedToken(shortToken.access_token);
+
+    await verifyGrantedScopes(longToken.access_token, SCOPES);
+
+    const profileUrl =
+      `${GRAPH_BASE}/me` +
+      `?fields=id,name,picture&access_token=${encodeURIComponent(longToken.access_token)}`;
+    const profileResp = await fetch(profileUrl);
+    const profile = (await profileResp.json()) as {
+      id: string;
+      name: string;
+      picture?: { data?: { url?: string } };
+    };
+
+    const FIFTY_NINE_DAYS_S = 59 * 24 * 60 * 60;
+
+    return {
+      platformUserId: profile.id,
+      accessToken: longToken.access_token,
+      refreshToken: longToken.access_token,
+      expiresIn: longToken.expires_in ?? FIFTY_NINE_DAYS_S,
+      displayName: profile.name,
+      avatarUrl: profile.picture?.data?.url ?? "",
+      username: "",
+      requiresPageSelection: true,
+    };
+  },
+
+  async refreshToken(_refreshToken: string): Promise<RefreshTokenResult> {
+    // Meta long-lived tokens do not have an explicit refresh endpoint.
+    return { accessToken: _refreshToken };
+  },
+
+  // -------------------------------------------------------------------------
+  // Page selection
+  // -------------------------------------------------------------------------
+
+  /**
+   * List all Facebook Pages managed by the authenticated user.
+   *
+   * Returns a page-scoped access_token for each page so the caller can store
+   * it and use it for publishing without needing the user token later.
+   */
+  async fetchPageInformation(accessToken: string): Promise<PageInfo[]> {
+    const seenIds = new Set<string>();
+    const pages: PageInfo[] = [];
+
+    const fetchPaginated = async (startUrl: string): Promise<void> => {
+      let nextUrl: string | undefined = startUrl;
+      while (nextUrl) {
+        const resp = await fetch(nextUrl);
+        const json = (await resp.json()) as {
+          data?: Array<{
+            id: string;
+            name: string;
+            username?: string;
+            access_token?: string;
+            picture?: { data?: { url?: string } };
+          }>;
+          paging?: { next?: string };
+        };
+
+        for (const page of json.data ?? []) {
+          if (!seenIds.has(page.id)) {
+            seenIds.add(page.id);
+            pages.push({
+              id: page.id,
+              name: page.name,
+              username: page.username,
+              picture: page.picture?.data?.url,
+              accessToken: page.access_token,
+            });
+          }
+        }
+
+        nextUrl = json.paging?.next;
+      }
+    };
+
+    // Primary: pages the user explicitly shared during OAuth
+    await fetchPaginated(
+      `${GRAPH_BASE}/me/accounts` +
+        `?fields=id,username,name,access_token,picture.type(large)` +
+        `&limit=100&access_token=${encodeURIComponent(accessToken)}`,
+    );
+
+    // Secondary: Business Manager owned/client pages (best-effort)
+    try {
+      let bizUrl: string | undefined =
+        `${GRAPH_BASE}/me/businesses?access_token=${encodeURIComponent(accessToken)}`;
+
+      while (bizUrl) {
+        const bizResp = await fetch(bizUrl);
+        const bizData = (await bizResp.json()) as {
+          data?: Array<{ id: string }>;
+          paging?: { next?: string };
+        };
+
+        for (const biz of bizData.data ?? []) {
+          try {
+            await fetchPaginated(
+              `${GRAPH_BASE}/${biz.id}/owned_pages` +
+                `?fields=id,username,name,access_token,picture.type(large)` +
+                `&limit=100&access_token=${encodeURIComponent(accessToken)}`,
+            );
+          } catch {
+            // Best-effort
+          }
+          try {
+            await fetchPaginated(
+              `${GRAPH_BASE}/${biz.id}/client_pages` +
+                `?fields=id,username,name,access_token,picture.type(large)` +
+                `&limit=100&access_token=${encodeURIComponent(accessToken)}`,
+            );
+          } catch {
+            // Best-effort
+          }
+        }
+
+        bizUrl = bizData.paging?.next;
+      }
+    } catch {
+      // Business Manager API not available for all tokens
+    }
+
+    return pages;
+  },
+
+  // -------------------------------------------------------------------------
+  // Publishing
+  // -------------------------------------------------------------------------
+
+  async post(
+    pageId: string,
+    accessToken: string,
+    requests: PublishRequest[],
+  ): Promise<PublishResult[]> {
+    const [request] = requests;
+    if (!request) return [];
+
+    const media = request.media ?? [];
+    const content = request.content;
+
+    const videos = media.filter((m) => m.type === "video");
+    const images = media.filter((m) => m.type === "image");
+
+    // ------------------------------------------------------------------
+    // Video post
+    // ------------------------------------------------------------------
+    if (videos.length > 0) {
+      const videoUrl = videos[0].url;
+
+      const response = await fetch(
+        `${GRAPH_BASE}/${pageId}/videos` +
+          `?access_token=${encodeURIComponent(accessToken)}&fields=id,permalink_url`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            file_url: videoUrl,
+            description: content,
+            published: true,
+          }),
+        },
+      );
+
+      const data = (await response.json()) as {
+        id?: string;
+        permalink_url?: string;
+        error?: { message: string; code: number };
+      };
+
+      if (data.error || !data.id) {
+        throw new MetaApiError(
+          data.error?.message ?? "Failed to upload video",
+          data.error?.code,
+          JSON.stringify(data),
+        );
+      }
+
+      return [
+        {
+          postId: request.postId,
+          platformPostId: data.id,
+          platformPostUrl: data.permalink_url ?? `https://www.facebook.com/reel/${data.id}`,
+          status: "published",
+        },
+      ];
+    }
+
+    // ------------------------------------------------------------------
+    // Photo post (single or multi-photo)
+    // ------------------------------------------------------------------
+    const attachedMedia: Array<{ media_fbid: string }> = [];
+
+    if (images.length > 0) {
+      const photoIds = await Promise.all(
+        images.map((img) => uploadUnpublishedPhoto(pageId, accessToken, img.url)),
+      );
+      attachedMedia.push(...photoIds.map((id) => ({ media_fbid: id })));
+    }
+
+    const feedBody: Record<string, unknown> = {
+      message: content,
+      published: true,
+    };
+
+    if (attachedMedia.length > 0) {
+      feedBody.attached_media = attachedMedia;
+    }
+
+    // Support optional link attachment from platformSettings
+    const link = request.platformSettings?.link;
+    if (typeof link === "string" && link) {
+      feedBody.link = link;
+    }
+
+    const feedResponse = await fetch(
+      `${GRAPH_BASE}/${pageId}/feed` +
+        `?access_token=${encodeURIComponent(accessToken)}&fields=id,permalink_url`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(feedBody),
+      },
+    );
+
+    const feedData = (await feedResponse.json()) as {
+      id?: string;
+      permalink_url?: string;
+      error?: { message: string; code: number };
+    };
+
+    if (feedData.error || !feedData.id) {
+      throw new MetaApiError(
+        feedData.error?.message ?? "Failed to publish Facebook post",
+        feedData.error?.code,
+        JSON.stringify(feedData),
+      );
+    }
+
+    return [
+      {
+        postId: request.postId,
+        platformPostId: feedData.id,
+        platformPostUrl:
+          feedData.permalink_url ??
+          `https://www.facebook.com/${pageId}/posts/${feedData.id}`,
+        status: "published",
+      },
+    ];
+  },
+
+  // -------------------------------------------------------------------------
+  // Error classification
+  // -------------------------------------------------------------------------
+
+  classifyError(error: unknown): SocialProviderError {
+    const body =
+      error instanceof Error
+        ? JSON.stringify({ message: error.message })
+        : typeof error === "string"
+          ? error
+          : JSON.stringify(error);
+
+    return (
+      classifyMetaError(body) ?? {
+        type: "retry",
+        message:
+          error instanceof Error
+            ? error.message
+            : "An unexpected Facebook error occurred.",
+        original: error,
+      }
+    );
+  },
+
+  // -------------------------------------------------------------------------
+  // Capabilities
+  // -------------------------------------------------------------------------
+
+  getCapabilities() {
+    return {
+      identifier: "facebook" as const,
+      displayName: "Facebook",
+      maxContentLength: 63206,
+      supportsImages: true,
+      supportsVideo: true,
+      supportsCarousel: true,
+      requiresPageSelection: true,
+    };
+  },
+};

--- a/src/lib/social/providers/index.ts
+++ b/src/lib/social/providers/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Social provider bootstrap module.
+ *
+ * Import this module once (e.g., in the social API route handler) to ensure
+ * all provider adapters are registered in the provider registry before use.
+ * Each provider calls registerProvider() as a side effect at module load time.
+ */
+import "./linkedin";
+import "./x";
+import "./instagram";
+import "./facebook";
+import "./tiktok";
+import "./youtube";
+
+export { linkedInProvider } from "./linkedin";
+export { xProvider } from "./x";
+export { tikTokProvider } from "./tiktok";
+export { youTubeProvider } from "./youtube";
+export { facebookProvider } from "./facebook";
+export { instagramProvider } from "./instagram";

--- a/src/lib/social/providers/instagram.ts
+++ b/src/lib/social/providers/instagram.ts
@@ -1,0 +1,607 @@
+/**
+ * Instagram provider adapter.
+ *
+ * Instagram Business accounts publish via the Meta Graph API using a
+ * container-based async flow:
+ *   1. POST /{ig-user-id}/media  → create a container
+ *   2. Poll GET /{container-id}?fields=status_code until FINISHED
+ *   3. POST /{ig-user-id}/media_publish?creation_id={container-id}
+ *   4. GET /{media-id}?fields=permalink
+ *
+ * Carousel posts add an extra step: each item is created with
+ * is_carousel_item=true, then a parent CAROUSEL container is created
+ * before the final publish call.
+ *
+ * The OAuth flow uses Facebook Login (same as the Facebook provider) but
+ * with different scopes. After the initial code exchange the caller must
+ * call fetchPageInformation() to resolve which IG Business account they
+ * want to post from, then store that account's page-scoped access token.
+ *
+ * Env vars: META_APP_ID, META_APP_SECRET
+ */
+
+import type {
+  AuthenticateResult,
+  GenerateAuthUrlResult,
+  PageInfo,
+  PublishRequest,
+  PublishResult,
+  RefreshTokenResult,
+  SocialProviderAdapter,
+  SocialProviderError,
+} from "@/lib/social/provider-interface";
+import {
+  classifyMetaError,
+  exchangeCodeForToken,
+  exchangeForLongLivedToken,
+  getMetaAppId,
+  GRAPH_BASE,
+  makeOAuthState,
+  MetaApiError,
+  verifyGrantedScopes,
+} from "@/lib/social/providers/meta-common";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SCOPES = [
+  "instagram_basic",
+  "pages_show_list",
+  "pages_read_engagement",
+  "business_management",
+  "instagram_content_publish",
+  "instagram_manage_comments",
+  "instagram_manage_insights",
+];
+
+/** Milliseconds to wait between container status polls. */
+const POLL_INTERVAL_MS = 30_000;
+
+/** Maximum number of poll attempts before giving up. */
+const MAX_POLL_ATTEMPTS = 10;
+
+// ---------------------------------------------------------------------------
+// Helper: poll container until FINISHED
+// ---------------------------------------------------------------------------
+
+async function pollContainerStatus(
+  containerId: string,
+  accessToken: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+    const url =
+      `${GRAPH_BASE}/${containerId}` +
+      `?fields=status_code&access_token=${encodeURIComponent(accessToken)}`;
+
+    const response = await fetch(url);
+    const data = (await response.json()) as {
+      status_code?: string;
+      error?: { message: string; code: number };
+    };
+
+    if (data.error) {
+      throw new MetaApiError(
+        data.error.message,
+        data.error.code,
+        JSON.stringify(data),
+      );
+    }
+
+    const statusCode = data.status_code ?? "IN_PROGRESS";
+
+    if (statusCode === "FINISHED") {
+      return;
+    }
+
+    if (statusCode === "ERROR" || statusCode === "EXPIRED") {
+      throw new MetaApiError(
+        `Instagram container processing failed with status: ${statusCode}`,
+        undefined,
+        JSON.stringify(data),
+      );
+    }
+
+    // IN_PROGRESS or any other transient state — wait then retry
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  throw new MetaApiError(
+    `Instagram container ${containerId} did not finish processing after ${MAX_POLL_ATTEMPTS} polls.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create a single media container
+// ---------------------------------------------------------------------------
+
+async function createMediaContainer(
+  igUserId: string,
+  accessToken: string,
+  opts: {
+    mediaUrl: string;
+    isVideo: boolean;
+    caption?: string;
+    isCarouselItem?: boolean;
+  },
+): Promise<string> {
+  const params = new URLSearchParams();
+  params.set("access_token", accessToken);
+
+  if (opts.isVideo) {
+    params.set("video_url", opts.mediaUrl);
+    params.set("media_type", "REELS");
+  } else {
+    params.set("image_url", opts.mediaUrl);
+  }
+
+  if (opts.caption) {
+    params.set("caption", opts.caption);
+  }
+
+  if (opts.isCarouselItem) {
+    params.set("is_carousel_item", "true");
+  }
+
+  const url = `${GRAPH_BASE}/${igUserId}/media?${params.toString()}`;
+  const response = await fetch(url, { method: "POST" });
+  const data = (await response.json()) as {
+    id?: string;
+    error?: { message: string; code: number };
+  };
+
+  if (data.error || !data.id) {
+    throw new MetaApiError(
+      data.error?.message ?? "Failed to create media container",
+      data.error?.code,
+      JSON.stringify(data),
+    );
+  }
+
+  return data.id;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: publish a container
+// ---------------------------------------------------------------------------
+
+async function publishContainer(
+  igUserId: string,
+  creationId: string,
+  accessToken: string,
+): Promise<string> {
+  const params = new URLSearchParams({
+    creation_id: creationId,
+    access_token: accessToken,
+    field: "id",
+  });
+
+  const url = `${GRAPH_BASE}/${igUserId}/media_publish?${params.toString()}`;
+  const response = await fetch(url, { method: "POST" });
+  const data = (await response.json()) as {
+    id?: string;
+    error?: { message: string; code: number };
+  };
+
+  if (data.error || !data.id) {
+    throw new MetaApiError(
+      data.error?.message ?? "Failed to publish media container",
+      data.error?.code,
+      JSON.stringify(data),
+    );
+  }
+
+  return data.id;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: fetch media permalink
+// ---------------------------------------------------------------------------
+
+async function fetchPermalink(
+  mediaId: string,
+  accessToken: string,
+): Promise<string> {
+  const url =
+    `${GRAPH_BASE}/${mediaId}` +
+    `?fields=permalink&access_token=${encodeURIComponent(accessToken)}`;
+
+  const response = await fetch(url);
+  const data = (await response.json()) as {
+    permalink?: string;
+    error?: { message: string; code: number };
+  };
+
+  if (data.error) {
+    throw new MetaApiError(
+      data.error.message,
+      data.error.code,
+      JSON.stringify(data),
+    );
+  }
+
+  return data.permalink ?? `https://www.instagram.com/p/${mediaId}/`;
+}
+
+// ---------------------------------------------------------------------------
+// Provider implementation
+// ---------------------------------------------------------------------------
+
+export const instagramProvider: SocialProviderAdapter = {
+  identifier: "instagram",
+  displayName: "Instagram",
+  maxContentLength: 2200,
+  supportsImages: true,
+  supportsVideo: true,
+  supportsCarousel: true,
+  maxImages: 10,
+  maxConcurrentJobs: 5,
+  requiresPageSelection: true,
+
+  // -------------------------------------------------------------------------
+  // OAuth
+  // -------------------------------------------------------------------------
+
+  async generateAuthUrl(callbackUrl: string): Promise<GenerateAuthUrlResult> {
+    const state = makeOAuthState(16);
+    const url =
+      "https://www.facebook.com/v20.0/dialog/oauth" +
+      `?client_id=${encodeURIComponent(getMetaAppId())}` +
+      `&redirect_uri=${encodeURIComponent(callbackUrl)}` +
+      `&state=${state}` +
+      `&scope=${encodeURIComponent(SCOPES.join(","))}`;
+
+    return { url, state, codeVerifier: makeOAuthState(10) };
+  },
+
+  async authenticate(params: {
+    code: string;
+    codeVerifier?: string;
+    state?: string;
+  }): Promise<AuthenticateResult> {
+    // We don't know the exact callbackUrl here — the caller must have stored it
+    // (or passed it). We accept the redirect_uri via codeVerifier field as a
+    // convention: codeVerifier is overloaded as the redirect_uri by the OAuth
+    // callback handler. If absent we fall back to a placeholder (this path is
+    // typically not hit in production — the callback route calls authenticate
+    // with the correct redirect_uri encoded in codeVerifier).
+    const redirectUri = params.codeVerifier ?? "";
+
+    const shortToken = await exchangeCodeForToken(params.code, redirectUri);
+    const longToken = await exchangeForLongLivedToken(shortToken.access_token);
+
+    await verifyGrantedScopes(longToken.access_token, SCOPES);
+
+    const profileUrl =
+      `${GRAPH_BASE}/me` +
+      `?fields=id,name,picture&access_token=${encodeURIComponent(longToken.access_token)}`;
+    const profileResp = await fetch(profileUrl);
+    const profile = (await profileResp.json()) as {
+      id: string;
+      name: string;
+      picture?: { data?: { url?: string } };
+    };
+
+    // ~59 days expressed in seconds (Meta long-lived tokens last 60 days)
+    const FIFTY_NINE_DAYS_S = 59 * 24 * 60 * 60;
+
+    return {
+      platformUserId: profile.id,
+      accessToken: longToken.access_token,
+      refreshToken: longToken.access_token, // FB tokens self-refresh; store same value
+      expiresIn: longToken.expires_in ?? FIFTY_NINE_DAYS_S,
+      displayName: profile.name,
+      avatarUrl: profile.picture?.data?.url ?? "",
+      username: "",
+      requiresPageSelection: true,
+    };
+  },
+
+  async refreshToken(_refreshToken: string): Promise<RefreshTokenResult> {
+    // Meta long-lived tokens are renewed by making a regular API call before
+    // they expire; there is no explicit refresh endpoint. The caller should
+    // re-authenticate once the token expires.
+    return { accessToken: _refreshToken };
+  },
+
+  // -------------------------------------------------------------------------
+  // Page selection
+  // -------------------------------------------------------------------------
+
+  /**
+   * List all Instagram Business accounts visible to the user token.
+   *
+   * The flow is: Facebook Pages → instagram_business_account field → IG User.
+   * We also walk Business Manager owned/client pages for completeness.
+   */
+  async fetchPageInformation(accessToken: string): Promise<PageInfo[]> {
+    const seenPageIds = new Set<string>();
+    const facebookPages: Array<{
+      id: string;
+      instagram_business_account?: { id: string };
+    }> = [];
+
+    const fetchPaginated = async (startUrl: string): Promise<void> => {
+      let nextUrl: string | undefined = startUrl;
+      while (nextUrl) {
+        const resp = await fetch(nextUrl);
+        const json = (await resp.json()) as {
+          data?: typeof facebookPages;
+          paging?: { next?: string };
+        };
+        if (json.data) {
+          for (const page of json.data) {
+            if (!seenPageIds.has(page.id)) {
+              seenPageIds.add(page.id);
+              facebookPages.push(page);
+            }
+          }
+        }
+        nextUrl = json.paging?.next;
+      }
+    };
+
+    // Primary: pages explicitly shared during OAuth
+    await fetchPaginated(
+      `${GRAPH_BASE}/me/accounts` +
+        `?fields=id,instagram_business_account,username,name,picture.type(large)` +
+        `&limit=100&access_token=${encodeURIComponent(accessToken)}`,
+    );
+
+    // Secondary: Business Manager pages (best-effort)
+    try {
+      let bizUrl: string | undefined =
+        `${GRAPH_BASE}/me/businesses?access_token=${encodeURIComponent(accessToken)}`;
+
+      while (bizUrl) {
+        const bizResp = await fetch(bizUrl);
+        const bizData = (await bizResp.json()) as {
+          data?: Array<{ id: string }>;
+          paging?: { next?: string };
+        };
+
+        for (const biz of bizData.data ?? []) {
+          try {
+            await fetchPaginated(
+              `${GRAPH_BASE}/${biz.id}/owned_pages` +
+                `?fields=id,instagram_business_account,username,name,picture.type(large)` +
+                `&limit=100&access_token=${encodeURIComponent(accessToken)}`,
+            );
+          } catch {
+            // Best-effort
+          }
+          try {
+            await fetchPaginated(
+              `${GRAPH_BASE}/${biz.id}/client_pages` +
+                `?fields=id,instagram_business_account,username,name,picture.type(large)` +
+                `&limit=100&access_token=${encodeURIComponent(accessToken)}`,
+            );
+          } catch {
+            // Best-effort
+          }
+        }
+
+        bizUrl = bizData.paging?.next;
+      }
+    } catch {
+      // Business Manager API not available for all tokens
+    }
+
+    // Resolve each FB Page → IG Business Account details
+    const results = await Promise.all(
+      facebookPages
+        .filter((p) => p.instagram_business_account)
+        .map(async (page) => {
+          const igId = page.instagram_business_account!.id;
+
+          const igResp = await fetch(
+            `${GRAPH_BASE}/${igId}` +
+              `?fields=name,username,profile_picture_url` +
+              `&access_token=${encodeURIComponent(accessToken)}`,
+          );
+          const igData = (await igResp.json()) as {
+            id?: string;
+            name?: string;
+            username?: string;
+            profile_picture_url?: string;
+          };
+
+          // Fetch page-scoped access token (required for publishing)
+          const pageResp = await fetch(
+            `${GRAPH_BASE}/${page.id}` +
+              `?fields=access_token,name,picture.type(large)` +
+              `&access_token=${encodeURIComponent(accessToken)}`,
+          );
+          const pageData = (await pageResp.json()) as {
+            access_token?: string;
+          };
+
+          return {
+            id: igId,
+            name: igData.name ?? igId,
+            username: igData.username,
+            picture: igData.profile_picture_url,
+            accessToken: pageData.access_token,
+          } satisfies PageInfo;
+        }),
+    );
+
+    return results.filter((r) => r.id);
+  },
+
+  // -------------------------------------------------------------------------
+  // Publishing
+  // -------------------------------------------------------------------------
+
+  async post(
+    igUserId: string,
+    accessToken: string,
+    requests: PublishRequest[],
+  ): Promise<PublishResult[]> {
+    const [request] = requests;
+    if (!request) return [];
+
+    const media = request.media ?? [];
+    const content = request.content;
+
+    const images = media.filter((m) => m.type === "image");
+    const videos = media.filter((m) => m.type === "video");
+
+    // ------------------------------------------------------------------
+    // Single video (Reel)
+    // ------------------------------------------------------------------
+    if (videos.length === 1 && images.length === 0) {
+      const containerId = await createMediaContainer(igUserId, accessToken, {
+        mediaUrl: videos[0].url,
+        isVideo: true,
+        caption: content,
+      });
+
+      await pollContainerStatus(containerId, accessToken);
+
+      const mediaId = await publishContainer(igUserId, containerId, accessToken);
+      const permalink = await fetchPermalink(mediaId, accessToken);
+
+      return [
+        {
+          postId: request.postId,
+          platformPostId: mediaId,
+          platformPostUrl: permalink,
+          status: "published",
+        },
+      ];
+    }
+
+    // ------------------------------------------------------------------
+    // Single image
+    // ------------------------------------------------------------------
+    if (images.length === 1 && videos.length === 0) {
+      const containerId = await createMediaContainer(igUserId, accessToken, {
+        mediaUrl: images[0].url,
+        isVideo: false,
+        caption: content,
+      });
+
+      await pollContainerStatus(containerId, accessToken);
+
+      const mediaId = await publishContainer(igUserId, containerId, accessToken);
+      const permalink = await fetchPermalink(mediaId, accessToken);
+
+      return [
+        {
+          postId: request.postId,
+          platformPostId: mediaId,
+          platformPostUrl: permalink,
+          status: "published",
+        },
+      ];
+    }
+
+    // ------------------------------------------------------------------
+    // Carousel (2-10 images)
+    // ------------------------------------------------------------------
+    if (images.length >= 2) {
+      // Step 1: create individual carousel item containers
+      const itemContainerIds = await Promise.all(
+        images.map((img) =>
+          createMediaContainer(igUserId, accessToken, {
+            mediaUrl: img.url,
+            isVideo: false,
+            isCarouselItem: true,
+          }),
+        ),
+      );
+
+      // Step 2: poll each item container
+      await Promise.all(
+        itemContainerIds.map((id) => pollContainerStatus(id, accessToken)),
+      );
+
+      // Step 3: create the carousel container
+      const carouselParams = new URLSearchParams({
+        media_type: "CAROUSEL",
+        caption: content,
+        children: itemContainerIds.join(","),
+        access_token: accessToken,
+      });
+
+      const carouselResp = await fetch(
+        `${GRAPH_BASE}/${igUserId}/media?${carouselParams.toString()}`,
+        { method: "POST" },
+      );
+      const carouselData = (await carouselResp.json()) as {
+        id?: string;
+        error?: { message: string; code: number };
+      };
+
+      if (carouselData.error || !carouselData.id) {
+        throw new MetaApiError(
+          carouselData.error?.message ?? "Failed to create carousel container",
+          carouselData.error?.code,
+          JSON.stringify(carouselData),
+        );
+      }
+
+      // Step 4: poll carousel container
+      await pollContainerStatus(carouselData.id, accessToken);
+
+      // Step 5: publish
+      const mediaId = await publishContainer(igUserId, carouselData.id, accessToken);
+      const permalink = await fetchPermalink(mediaId, accessToken);
+
+      return [
+        {
+          postId: request.postId,
+          platformPostId: mediaId,
+          platformPostUrl: permalink,
+          status: "published",
+        },
+      ];
+    }
+
+    // No media — Instagram requires at least one media item
+    throw new MetaApiError(
+      "Instagram posts require at least one image or video.",
+    );
+  },
+
+  // -------------------------------------------------------------------------
+  // Error classification
+  // -------------------------------------------------------------------------
+
+  classifyError(error: unknown): SocialProviderError {
+    const body =
+      error instanceof Error
+        ? JSON.stringify({ message: error.message })
+        : typeof error === "string"
+          ? error
+          : JSON.stringify(error);
+
+    return (
+      classifyMetaError(body) ?? {
+        type: "retry",
+        message:
+          error instanceof Error
+            ? error.message
+            : "An unexpected Instagram error occurred.",
+        original: error,
+      }
+    );
+  },
+
+  // -------------------------------------------------------------------------
+  // Capabilities
+  // -------------------------------------------------------------------------
+
+  getCapabilities() {
+    return {
+      identifier: "instagram" as const,
+      displayName: "Instagram",
+      maxContentLength: 2200,
+      supportsImages: true,
+      supportsVideo: true,
+      supportsCarousel: true,
+      requiresPageSelection: true,
+    };
+  },
+};

--- a/src/lib/social/providers/linkedin.ts
+++ b/src/lib/social/providers/linkedin.ts
@@ -1,0 +1,581 @@
+/**
+ * LinkedIn provider adapter.
+ *
+ * Supports posting to personal profiles and organization pages.
+ * Media is uploaded via the LinkedIn REST media upload flow:
+ *   1. POST /rest/images?action=initializeUpload  → get uploadUrl + image URN
+ *   2. PUT <uploadUrl> with binary image data
+ *   3. POST /rest/posts with the image URN in content.media or content.multiImage
+ *
+ * The OAuth flow uses LinkedIn's authorization code flow with 7 scopes.
+ * fetchPageInformation() returns organization pages the user admin.
+ *
+ * Text content must escape LinkedIn markdown special chars before posting.
+ *
+ * Env vars: LINKEDIN_CLIENT_ID, LINKEDIN_CLIENT_SECRET
+ */
+
+import type {
+  AuthenticateResult,
+  GenerateAuthUrlResult,
+  PageInfo,
+  ProviderCapabilities,
+  PublishRequest,
+  PublishResult,
+  RefreshTokenResult,
+  SocialProviderAdapter,
+  SocialProviderError,
+} from "@/lib/social/provider-interface";
+import { registerProvider } from "@/lib/social/provider-registry";
+import { makeOAuthState } from "@/lib/social/providers/meta-common";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LINKEDIN_SCOPES = [
+  "openid",
+  "profile",
+  "w_member_social",
+  "r_basicprofile",
+  "rw_organization_admin",
+  "w_organization_social",
+  "r_organization_social",
+];
+
+const LINKEDIN_AUTH_URL = "https://www.linkedin.com/oauth/v2/authorization";
+const LINKEDIN_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken";
+const LINKEDIN_API_BASE = "https://api.linkedin.com";
+
+/** LinkedIn API version header value used for REST endpoints. */
+const LINKEDIN_VERSION = "202409";
+
+// ---------------------------------------------------------------------------
+// Environment helpers
+// ---------------------------------------------------------------------------
+
+function getClientId(): string {
+  const id = process.env.LINKEDIN_CLIENT_ID;
+  if (!id) throw new Error("LINKEDIN_CLIENT_ID environment variable is not set.");
+  return id;
+}
+
+function getClientSecret(): string {
+  const secret = process.env.LINKEDIN_CLIENT_SECRET;
+  if (!secret)
+    throw new Error("LINKEDIN_CLIENT_SECRET environment variable is not set.");
+  return secret;
+}
+
+// ---------------------------------------------------------------------------
+// Text escaping
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape LinkedIn markdown special characters in post text.
+ *
+ * Organisation mention syntax `@[Name](urn:li:organization:id)` is preserved
+ * verbatim — only the plain-text regions between mentions are escaped.
+ */
+function escapeLinkedInText(text: string): string {
+  // Preserve existing org mention tokens
+  const MENTION_PATTERN = /@\[.+?]\(urn:li:organization.+?\)/g;
+  const matches = text.match(MENTION_PATTERN) ?? [];
+  const segments = text.split(MENTION_PATTERN);
+
+  const escapedSegments = segments.map((segment) =>
+    segment
+      .replace(/\\/g, "\\\\")
+      .replace(/</g, "\\<")
+      .replace(/>/g, "\\>")
+      .replace(/#/g, "\\#")
+      .replace(/~/g, "\\~")
+      .replace(/_/g, "\\_")
+      .replace(/\|/g, "\\|")
+      .replace(/\[/g, "\\[")
+      .replace(/]/g, "\\]")
+      .replace(/\*/g, "\\*")
+      .replace(/\(/g, "\\(")
+      .replace(/\)/g, "\\)")
+      .replace(/\{/g, "\\{")
+      .replace(/}/g, "\\}")
+      .replace(/@/g, "\\@"),
+  );
+
+  // Re-interleave escaped segments with original mention tokens
+  return escapedSegments.reduce((result, segment, index) => {
+    const mention = matches[index] ?? "";
+    return result + segment + mention;
+  }, "");
+}
+
+// ---------------------------------------------------------------------------
+// Media upload helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Upload a single image to LinkedIn and return its URN.
+ *
+ * Flow: initialize upload → PUT binary data → return image URN.
+ */
+async function uploadImage(
+  imageUrl: string,
+  accessToken: string,
+  ownerUrn: string,
+): Promise<string> {
+  // Step 1: initialize upload
+  const initResp = await fetch(
+    `${LINKEDIN_API_BASE}/rest/images?action=initializeUpload`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Restli-Protocol-Version": "2.0.0",
+        "LinkedIn-Version": LINKEDIN_VERSION,
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        initializeUploadRequest: { owner: ownerUrn },
+      }),
+    },
+  );
+
+  const initData = (await initResp.json()) as {
+    value?: { uploadUrl?: string; image?: string };
+    message?: string;
+    status?: number;
+  };
+
+  if (!initData.value?.uploadUrl || !initData.value?.image) {
+    throw new LinkedInApiError(
+      initData.message ?? "Failed to initialize LinkedIn image upload",
+      initData.status,
+    );
+  }
+
+  const { uploadUrl, image: imageUrn } = initData.value;
+
+  // Step 2: fetch image bytes and upload
+  const imageResp = await fetch(imageUrl);
+  if (!imageResp.ok) {
+    throw new LinkedInApiError(
+      `Failed to fetch image from URL: ${imageResp.status} ${imageUrl}`,
+    );
+  }
+  const imageBuffer = Buffer.from(await imageResp.arrayBuffer());
+
+  const uploadResp = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: {
+      "LinkedIn-Version": LINKEDIN_VERSION,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: imageBuffer,
+  });
+
+  if (!uploadResp.ok) {
+    throw new LinkedInApiError(
+      `LinkedIn image binary upload failed: ${uploadResp.status}`,
+      uploadResp.status,
+    );
+  }
+
+  return imageUrn;
+}
+
+// ---------------------------------------------------------------------------
+// Post payload builder
+// ---------------------------------------------------------------------------
+
+function buildPostPayload(
+  authorUrn: string,
+  text: string,
+  imageUrns: string[],
+): Record<string, unknown> {
+  const base = {
+    author: authorUrn,
+    commentary: escapeLinkedInText(text),
+    visibility: "PUBLIC",
+    distribution: {
+      feedDistribution: "MAIN_FEED",
+      targetEntities: [] as string[],
+      thirdPartyDistributionChannels: [] as string[],
+    },
+    lifecycleState: "PUBLISHED",
+    isReshareDisabledByAuthor: false,
+  };
+
+  if (imageUrns.length === 0) {
+    return base;
+  }
+
+  if (imageUrns.length === 1) {
+    return {
+      ...base,
+      content: {
+        media: { id: imageUrns[0] },
+      },
+    };
+  }
+
+  return {
+    ...base,
+    content: {
+      multiImage: {
+        images: imageUrns.map((id) => ({ id })),
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Custom error type
+// ---------------------------------------------------------------------------
+
+export class LinkedInApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "LinkedInApiError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider implementation
+// ---------------------------------------------------------------------------
+
+export const linkedInProvider: SocialProviderAdapter = {
+  identifier: "linkedin",
+  displayName: "LinkedIn",
+  maxContentLength: 3000,
+  supportsImages: true,
+  supportsVideo: false,
+  supportsCarousel: true,
+  maxImages: 9,
+  maxConcurrentJobs: 2,
+  requiresPageSelection: true,
+
+  // -------------------------------------------------------------------------
+  // OAuth
+  // -------------------------------------------------------------------------
+
+  async generateAuthUrl(callbackUrl: string): Promise<GenerateAuthUrlResult> {
+    const state = makeOAuthState(16);
+    const url =
+      LINKEDIN_AUTH_URL +
+      `?response_type=code` +
+      `&client_id=${encodeURIComponent(getClientId())}` +
+      `&redirect_uri=${encodeURIComponent(callbackUrl)}` +
+      `&state=${state}` +
+      `&scope=${encodeURIComponent(LINKEDIN_SCOPES.join(" "))}`;
+
+    return { url, state };
+  },
+
+  async authenticate(params: {
+    code: string;
+    codeVerifier?: string;
+    state?: string;
+  }): Promise<AuthenticateResult> {
+    const redirectUri = params.codeVerifier ?? "";
+
+    const tokenBody = new URLSearchParams({
+      grant_type: "authorization_code",
+      code: params.code,
+      redirect_uri: redirectUri,
+      client_id: getClientId(),
+      client_secret: getClientSecret(),
+    });
+
+    const tokenResp = await fetch(LINKEDIN_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: tokenBody,
+    });
+
+    const tokenData = (await tokenResp.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      error?: string;
+      error_description?: string;
+    };
+
+    if (!tokenData.access_token) {
+      throw new LinkedInApiError(
+        tokenData.error_description ?? tokenData.error ?? "LinkedIn token exchange failed",
+      );
+    }
+
+    const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } =
+      tokenData;
+
+    // Fetch user profile via userinfo endpoint (OIDC-compatible)
+    const profileResp = await fetch(`${LINKEDIN_API_BASE}/v2/userinfo`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const profile = (await profileResp.json()) as {
+      sub?: string;
+      name?: string;
+      picture?: string;
+    };
+
+    return {
+      platformUserId: profile.sub ?? "",
+      accessToken,
+      refreshToken: refreshToken ?? undefined,
+      expiresIn: expiresIn ?? undefined,
+      displayName: profile.name ?? "",
+      avatarUrl: profile.picture ?? undefined,
+      requiresPageSelection: true,
+    };
+  },
+
+  async refreshToken(refreshTokenValue: string): Promise<RefreshTokenResult> {
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshTokenValue,
+      client_id: getClientId(),
+      client_secret: getClientSecret(),
+    });
+
+    const resp = await fetch(LINKEDIN_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+
+    const data = (await resp.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      error?: string;
+      error_description?: string;
+    };
+
+    if (!data.access_token) {
+      throw new LinkedInApiError(
+        data.error_description ?? data.error ?? "LinkedIn token refresh failed",
+      );
+    }
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token ?? undefined,
+      expiresIn: data.expires_in ?? undefined,
+    };
+  },
+
+  // -------------------------------------------------------------------------
+  // Page / org selection
+  // -------------------------------------------------------------------------
+
+  async fetchPageInformation(accessToken: string): Promise<PageInfo[]> {
+    // Fetch organizations where the user has ADMINISTRATOR role
+    const resp = await fetch(
+      `${LINKEDIN_API_BASE}/v2/organizationAcls` +
+        `?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED` +
+        `&projection=(elements*(organization~(id,localizedName,logoV2(original~:playableStreams))))`,
+      {
+        headers: {
+          "X-Restli-Protocol-Version": "2.0.0",
+          "LinkedIn-Version": LINKEDIN_VERSION,
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    const data = (await resp.json()) as {
+      elements?: Array<{
+        "organization~"?: {
+          id?: number;
+          localizedName?: string;
+          logoV2?: {
+            "original~"?: {
+              elements?: Array<{
+                identifiers?: Array<{ identifier?: string }>;
+              }>;
+            };
+          };
+        };
+      }>;
+      message?: string;
+      status?: number;
+    };
+
+    if (!data.elements) {
+      // Gracefully handle cases where the user has no admin orgs
+      return [];
+    }
+
+    return data.elements
+      .map((el) => {
+        const org = el["organization~"];
+        if (!org?.id) return null;
+
+        const logoUrl =
+          org.logoV2?.["original~"]?.elements?.[0]?.identifiers?.[0]?.identifier ?? undefined;
+
+        return {
+          id: String(org.id),
+          name: org.localizedName ?? String(org.id),
+          picture: logoUrl,
+        } satisfies PageInfo;
+      })
+      .filter((p): p is PageInfo => p !== null);
+  },
+
+  // -------------------------------------------------------------------------
+  // Publishing
+  // -------------------------------------------------------------------------
+
+  async post(
+    platformUserId: string,
+    accessToken: string,
+    requests: PublishRequest[],
+  ): Promise<PublishResult[]> {
+    const [request] = requests;
+    if (!request) return [];
+
+    // Determine author URN — platformUserId may be a person or org ID.
+    // Convention: if platformSettings.type === "organization", use org URN.
+    const isOrg = request.platformSettings?.type === "organization";
+    const authorUrn = isOrg
+      ? `urn:li:organization:${platformUserId}`
+      : `urn:li:person:${platformUserId}`;
+
+    // Upload all images
+    const images = (request.media ?? []).filter((m) => m.type === "image");
+    const imageUrns = await Promise.all(
+      images.map((img) => uploadImage(img.url, accessToken, authorUrn)),
+    );
+
+    const payload = buildPostPayload(authorUrn, request.content, imageUrns);
+
+    const postResp = await fetch(`${LINKEDIN_API_BASE}/rest/posts`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Restli-Protocol-Version": "2.0.0",
+        "LinkedIn-Version": LINKEDIN_VERSION,
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (postResp.status !== 201 && postResp.status !== 200) {
+      const errorBody = await postResp.text();
+      throw new LinkedInApiError(
+        `LinkedIn post creation failed: ${postResp.status} — ${errorBody}`,
+        postResp.status,
+      );
+    }
+
+    // LinkedIn returns the post URN in the x-restli-id header
+    const postUrn = postResp.headers.get("x-restli-id") ?? "";
+    const platformPostUrl = `https://www.linkedin.com/feed/update/${encodeURIComponent(postUrn)}`;
+
+    return [
+      {
+        postId: request.postId,
+        platformPostId: postUrn,
+        platformPostUrl,
+        status: "published",
+      },
+    ];
+  },
+
+  // -------------------------------------------------------------------------
+  // Error classification
+  // -------------------------------------------------------------------------
+
+  classifyError(error: unknown): SocialProviderError {
+    const body =
+      error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : JSON.stringify(error);
+
+    // 401 / expired token
+    if (
+      body.includes("401") ||
+      body.includes("Unauthorized") ||
+      body.includes("token") && body.includes("expired")
+    ) {
+      return {
+        type: "refresh-token",
+        message: "LinkedIn access token expired. Please re-authenticate.",
+        original: error,
+      };
+    }
+
+    // 429 rate limit
+    if (body.includes("429") || body.includes("Too Many Requests")) {
+      return {
+        type: "retry",
+        message: "LinkedIn rate limit reached. Will retry shortly.",
+        original: error,
+      };
+    }
+
+    // Bad payload / content issues
+    if (
+      body.includes("INVALID_REQUEST") ||
+      body.includes("400") ||
+      body.includes("invalid") ||
+      body.includes("not allowed") ||
+      body.includes("violates") ||
+      body.includes("bad-body")
+    ) {
+      return {
+        type: "bad-body",
+        message:
+          error instanceof Error
+            ? error.message
+            : "The post content was rejected by LinkedIn.",
+        original: error,
+      };
+    }
+
+    // Transient LinkedIn errors
+    if (
+      body.includes("Unable to obtain activity") ||
+      body.includes("resource is forbidden")
+    ) {
+      return {
+        type: "retry",
+        message: body,
+        original: error,
+      };
+    }
+
+    return {
+      type: "retry",
+      message:
+        error instanceof Error ? error.message : "An unexpected LinkedIn error occurred.",
+      original: error,
+    };
+  },
+
+  // -------------------------------------------------------------------------
+  // Capabilities
+  // -------------------------------------------------------------------------
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      identifier: "linkedin",
+      displayName: "LinkedIn",
+      maxContentLength: 3000,
+      supportsImages: true,
+      supportsVideo: false,
+      supportsCarousel: true,
+      requiresPageSelection: true,
+    };
+  },
+};
+
+// Register at module load time
+registerProvider(linkedInProvider);

--- a/src/lib/social/providers/linkedin.ts
+++ b/src/lib/social/providers/linkedin.ts
@@ -410,21 +410,21 @@ export const linkedInProvider: SocialProviderAdapter = {
       return [];
     }
 
-    return data.elements
-      .map((el) => {
-        const org = el["organization~"];
-        if (!org?.id) return null;
+    const pages: PageInfo[] = [];
+    for (const el of data.elements) {
+      const org = el["organization~"];
+      if (!org?.id) continue;
 
-        const logoUrl =
-          org.logoV2?.["original~"]?.elements?.[0]?.identifiers?.[0]?.identifier ?? undefined;
+      const logoUrl =
+        org.logoV2?.["original~"]?.elements?.[0]?.identifiers?.[0]?.identifier ?? undefined;
 
-        return {
-          id: String(org.id),
-          name: org.localizedName ?? String(org.id),
-          picture: logoUrl,
-        } satisfies PageInfo;
-      })
-      .filter((p): p is PageInfo => p !== null);
+      pages.push({
+        id: String(org.id),
+        name: org.localizedName ?? String(org.id),
+        picture: logoUrl,
+      });
+    }
+    return pages;
   },
 
   // -------------------------------------------------------------------------

--- a/src/lib/social/providers/meta-common.ts
+++ b/src/lib/social/providers/meta-common.ts
@@ -1,0 +1,415 @@
+/**
+ * Shared Meta (Facebook/Instagram) Graph API helpers.
+ *
+ * Both the Instagram and Facebook providers use the same OAuth flow (Facebook
+ * Login) and the same token-exchange pattern. Centralising these here avoids
+ * duplication and makes future version bumps (v20 → v21) a one-line change.
+ */
+
+import type { SocialProviderError, SocialErrorType } from "@/lib/social/provider-interface";
+
+/** Graph API version used across all Meta calls. */
+export const META_API_VERSION = "v20.0";
+
+/** Base URL for all Graph API calls. */
+export const GRAPH_BASE = `https://graph.facebook.com/${META_API_VERSION}`;
+
+// ---------------------------------------------------------------------------
+// Environment helpers
+// ---------------------------------------------------------------------------
+
+export function getMetaAppId(): string {
+  const id = process.env.META_APP_ID;
+  if (!id) throw new Error("META_APP_ID environment variable is not set.");
+  return id;
+}
+
+export function getMetaAppSecret(): string {
+  const secret = process.env.META_APP_SECRET;
+  if (!secret) throw new Error("META_APP_SECRET environment variable is not set.");
+  return secret;
+}
+
+// ---------------------------------------------------------------------------
+// Token exchange
+// ---------------------------------------------------------------------------
+
+export interface ShortToLongTokenResult {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+}
+
+/**
+ * Exchange a short-lived user access token for a long-lived one (~60 days).
+ * This is the second step of the Facebook OAuth code exchange.
+ */
+export async function exchangeForLongLivedToken(
+  shortLivedToken: string,
+): Promise<ShortToLongTokenResult> {
+  const url =
+    `${GRAPH_BASE}/oauth/access_token` +
+    `?grant_type=fb_exchange_token` +
+    `&client_id=${getMetaAppId()}` +
+    `&client_secret=${getMetaAppSecret()}` +
+    `&fb_exchange_token=${encodeURIComponent(shortLivedToken)}`;
+
+  const response = await fetch(url);
+  const data = (await response.json()) as ShortToLongTokenResult & {
+    error?: { message: string; code: number };
+  };
+
+  if (data.error) {
+    throw new MetaApiError(
+      data.error.message,
+      data.error.code,
+      JSON.stringify(data),
+    );
+  }
+
+  return data;
+}
+
+/**
+ * Exchange an authorization code for a short-lived access token.
+ * This is the first step of the Facebook OAuth code exchange.
+ */
+export async function exchangeCodeForToken(
+  code: string,
+  redirectUri: string,
+): Promise<{ access_token: string; token_type: string; expires_in?: number }> {
+  const url =
+    `${GRAPH_BASE}/oauth/access_token` +
+    `?client_id=${getMetaAppId()}` +
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&client_secret=${getMetaAppSecret()}` +
+    `&code=${encodeURIComponent(code)}`;
+
+  const response = await fetch(url);
+  const data = (await response.json()) as {
+    access_token: string;
+    token_type: string;
+    expires_in?: number;
+    error?: { message: string; code: number };
+  };
+
+  if (data.error) {
+    throw new MetaApiError(
+      data.error.message,
+      data.error.code,
+      JSON.stringify(data),
+    );
+  }
+
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Permission verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch granted permissions for a user token and verify all required scopes
+ * are present. Throws MetaPermissionError when any scope is missing.
+ */
+export async function verifyGrantedScopes(
+  accessToken: string,
+  requiredScopes: string[],
+): Promise<void> {
+  const url = `${GRAPH_BASE}/me/permissions?access_token=${encodeURIComponent(accessToken)}`;
+  const response = await fetch(url);
+  const data = (await response.json()) as {
+    data?: Array<{ permission: string; status: string }>;
+    error?: { message: string; code: number };
+  };
+
+  if (data.error) {
+    throw new MetaApiError(data.error.message, data.error.code, JSON.stringify(data));
+  }
+
+  const granted = new Set(
+    (data.data ?? [])
+      .filter((d) => d.status === "granted")
+      .map((d) => d.permission),
+  );
+
+  const missing = requiredScopes.filter((s) => !granted.has(s));
+  if (missing.length > 0) {
+    throw new MetaPermissionError(missing);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a Meta Graph API error body string into a SocialProviderError.
+ *
+ * This runs through the same error codes that Postiz's Instagram/Facebook
+ * providers handle, adapted to our SocialProviderError type.
+ *
+ * @param body - The raw JSON-serialised error body (or any string containing it).
+ * @returns A classified SocialProviderError, or undefined if unknown.
+ */
+export function classifyMetaError(body: string): SocialProviderError | undefined {
+  // ------------------------------------------------------------------
+  // Token / re-auth errors
+  // ------------------------------------------------------------------
+  if (
+    body.includes("Error validating access token") ||
+    body.includes("REVOKED_ACCESS_TOKEN") ||
+    body.includes("session has been invalidated") ||
+    body.includes("490,")
+  ) {
+    return err("refresh-token", "Please re-authenticate your account.");
+  }
+
+  if (body.includes("the user is not an instagram business")) {
+    return err(
+      "refresh-token",
+      "Your Instagram account is not a business account. Convert it in the Instagram app, then reconnect.",
+    );
+  }
+
+  if (body.includes("Not enough permissions to post") || body.includes("190,")) {
+    return err(
+      "refresh-token",
+      "Missing required permissions. Please re-add the account and allow all requested permissions.",
+    );
+  }
+
+  if (body.includes("1404078")) {
+    return err(
+      "refresh-token",
+      "Page publishing authorization required. Please re-authenticate.",
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Transient / retry errors
+  // ------------------------------------------------------------------
+  if (body.includes("An unknown error occurred")) {
+    return err("retry", "An unknown error occurred. Please try again later.");
+  }
+
+  if (body.includes("1363047") || body.includes("1609010")) {
+    return err("retry", "Facebook service temporarily unavailable. Please try again.");
+  }
+
+  // ------------------------------------------------------------------
+  // Content / bad-body errors — Instagram media
+  // ------------------------------------------------------------------
+  if (body.includes("2207081")) {
+    return err("bad-body", "This account doesn't support Trial Reels.");
+  }
+
+  if (body.includes("2207050")) {
+    return err("bad-body", "Instagram user is restricted.");
+  }
+
+  if (body.includes("2207003")) {
+    return err("bad-body", "Timeout downloading media. Please try again.");
+  }
+
+  if (body.includes("2207020")) {
+    return err("bad-body", "Media expired. Please upload again.");
+  }
+
+  if (body.includes("2207032")) {
+    return err("bad-body", "Failed to create media. Please try again.");
+  }
+
+  if (body.includes("2207053")) {
+    return err("bad-body", "Unknown upload error. Please try again.");
+  }
+
+  if (body.includes("2207052")) {
+    return err("bad-body", "Media fetch failed. Please try again.");
+  }
+
+  if (body.includes("2207057")) {
+    return err("bad-body", "Invalid thumbnail offset for video.");
+  }
+
+  if (body.includes("2207026")) {
+    return err("bad-body", "Unsupported video format.");
+  }
+
+  if (body.includes("2207023")) {
+    return err("bad-body", "Unknown media type.");
+  }
+
+  if (body.includes("2207006")) {
+    return err("bad-body", "Media not found. Please upload again.");
+  }
+
+  if (body.includes("2207008")) {
+    return err("bad-body", "Media builder expired. Please try again.");
+  }
+
+  if (body.includes("2207028")) {
+    return err("bad-body", "Carousel validation failed.");
+  }
+
+  if (body.includes("2207010")) {
+    return err("bad-body", "Caption is too long.");
+  }
+
+  if (body.includes("2207035")) {
+    return err("bad-body", "Product tag positions not supported for videos.");
+  }
+
+  if (body.includes("2207036")) {
+    return err("bad-body", "Product tag positions required for photos.");
+  }
+
+  if (body.includes("2207037")) {
+    return err("bad-body", "Product tag validation failed.");
+  }
+
+  if (body.includes("2207040")) {
+    return err("bad-body", "Too many product tags.");
+  }
+
+  if (body.includes("2207004")) {
+    return err("bad-body", "Image is too large.");
+  }
+
+  if (body.includes("2207005")) {
+    return err("bad-body", "Unsupported image format.");
+  }
+
+  if (body.includes("2207009") || body.includes("36003")) {
+    return err(
+      "bad-body",
+      "Aspect ratio not supported. Must be between 4:5 and 1.91:1.",
+    );
+  }
+
+  if (body.includes("36001")) {
+    return err("bad-body", "Invalid Instagram image resolution. Max: 1920×1080 px.");
+  }
+
+  if (body.includes("2207051")) {
+    return err("bad-body", "Instagram blocked your request.");
+  }
+
+  if (body.includes("2207001")) {
+    return err(
+      "bad-body",
+      "Instagram detected spam. Please try again with different content.",
+    );
+  }
+
+  if (body.includes("2207027") || body.includes("2207042")) {
+    return err(
+      "bad-body",
+      "You have reached the maximum of 25 posts per day for your account.",
+    );
+  }
+
+  if (body.includes("Page request limit reached")) {
+    return err("bad-body", "Page posting limit reached for today. Try again tomorrow.");
+  }
+
+  if (body.includes("param collaborators is not allowed")) {
+    return err("bad-body", "Collaborators are not allowed for carousel posts.");
+  }
+
+  // ------------------------------------------------------------------
+  // Content / bad-body errors — Facebook page
+  // ------------------------------------------------------------------
+  if (body.includes("1366046")) {
+    return err("bad-body", "Photos must be smaller than 4 MB and saved as JPG or PNG.");
+  }
+
+  if (body.includes("1390008")) {
+    return err("bad-body", "You are posting too fast. Please slow down.");
+  }
+
+  if (body.includes("1346003")) {
+    return err("bad-body", "Content flagged as abusive by Facebook.");
+  }
+
+  if (body.includes("1404006")) {
+    return err(
+      "bad-body",
+      "A security check is required by Facebook to proceed.",
+    );
+  }
+
+  if (body.includes("1404102")) {
+    return err("bad-body", "Content violates Facebook Community Standards.");
+  }
+
+  if (body.includes("1404112")) {
+    return err(
+      "bad-body",
+      "Your account has limited access for a few days for security reasons.",
+    );
+  }
+
+  if (body.includes("1609008")) {
+    return err("bad-body", "Cannot post Facebook.com links.");
+  }
+
+  if (body.includes("2061006")) {
+    return err("bad-body", "Invalid URL format in post content.");
+  }
+
+  if (body.includes("1349125")) {
+    return err("bad-body", "Invalid content format.");
+  }
+
+  if (body.includes("Name parameter too long")) {
+    return err("bad-body", "Post content is too long.");
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function err(type: SocialErrorType, message: string): SocialProviderError {
+  return { type, message };
+}
+
+// ---------------------------------------------------------------------------
+// Custom error types
+// ---------------------------------------------------------------------------
+
+export class MetaApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: number,
+    public readonly rawBody?: string,
+  ) {
+    super(message);
+    this.name = "MetaApiError";
+  }
+}
+
+export class MetaPermissionError extends Error {
+  constructor(public readonly missingScopes: string[]) {
+    super(
+      `Missing required Meta permissions: ${missingScopes.join(", ")}. ` +
+        "Please re-authenticate and grant all requested permissions.",
+    );
+    this.name = "MetaPermissionError";
+  }
+}
+
+/**
+ * Generate a random alphanumeric state string for OAuth CSRF protection.
+ */
+export function makeOAuthState(length = 16): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let state = "";
+  for (let i = 0; i < length; i++) {
+    state += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return state;
+}

--- a/src/lib/social/providers/tiktok.ts
+++ b/src/lib/social/providers/tiktok.ts
@@ -1,0 +1,378 @@
+import { randomBytes } from "node:crypto";
+import type {
+  AuthenticateResult,
+  GenerateAuthUrlResult,
+  ProviderCapabilities,
+  PublishRequest,
+  PublishResult,
+  RefreshTokenResult,
+  SocialProviderAdapter,
+  SocialProviderError,
+} from "@/lib/social/provider-interface";
+import { registerProvider } from "@/lib/social/provider-registry";
+
+const TIKTOK_OAUTH_SCOPES = [
+  "video.list",
+  "user.info.basic",
+  "video.publish",
+  "video.upload",
+  "user.info.profile",
+  "user.info.stats",
+];
+
+const TIKTOK_TOKEN_URL = "https://open.tiktokapis.com/v2/oauth/token/";
+const TIKTOK_USER_INFO_URL =
+  "https://open.tiktokapis.com/v2/user/info/?fields=open_id,avatar_url,display_name,union_id,username";
+const TIKTOK_PUBLISH_STATUS_URL =
+  "https://open.tiktokapis.com/v2/post/publish/status/fetch/";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchTikTokUserInfo(accessToken: string): Promise<{
+  openId: string;
+  displayName: string;
+  avatarUrl: string;
+  username: string;
+}> {
+  const response = await fetch(TIKTOK_USER_INFO_URL, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`TikTok user info fetch failed: ${response.status} ${body}`);
+  }
+
+  const {
+    data: {
+      user: { open_id, display_name, avatar_url, username },
+    },
+  } = await response.json();
+
+  return {
+    openId: (open_id as string).replace(/-/g, ""),
+    displayName: display_name as string,
+    avatarUrl: (avatar_url as string) ?? "",
+    username: (username as string) ?? "",
+  };
+}
+
+export async function pollTikTokPublishStatus(
+  username: string,
+  publishId: string,
+  accessToken: string,
+  pollIntervalMs = 10_000,
+): Promise<{ platformPostId: string; platformPostUrl: string }> {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const response = await fetch(TIKTOK_PUBLISH_STATUS_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=UTF-8",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ publish_id: publishId }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(
+        `TikTok publish status poll failed: ${response.status} ${body}`,
+      );
+    }
+
+    const data = await response.json();
+    const { status, publicaly_available_post_id } = data.data ?? {};
+
+    if (status === "SEND_TO_USER_INBOX") {
+      return {
+        platformPostId: "inbox",
+        platformPostUrl: "https://www.tiktok.com/messages?lang=en",
+      };
+    }
+
+    if (status === "PUBLISH_COMPLETE") {
+      const postId = publicaly_available_post_id?.[0] ?? publishId;
+      const postUrl = publicaly_available_post_id?.[0]
+        ? `https://www.tiktok.com/@${username}/video/${publicaly_available_post_id[0]}`
+        : `https://www.tiktok.com/@${username}`;
+      return { platformPostId: postId, platformPostUrl: postUrl };
+    }
+
+    if (status === "FAILED") {
+      const errorCode = data.data?.fail_reason ?? data.error?.code ?? "unknown";
+      throw new Error(
+        `TikTok publish failed: ${errorCode} — ${JSON.stringify(data)}`,
+      );
+    }
+
+    await delay(pollIntervalMs);
+  }
+}
+
+async function initiateVideoPost(
+  videoUrl: string,
+  content: string,
+  accessToken: string,
+): Promise<string> {
+  const response = await fetch(
+    "https://open.tiktokapis.com/v2/post/publish/video/init/",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=UTF-8",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        post_info: {
+          title: content.slice(0, 2200),
+          privacy_level: "PUBLIC_TO_EVERYONE",
+          disable_comment: false,
+          disable_duet: false,
+          disable_stitch: false,
+        },
+        source_info: {
+          source: "PULL_FROM_URL",
+          video_url: videoUrl,
+        },
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`TikTok video publish init failed: ${response.status} ${body}`);
+  }
+
+  const { data } = await response.json();
+  return data.publish_id as string;
+}
+
+async function initiatePhotoPost(
+  imageUrls: string[],
+  content: string,
+  accessToken: string,
+): Promise<string> {
+  const response = await fetch(
+    "https://open.tiktokapis.com/v2/post/publish/content/init/",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=UTF-8",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        post_info: {
+          description: content.slice(0, 2200),
+          privacy_level: "PUBLIC_TO_EVERYONE",
+          disable_comment: false,
+          auto_add_music: false,
+        },
+        source_info: {
+          source: "PULL_FROM_URL",
+          photo_images: imageUrls,
+          photo_cover_index: 0,
+        },
+        post_mode: "DIRECT_POST",
+        media_type: "PHOTO",
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`TikTok photo publish init failed: ${response.status} ${body}`);
+  }
+
+  const { data } = await response.json();
+  return data.publish_id as string;
+}
+
+export const tikTokProvider: SocialProviderAdapter = {
+  identifier: "tiktok",
+  displayName: "TikTok",
+  maxContentLength: 2200,
+  supportsImages: true,
+  supportsVideo: true,
+  supportsCarousel: true,
+  maxImages: 35,
+  maxConcurrentJobs: 5,
+  requiresPageSelection: false,
+
+  async generateAuthUrl(callbackUrl: string): Promise<GenerateAuthUrlResult> {
+    const clientKey = process.env.TIKTOK_CLIENT_KEY;
+    if (!clientKey) {
+      throw new Error("TIKTOK_CLIENT_KEY is not configured");
+    }
+    const state = randomBytes(16).toString("hex");
+    const codeVerifier = randomBytes(32).toString("hex");
+    const params = new URLSearchParams({
+      client_key: clientKey,
+      redirect_uri: callbackUrl,
+      response_type: "code",
+      scope: TIKTOK_OAUTH_SCOPES.join(","),
+      state,
+    });
+    const url = `https://www.tiktok.com/v2/auth/authorize/?${params.toString()}`;
+    return { url, state, codeVerifier };
+  },
+
+  async authenticate(params: {
+    code: string;
+    codeVerifier?: string;
+    state?: string;
+  }): Promise<AuthenticateResult> {
+    const clientKey = process.env.TIKTOK_CLIENT_KEY;
+    const clientSecret = process.env.TIKTOK_CLIENT_SECRET;
+    if (!clientKey || !clientSecret) {
+      throw new Error("TIKTOK_CLIENT_KEY and TIKTOK_CLIENT_SECRET must be configured");
+    }
+    const tokenResponse = await fetch(TIKTOK_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_key: clientKey,
+        client_secret: clientSecret,
+        code: params.code,
+        grant_type: "authorization_code",
+        redirect_uri: params.state ?? "",
+      }),
+    });
+    if (!tokenResponse.ok) {
+      const body = await tokenResponse.text();
+      throw new Error(`TikTok token exchange failed: ${tokenResponse.status} ${body}`);
+    }
+    const { access_token: accessToken, refresh_token: refreshToken } =
+      await tokenResponse.json();
+    const TWENTY_THREE_HOURS_SECONDS = 23 * 60 * 60;
+    const { openId, displayName, avatarUrl, username } =
+      await fetchTikTokUserInfo(accessToken);
+    return {
+      platformUserId: openId,
+      accessToken,
+      refreshToken: refreshToken ?? undefined,
+      expiresIn: TWENTY_THREE_HOURS_SECONDS,
+      displayName: displayName ?? "TikTok User",
+      username: username ?? undefined,
+      avatarUrl: avatarUrl ?? undefined,
+      requiresPageSelection: false,
+    };
+  },
+
+  async refreshToken(refreshToken: string): Promise<RefreshTokenResult> {
+    const clientKey = process.env.TIKTOK_CLIENT_KEY;
+    const clientSecret = process.env.TIKTOK_CLIENT_SECRET;
+    if (!clientKey || !clientSecret) {
+      throw new Error("TIKTOK_CLIENT_KEY and TIKTOK_CLIENT_SECRET must be configured");
+    }
+    const response = await fetch(TIKTOK_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_key: clientKey,
+        client_secret: clientSecret,
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`TikTok token refresh failed: ${response.status} ${body}`);
+    }
+    const { access_token: accessToken, refresh_token: newRefreshToken } =
+      await response.json();
+    const TWENTY_THREE_HOURS_SECONDS = 23 * 60 * 60;
+    return {
+      accessToken,
+      refreshToken: newRefreshToken ?? refreshToken,
+      expiresIn: TWENTY_THREE_HOURS_SECONDS,
+    };
+  },
+
+  async post(
+    platformUserId: string,
+    accessToken: string,
+    requests: PublishRequest[],
+  ): Promise<PublishResult[]> {
+    const results: PublishResult[] = [];
+    for (const request of requests) {
+      const media = request.media ?? [];
+      const hasVideo = media.some((m) => m.type === "video");
+      let publishId: string;
+      if (hasVideo) {
+        const videoItem = media.find((m) => m.type === "video");
+        if (!videoItem) {
+          throw new Error("TikTok video post requires exactly one video item");
+        }
+        publishId = await initiateVideoPost(videoItem.url, request.content, accessToken);
+      } else if (media.length > 0) {
+        const imageUrls = media.map((m) => m.url);
+        publishId = await initiatePhotoPost(imageUrls, request.content, accessToken);
+      } else {
+        throw new Error("TikTok requires at least one media item (video or images)");
+      }
+      let username = platformUserId;
+      try {
+        const info = await fetchTikTokUserInfo(accessToken);
+        username = info.username || platformUserId;
+      } catch {
+        // Non-fatal
+      }
+      const { platformPostId, platformPostUrl } =
+        await pollTikTokPublishStatus(username, publishId, accessToken);
+      results.push({
+        postId: request.postId,
+        platformPostId,
+        platformPostUrl,
+        status: "processing",
+      });
+    }
+    return results;
+  },
+
+  classifyError(error: unknown): SocialProviderError {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("access_token_invalid") || message.includes('"code":"access_token_invalid"')) {
+      return { type: "refresh-token", message: "TikTok access token is invalid — please re-authenticate", original: error };
+    }
+    if (message.includes("scope_not_authorized") || message.includes("scope_permission_missed")) {
+      return { type: "refresh-token", message: "TikTok missing required permissions — please re-authenticate with all scopes", original: error };
+    }
+    if (message.includes("spam_risk_user_banned_from_posting") || message.includes("spam_risk_text") || message.includes("spam_risk_too_many_posts") || message.includes("spam_risk_too_many_pending_share") || message.includes("spam_risk")) {
+      return { type: "bad-body", message: "TikTok spam detection triggered — post cannot be published", original: error };
+    }
+    if (message.includes("file_format_check_failed") || message.includes("duration_check_failed") || message.includes("frame_rate_check_failed") || message.includes("picture_size_check_failed") || message.includes("invalid_file_upload") || message.includes("invalid_params") || message.includes("privacy_level_option_mismatch") || message.includes("url_ownership_unverified")) {
+      return { type: "bad-body", message: `TikTok content validation failed: ${message}`, original: error };
+    }
+    if (message.includes("video_pull_failed") || message.includes("photo_pull_failed")) {
+      return { type: "retry", message: "TikTok failed to pull media from URL — will retry", original: error };
+    }
+    if (message.includes("rate_limit_exceeded")) {
+      return { type: "retry", message: "TikTok API rate limit exceeded — will retry", original: error };
+    }
+    if (message.includes("app_version_check_failed") || message.includes("unaudited_client_can_only_post_to_private_accounts") || message.includes("reached_active_user_cap")) {
+      return { type: "bad-body", message: `TikTok app policy error: ${message}`, original: error };
+    }
+    if (message.includes("internal") || message.includes("TikTok API error")) {
+      return { type: "retry", message: "TikTok server error — will retry", original: error };
+    }
+    return { type: "retry", message, original: error };
+  },
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      identifier: "tiktok",
+      displayName: "TikTok",
+      maxContentLength: 2200,
+      supportsImages: true,
+      supportsVideo: true,
+      supportsCarousel: true,
+      requiresPageSelection: false,
+    };
+  },
+};
+
+registerProvider(tikTokProvider);

--- a/src/lib/social/providers/x.ts
+++ b/src/lib/social/providers/x.ts
@@ -1,0 +1,301 @@
+/**
+ * X (Twitter) provider adapter.
+ *
+ * Uses OAuth 1.0a via the `twitter-api-v2` package.
+ *
+ * Auth flow:
+ *   1. generateAuthUrl — calls TwitterApi.generateAuthLink(), stores
+ *      oauth_token + oauth_token_secret as `codeVerifier` ("token:secret").
+ *   2. authenticate — splits codeVerifier, constructs a TwitterApi client,
+ *      calls client.login(oauthVerifier), returns permanent tokens.
+ *   3. refreshToken — no-op (OAuth 1.0a tokens do not expire).
+ *
+ * Publishing:
+ *   - Images are downloaded from their URL, resized to max 1000px wide via
+ *     sharp, then uploaded via client.v2.uploadMedia().
+ *   - Text is posted with client.v2.tweet().
+ *
+ * Env vars: X_API_KEY, X_API_SECRET
+ */
+
+import sharp from "sharp";
+import { TwitterApi } from "twitter-api-v2";
+import type {
+  AuthenticateResult,
+  GenerateAuthUrlResult,
+  ProviderCapabilities,
+  PublishRequest,
+  PublishResult,
+  RefreshTokenResult,
+  SocialProviderAdapter,
+  SocialProviderError,
+} from "@/lib/social/provider-interface";
+import { registerProvider } from "@/lib/social/provider-registry";
+
+// ---------------------------------------------------------------------------
+// Environment helpers
+// ---------------------------------------------------------------------------
+
+function getApiKey(): string {
+  const key = process.env.X_API_KEY;
+  if (!key) throw new Error("X_API_KEY environment variable is not set.");
+  return key;
+}
+
+function getApiSecret(): string {
+  const secret = process.env.X_API_SECRET;
+  if (!secret) throw new Error("X_API_SECRET environment variable is not set.");
+  return secret;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Download an image from a URL and resize it to at most 1000px wide,
+ * preserving aspect ratio. Returns a Buffer suitable for uploadMedia().
+ */
+async function fetchAndResizeImage(imageUrl: string): Promise<Buffer> {
+  const resp = await fetch(imageUrl);
+  if (!resp.ok) {
+    throw new Error(
+      `X: failed to download image: ${resp.status} ${imageUrl}`,
+    );
+  }
+  const raw = Buffer.from(await resp.arrayBuffer());
+
+  return sharp(raw)
+    .resize({ width: 1000, withoutEnlargement: true })
+    .toBuffer();
+}
+
+/**
+ * Build a TwitterApi client for an access token stored as "token:secret".
+ */
+function buildClient(accessToken: string): TwitterApi {
+  const [tokenPart, secretPart] = accessToken.split(":");
+  return new TwitterApi({
+    appKey: getApiKey(),
+    appSecret: getApiSecret(),
+    accessToken: tokenPart,
+    accessSecret: secretPart,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Provider implementation
+// ---------------------------------------------------------------------------
+
+export const xProvider: SocialProviderAdapter = {
+  identifier: "x",
+  displayName: "X (Twitter)",
+  maxContentLength: 280,
+  supportsImages: true,
+  supportsVideo: false,
+  supportsCarousel: false,
+  maxImages: 4,
+  maxConcurrentJobs: 1,
+  requiresPageSelection: false,
+
+  // -------------------------------------------------------------------------
+  // OAuth
+  // -------------------------------------------------------------------------
+
+  async generateAuthUrl(callbackUrl: string): Promise<GenerateAuthUrlResult> {
+    const client = new TwitterApi({
+      appKey: getApiKey(),
+      appSecret: getApiSecret(),
+    });
+
+    const { url, oauth_token, oauth_token_secret } =
+      await client.generateAuthLink(callbackUrl, {
+        authAccessType: "write",
+        linkMode: "authenticate",
+        forceLogin: false,
+      });
+
+    return {
+      url,
+      state: oauth_token,
+      // Store both halves so authenticate() can reconstruct the pre-login client
+      codeVerifier: `${oauth_token}:${oauth_token_secret}`,
+    };
+  },
+
+  async authenticate(params: {
+    code: string; // oauth_verifier from callback
+    codeVerifier?: string; // "oauth_token:oauth_token_secret"
+    state?: string;
+  }): Promise<AuthenticateResult> {
+    const { code: oauthVerifier, codeVerifier = "" } = params;
+    const [oauthToken, oauthTokenSecret] = codeVerifier.split(":");
+
+    const startingClient = new TwitterApi({
+      appKey: getApiKey(),
+      appSecret: getApiSecret(),
+      accessToken: oauthToken,
+      accessSecret: oauthTokenSecret,
+    });
+
+    const { accessToken, accessSecret, client } =
+      await startingClient.login(oauthVerifier);
+
+    const {
+      data: { id, name, username, profile_image_url },
+    } = await client.v2.me({
+      "user.fields": ["username", "profile_image_url", "name"],
+    });
+
+    return {
+      // Encode as "token:secret" so post() can split it back
+      platformUserId: String(id),
+      accessToken: `${accessToken}:${accessSecret}`,
+      displayName: name,
+      username,
+      avatarUrl: profile_image_url ?? undefined,
+      // OAuth 1.0a tokens are permanent — no expiry
+    };
+  },
+
+  /**
+   * OAuth 1.0a tokens do not expire and there is no refresh endpoint.
+   * Return the same token unchanged.
+   */
+  async refreshToken(_refreshToken: string): Promise<RefreshTokenResult> {
+    return { accessToken: _refreshToken };
+  },
+
+  // -------------------------------------------------------------------------
+  // Publishing
+  // -------------------------------------------------------------------------
+
+  async post(
+    _platformUserId: string,
+    accessToken: string,
+    requests: PublishRequest[],
+    _options?: { accessTokenSecret?: string },
+  ): Promise<PublishResult[]> {
+    const [request] = requests;
+    if (!request) return [];
+
+    const client = buildClient(accessToken);
+
+    const images = (request.media ?? []).filter((m) => m.type === "image");
+
+    // Upload all images, capping at maxImages
+    const mediaIds: string[] = [];
+    for (const img of images.slice(0, 4)) {
+      const buffer = await fetchAndResizeImage(img.url);
+      const mediaId = await client.v2.uploadMedia(buffer, {
+        media_type: "image/jpeg",
+      });
+      mediaIds.push(mediaId);
+    }
+
+    const { data } = (await client.v2.tweet({
+      text: request.content,
+      ...(mediaIds.length ? { media: { media_ids: mediaIds } } : {}),
+    })) as { data: { id: string } };
+
+    // Retrieve username for the post URL
+    const {
+      data: { username },
+    } = await client.v2.me({ "user.fields": ["username"] });
+
+    return [
+      {
+        postId: request.postId,
+        platformPostId: data.id,
+        platformPostUrl: `https://x.com/${username}/status/${data.id}`,
+        status: "published",
+      },
+    ];
+  },
+
+  // -------------------------------------------------------------------------
+  // Error classification
+  // -------------------------------------------------------------------------
+
+  classifyError(error: unknown): SocialProviderError {
+    const body =
+      error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : JSON.stringify(error);
+
+    // Rate limit
+    if (
+      body.includes("429") ||
+      body.includes("Too Many Requests") ||
+      body.includes("Rate limit") ||
+      body.includes("rate-limit-exceeded")
+    ) {
+      return {
+        type: "retry",
+        message: "X rate limit reached. Will retry shortly.",
+        original: error,
+      };
+    }
+
+    // Auth / token issues
+    if (
+      body.includes("401") ||
+      body.includes("Unauthorized") ||
+      body.includes("Unsupported Authentication") ||
+      body.includes("Invalid or expired token")
+    ) {
+      return {
+        type: "refresh-token",
+        message: "X authentication has expired. Please reconnect your account.",
+        original: error,
+      };
+    }
+
+    // Content policy / duplicate violations
+    if (
+      body.includes("duplicate") ||
+      body.includes("usage-capped") ||
+      body.includes("duplicate-rules") ||
+      body.includes("invalid URL") ||
+      body.includes("policy") ||
+      body.includes("forbidden")
+    ) {
+      return {
+        type: "bad-body",
+        message:
+          error instanceof Error
+            ? error.message
+            : "The post was rejected by X.",
+        original: error,
+      };
+    }
+
+    return {
+      type: "retry",
+      message:
+        error instanceof Error ? error.message : "An unexpected X error occurred.",
+      original: error,
+    };
+  },
+
+  // -------------------------------------------------------------------------
+  // Capabilities
+  // -------------------------------------------------------------------------
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      identifier: "x",
+      displayName: "X (Twitter)",
+      maxContentLength: 280,
+      supportsImages: true,
+      supportsVideo: false,
+      supportsCarousel: false,
+      requiresPageSelection: false,
+    };
+  },
+};
+
+// Register at module load time
+registerProvider(xProvider);

--- a/src/lib/social/providers/x.ts
+++ b/src/lib/social/providers/x.ts
@@ -193,10 +193,13 @@ export const xProvider: SocialProviderAdapter = {
       mediaIds.push(mediaId);
     }
 
-    const { data } = (await client.v2.tweet({
-      text: request.content,
-      ...(mediaIds.length ? { media: { media_ids: mediaIds } } : {}),
-    })) as { data: { id: string } };
+    const tweetPayload: Record<string, unknown> = { text: request.content };
+    if (mediaIds.length) {
+      tweetPayload.media = { media_ids: mediaIds };
+    }
+    const { data } = (await client.v2.tweet(
+      tweetPayload as Parameters<typeof client.v2.tweet>[0],
+    )) as { data: { id: string } };
 
     // Retrieve username for the post URL
     const {

--- a/src/lib/social/providers/youtube.ts
+++ b/src/lib/social/providers/youtube.ts
@@ -1,0 +1,286 @@
+import { randomBytes } from "node:crypto";
+import { google } from "googleapis";
+import type {
+  AuthenticateResult,
+  GenerateAuthUrlResult,
+  PageInfo,
+  ProviderCapabilities,
+  PublishRequest,
+  PublishResult,
+  RefreshTokenResult,
+  SocialProviderAdapter,
+  SocialProviderError,
+} from "@/lib/social/provider-interface";
+import { registerProvider } from "@/lib/social/provider-registry";
+
+const YOUTUBE_SCOPES = [
+  "https://www.googleapis.com/auth/userinfo.profile",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/youtube.upload",
+  "https://www.googleapis.com/auth/youtube.readonly",
+];
+
+function buildOAuth2Client(redirectUri?: string) {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be configured",
+    );
+  }
+  return new google.auth.OAuth2({ clientId, clientSecret, redirectUri });
+}
+
+/**
+ * Convert a public URL to a Node.js-compatible ReadableStream by fetching
+ * it and returning the response body. Used for streaming video uploads.
+ */
+async function urlToReadableStream(
+  url: string,
+): Promise<NodeJS.ReadableStream> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `YouTube: failed to fetch video from URL: ${response.status} ${url}`,
+    );
+  }
+  // response.body is a ReadableStream (Web Streams API). The googleapis
+  // upload accepts a Node.js Readable, but in practice passing the Web
+  // ReadableStream works fine in Node 18+ since they share the stream
+  // protocol for piping.
+  return response.body as unknown as NodeJS.ReadableStream;
+}
+
+export const youTubeProvider: SocialProviderAdapter = {
+  identifier: "youtube",
+  displayName: "YouTube",
+  maxContentLength: 5000,
+  supportsImages: false,
+  supportsVideo: true,
+  supportsCarousel: false,
+  maxImages: 0,
+  maxConcurrentJobs: 3,
+  requiresPageSelection: true,
+
+  async generateAuthUrl(callbackUrl: string): Promise<GenerateAuthUrlResult> {
+    const client = buildOAuth2Client(callbackUrl);
+    const state = randomBytes(16).toString("hex");
+    const url = client.generateAuthUrl({
+      access_type: "offline",
+      prompt: "consent",
+      scope: YOUTUBE_SCOPES,
+      state,
+      redirect_uri: callbackUrl,
+    });
+    return { url, state };
+  },
+
+  async authenticate(params: {
+    code: string;
+    codeVerifier?: string;
+    state?: string;
+  }): Promise<AuthenticateResult> {
+    const client = buildOAuth2Client(params.state);
+    const { tokens } = await client.getToken(params.code);
+    client.setCredentials(tokens);
+
+    const oauth2 = google.oauth2({ version: "v2", auth: client });
+    const { data: userInfo } = await oauth2.userinfo.get();
+
+    const expiresIn = tokens.expiry_date
+      ? Math.floor((tokens.expiry_date - Date.now()) / 1000)
+      : 3600;
+
+    return {
+      platformUserId: userInfo.id ?? "",
+      accessToken: tokens.access_token ?? "",
+      refreshToken: tokens.refresh_token ?? undefined,
+      expiresIn: expiresIn > 0 ? expiresIn : 3600,
+      displayName: userInfo.name ?? "YouTube User",
+      avatarUrl: userInfo.picture ?? undefined,
+      requiresPageSelection: true,
+    };
+  },
+
+  async refreshToken(refreshToken: string): Promise<RefreshTokenResult> {
+    const client = buildOAuth2Client();
+    client.setCredentials({ refresh_token: refreshToken });
+    const { credentials } = await client.refreshAccessToken();
+
+    const expiresIn = credentials.expiry_date
+      ? Math.floor((credentials.expiry_date - Date.now()) / 1000)
+      : 3600;
+
+    return {
+      accessToken: credentials.access_token ?? "",
+      refreshToken: credentials.refresh_token ?? refreshToken,
+      expiresIn: expiresIn > 0 ? expiresIn : 3600,
+    };
+  },
+
+  async post(
+    _platformUserId: string,
+    accessToken: string,
+    requests: PublishRequest[],
+  ): Promise<PublishResult[]> {
+    const client = buildOAuth2Client();
+    client.setCredentials({ access_token: accessToken });
+    const yt = google.youtube({ version: "v3", auth: client });
+
+    const results: PublishResult[] = [];
+
+    for (const request of requests) {
+      const media = request.media ?? [];
+      const videoItem = media.find((m) => m.type === "video");
+      if (!videoItem) {
+        throw new Error("YouTube requires exactly one video media item");
+      }
+
+      const settings = request.platformSettings ?? {};
+      const title =
+        (settings.title as string | undefined) ??
+        request.content.slice(0, 100);
+      const privacyStatus =
+        (settings.privacyStatus as string | undefined) ?? "public";
+      const tags = (settings.tags as string[] | undefined) ?? [];
+      const categoryId =
+        (settings.categoryId as string | undefined) ?? "22"; // "People & Blogs"
+
+      const videoStream = await urlToReadableStream(videoItem.url);
+
+      const insertResponse = await yt.videos.insert({
+        part: ["id", "snippet", "status"],
+        requestBody: {
+          snippet: {
+            title,
+            description: request.content,
+            tags,
+            categoryId,
+          },
+          status: {
+            privacyStatus,
+          },
+        },
+        media: {
+          body: videoStream,
+        },
+      });
+
+      const videoId = insertResponse.data.id ?? "";
+      const platformPostUrl = `https://www.youtube.com/watch?v=${videoId}`;
+
+      // Upload thumbnail if provided — best effort, non-fatal
+      const thumbnailUrl = settings.thumbnailUrl as string | undefined;
+      if (thumbnailUrl) {
+        try {
+          const thumbStream = await urlToReadableStream(thumbnailUrl);
+          await yt.thumbnails.set({
+            videoId,
+            media: { body: thumbStream },
+          });
+        } catch {
+          // Non-fatal — YouTube thumbnail upload can fail due to channel
+          // eligibility requirements. The video is already published.
+        }
+      }
+
+      results.push({
+        postId: request.postId,
+        platformPostId: videoId,
+        platformPostUrl,
+        status: "published",
+      });
+    }
+
+    return results;
+  },
+
+  classifyError(error: unknown): SocialProviderError {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (
+      message.includes("Unauthorized") ||
+      message.includes("UNAUTHENTICATED") ||
+      message.includes("invalid_grant") ||
+      message.includes("Token has been expired") ||
+      message.includes("token expired")
+    ) {
+      return {
+        type: "refresh-token",
+        message:
+          "YouTube access token is invalid or expired — please re-authenticate",
+        original: error,
+      };
+    }
+
+    if (
+      message.includes("invalidTitle") ||
+      message.includes("invalidDescription") ||
+      message.includes("invalidTags") ||
+      message.includes("youtubeSignupRequired") ||
+      message.includes("uploadLimitExceeded") ||
+      message.includes("videoDurationTooLong") ||
+      message.includes("videoFileSizeTooLarge") ||
+      message.includes("failedPrecondition") ||
+      message.includes("forbidden") ||
+      message.includes("privacySettingNotSupportedForPartner")
+    ) {
+      return {
+        type: "bad-body",
+        message: `YouTube content validation failed: ${message}`,
+        original: error,
+      };
+    }
+
+    if (
+      message.includes("quotaExceeded") ||
+      message.includes("rateLimitExceeded") ||
+      message.includes("backendError") ||
+      message.includes("internalError") ||
+      message.includes("serviceUnavailable") ||
+      message.includes("transientError")
+    ) {
+      return {
+        type: "retry",
+        message: "YouTube API quota or server error — will retry",
+        original: error,
+      };
+    }
+
+    return { type: "retry", message, original: error };
+  },
+
+  async fetchPageInformation(accessToken: string): Promise<PageInfo[]> {
+    const client = buildOAuth2Client();
+    client.setCredentials({ access_token: accessToken });
+    const yt = google.youtube({ version: "v3", auth: client });
+
+    const response = await yt.channels.list({
+      part: ["snippet"],
+      mine: true,
+    });
+
+    const items = response.data.items ?? [];
+    return items.map((channel) => ({
+      id: channel.id ?? "",
+      name: channel.snippet?.title ?? "YouTube Channel",
+      username: channel.snippet?.customUrl ?? undefined,
+      picture:
+        channel.snippet?.thumbnails?.default?.url ?? undefined,
+    }));
+  },
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      identifier: "youtube",
+      displayName: "YouTube",
+      maxContentLength: 5000,
+      supportsImages: false,
+      supportsVideo: true,
+      supportsCarousel: false,
+      requiresPageSelection: true,
+    };
+  },
+};
+
+registerProvider(youTubeProvider);


### PR DESCRIPTION
## Summary

Complete provider adapter implementations for all 6 target platforms:

| Provider | OAuth | Publishing | Key features |
|----------|-------|-----------|-------------|
| **LinkedIn** | OAuth 2.0 | REST API v202409 | Media upload (init→PUT), org pages, text escaping |
| **X (Twitter)** | OAuth 1.0a | twitter-api-v2 SDK | Permanent tokens, image resize 1000px, binary upload |
| **Instagram** | Meta Graph API | Container-based async | Create→poll→publish, carousel, IG Business selection |
| **Facebook** | Meta Graph API | Page posting | Multi-photo via attached_media, video upload |
| **TikTok** | OAuth 2.0 | Async PULL_FROM_URL | 23h token refresh, JPEG-only, photo carousel |
| **YouTube** | Google OAuth | googleapis stream | Video-only, channel selection, thumbnail upload |

Shared `meta-common.ts` for Meta OAuth token exchange and error classification.
Provider index barrel triggers `registerProvider()` for all 6 on import.

## Test plan

- [x] 170 new provider tests across 6 test files
- [x] 2220 total tests pass (zero errors)
- [x] Production build succeeds
- [x] Gate-A passes (no regression)

Closes #9, #10, #11, #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)