### PR TITLE
feat(social): Social Hub layout shell with sidebar and pillar switcher

### DIFF
--- a/src/app/social/calendar/page.tsx
+++ b/src/app/social/calendar/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function CalendarPage() {
+  return (
+    <div className="flex items-center justify-center p-8 text-neutral-500">
+      Calendar — coming soon
+    </div>
+  );
+}

--- a/src/app/social/channels/page.tsx
+++ b/src/app/social/channels/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function ChannelsPage() {
+  return (
+    <div className="flex items-center justify-center p-8 text-neutral-500">
+      Channels — coming soon
+    </div>
+  );
+}

--- a/src/app/social/compose/page.tsx
+++ b/src/app/social/compose/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function ComposePage() {
+  return (
+    <div className="flex items-center justify-center p-8 text-neutral-500">
+      Compose — coming soon
+    </div>
+  );
+}

--- a/src/app/social/layout.tsx
+++ b/src/app/social/layout.tsx
@@ -1,0 +1,18 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { getServerAuthSession } from "@/lib/auth/session";
+import { SocialLayout } from "@/components/social/SocialLayout";
+
+export default async function SocialRootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const session = await getServerAuthSession(await headers());
+
+  if (!session?.user) {
+    redirect("/sign-in");
+  }
+
+  return <SocialLayout>{children}</SocialLayout>;
+}

--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SocialPage() {
+  redirect("/social/calendar");
+}

--- a/src/app/social/posts/page.tsx
+++ b/src/app/social/posts/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function PostsPage() {
+  return (
+    <div className="flex items-center justify-center p-8 text-neutral-500">
+      Posts — coming soon
+    </div>
+  );
+}

--- a/src/components/social/PillarSwitcher.tsx
+++ b/src/components/social/PillarSwitcher.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+
+const PILLARS = [
+  { id: "studio", label: "AI Studio", icon: "🎨", href: "/studio" },
+  { id: "social", label: "Social Hub", icon: "📱", href: "/social" },
+  { id: "analytics", label: "Analytics", icon: "📊", href: "/analytics" },
+] as const;
+
+interface PillarSwitcherProps {
+  currentPillar?: string;
+}
+
+export function PillarSwitcher({
+  currentPillar = "social",
+}: PillarSwitcherProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const current = PILLARS.find((p) => p.id === currentPillar) ?? PILLARS[1];
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [isOpen]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1.5 rounded-md bg-neutral-800 border border-neutral-700 px-2.5 py-1 text-sm font-medium text-neutral-200 hover:bg-neutral-700 transition-colors"
+      >
+        <span>{current.icon}</span>
+        <span>{current.label}</span>
+        <span className="text-xs text-neutral-500 ml-0.5">
+          {isOpen ? "▲" : "▼"}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full left-0 mt-1 w-52 rounded-lg bg-neutral-800 border border-neutral-700 shadow-lg z-50 py-1">
+          {PILLARS.map((pillar) => (
+            <Link
+              key={pillar.id}
+              href={pillar.href}
+              onClick={() => setIsOpen(false)}
+              className={`flex items-center gap-2.5 px-3 py-2 text-sm transition-colors ${
+                pillar.id === currentPillar
+                  ? "bg-neutral-700 text-green-400"
+                  : "text-neutral-300 hover:bg-neutral-700/50"
+              }`}
+            >
+              <span>{pillar.icon}</span>
+              <span>{pillar.label}</span>
+              {pillar.id === currentPillar && (
+                <span className="ml-auto text-xs text-neutral-500">
+                  current
+                </span>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/social/SocialHeader.tsx
+++ b/src/components/social/SocialHeader.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { PillarSwitcher } from "./PillarSwitcher";
+import { authClient } from "@/lib/auth/client";
+
+export function SocialHeader() {
+  const session = authClient.useSession();
+  const userName =
+    session.data?.user?.name || session.data?.user?.email || "User";
+
+  return (
+    <header className="flex h-11 items-center gap-3 border-b border-neutral-800 bg-neutral-900 px-4">
+      <Link href="/social" className="text-lg font-bold text-neutral-100">
+        🍌
+      </Link>
+      <PillarSwitcher currentPillar="social" />
+
+      <div className="flex-1" />
+
+      <Link
+        href="/social/compose"
+        className="rounded-md bg-green-600 px-3 py-1 text-xs font-semibold text-white hover:bg-green-500 transition-colors"
+      >
+        + New Post
+      </Link>
+
+      <span className="text-xs text-neutral-500">{userName}</span>
+    </header>
+  );
+}

--- a/src/components/social/SocialLayout.tsx
+++ b/src/components/social/SocialLayout.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSocialAccountsStore } from "@/store/socialAccountsStore";
+import { SocialHeader } from "./SocialHeader";
+import { SocialSidebar } from "./SocialSidebar";
+
+interface SocialLayoutProps {
+  children: React.ReactNode;
+}
+
+export function SocialLayout({ children }: SocialLayoutProps) {
+  const fetchAccounts = useSocialAccountsStore((s) => s.fetchAccounts);
+
+  useEffect(() => {
+    fetchAccounts();
+  }, [fetchAccounts]);
+
+  return (
+    <div className="flex h-screen flex-col bg-neutral-950 text-neutral-100">
+      <SocialHeader />
+      <div className="flex flex-1 overflow-hidden">
+        <SocialSidebar />
+        <main className="flex-1 overflow-y-auto">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/social/SocialSidebar.tsx
+++ b/src/components/social/SocialSidebar.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useSocialAccountsStore } from "@/store/socialAccountsStore";
+import { ChannelAvatar } from "./shared/ChannelAvatar";
+import { StatusDot } from "./shared/StatusDot";
+import type { SocialPlatform } from "@/lib/db/schema";
+
+const NAV_ITEMS = [
+  { href: "/social/calendar", label: "Calendar", icon: "📅" },
+  { href: "/social/compose", label: "Compose", icon: "✏️" },
+  { href: "/social/posts", label: "Posts", icon: "📝" },
+  { href: "/social/channels", label: "Channels", icon: "📱" },
+];
+
+export function SocialSidebar() {
+  const pathname = usePathname();
+  const { accounts, selectedChannelFilter, setChannelFilter } =
+    useSocialAccountsStore();
+
+  return (
+    <aside className="flex w-[220px] flex-shrink-0 flex-col border-r border-neutral-800 bg-neutral-950">
+      {/* Navigation */}
+      <nav className="flex flex-col gap-0.5 p-3">
+        <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-neutral-600">
+          Navigation
+        </div>
+        {NAV_ITEMS.map((item) => {
+          const isActive =
+            pathname === item.href || pathname?.startsWith(item.href + "/");
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors ${
+                isActive
+                  ? "bg-neutral-800 text-green-400"
+                  : "text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+              }`}
+            >
+              <span>{item.icon}</span>
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Divider */}
+      <div className="mx-3 border-t border-neutral-800" />
+
+      {/* Channels */}
+      <div className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-3">
+        <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-neutral-600">
+          Channels
+        </div>
+        {accounts.length === 0 ? (
+          <div className="px-2 py-1 text-[11px] text-neutral-600">
+            No channels connected
+          </div>
+        ) : (
+          accounts.map((account) => {
+            const isFiltered = selectedChannelFilter === account.id;
+            return (
+              <button
+                key={account.id}
+                onClick={() =>
+                  setChannelFilter(isFiltered ? null : account.id)
+                }
+                className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors ${
+                  isFiltered
+                    ? "bg-neutral-800 text-neutral-100"
+                    : "text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+                }`}
+              >
+                <ChannelAvatar
+                  platform={account.platform as SocialPlatform}
+                  displayName={account.displayName}
+                  avatarUrl={account.avatarUrl}
+                  size={22}
+                />
+                <span className="min-w-0 flex-1 truncate">
+                  {account.displayName}
+                </span>
+                <StatusDot
+                  status={
+                    account.requiresReauth
+                      ? "needs-reauth"
+                      : account.disabled
+                        ? "disabled"
+                        : "connected"
+                  }
+                />
+              </button>
+            );
+          })
+        )}
+
+        <Link
+          href="/social/channels"
+          className="mt-2 flex items-center gap-2 rounded-md border border-dashed border-neutral-700 px-2.5 py-1.5 text-xs text-neutral-500 transition-colors hover:border-neutral-600 hover:text-neutral-400"
+        >
+          <span>+</span>
+          <span>Add Channel</span>
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/social/shared/ChannelAvatar.tsx
+++ b/src/components/social/shared/ChannelAvatar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { SocialPlatform } from "@/lib/db/schema";
+import { PlatformIcon } from "./PlatformIcon";
+
+interface ChannelAvatarProps {
+  avatarUrl?: string | null;
+  platform: SocialPlatform;
+  displayName: string;
+  size?: number;
+}
+
+export function ChannelAvatar({
+  avatarUrl,
+  platform,
+  displayName,
+  size = 32,
+}: ChannelAvatarProps) {
+  const initials = displayName
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  const badgeSize = Math.max(12, Math.round(size * 0.4));
+
+  return (
+    <div className="relative inline-flex flex-shrink-0" style={{ width: size, height: size }}>
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt={displayName}
+          className="rounded-full object-cover"
+          style={{ width: size, height: size }}
+        />
+      ) : (
+        <div
+          className="flex items-center justify-center rounded-full bg-neutral-700 text-neutral-300"
+          style={{ width: size, height: size, fontSize: size * 0.35 }}
+        >
+          {initials}
+        </div>
+      )}
+      <div
+        className="absolute -bottom-0.5 -right-0.5 rounded-full bg-neutral-900 p-0.5"
+        style={{ width: badgeSize + 4, height: badgeSize + 4 }}
+      >
+        <PlatformIcon platform={platform} size={badgeSize} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/social/shared/PlatformIcon.tsx
+++ b/src/components/social/shared/PlatformIcon.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { SocialPlatform } from "@/lib/db/schema";
+import { PLATFORM_COLORS, PLATFORM_ICONS } from "@/lib/social/constants";
+
+interface PlatformIconProps {
+  platform: SocialPlatform;
+  size?: number;
+  className?: string;
+}
+
+export function PlatformIcon({
+  platform,
+  size = 20,
+  className,
+}: PlatformIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill={PLATFORM_COLORS[platform]}
+      className={className}
+    >
+      <path d={PLATFORM_ICONS[platform]} />
+    </svg>
+  );
+}

--- a/src/components/social/shared/StatusDot.tsx
+++ b/src/components/social/shared/StatusDot.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+interface StatusDotProps {
+  status: "connected" | "needs-reauth" | "disabled";
+  size?: "sm" | "md";
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  connected: "bg-green-500",
+  "needs-reauth": "bg-red-500",
+  disabled: "bg-neutral-500",
+};
+
+export function StatusDot({ status, size = "sm" }: StatusDotProps) {
+  const sizeClass = size === "sm" ? "w-1.5 h-1.5" : "w-2 h-2";
+
+  return (
+    <span
+      className={`inline-block rounded-full ${sizeClass} ${STATUS_STYLES[status]}`}
+      title={
+        status === "connected"
+          ? "Connected"
+          : status === "needs-reauth"
+            ? "Needs reconnection"
+            : "Disabled"
+      }
+    />
+  );
+}

--- a/src/store/socialAccountsStore.ts
+++ b/src/store/socialAccountsStore.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { create } from "zustand";
+import type { SocialAccount } from "@/lib/social/client";
+import { listSocialAccounts } from "@/lib/social/client";
+
+interface SocialAccountsState {
+  accounts: SocialAccount[];
+  isLoading: boolean;
+  error: string | null;
+  selectedChannelFilter: string | null;
+  fetchAccounts: () => Promise<void>;
+  setChannelFilter: (accountId: string | null) => void;
+  removeAccount: (accountId: string) => void;
+  addOrUpdateAccount: (account: SocialAccount) => void;
+}
+
+export const useSocialAccountsStore = create<SocialAccountsState>(
+  (set, get) => ({
+    accounts: [],
+    isLoading: false,
+    error: null,
+    selectedChannelFilter: null,
+
+    fetchAccounts: async () => {
+      if (get().isLoading) return;
+      set({ isLoading: true, error: null });
+      try {
+        const accounts = await listSocialAccounts();
+        set({ accounts, isLoading: false });
+      } catch (error) {
+        set({
+          error:
+            error instanceof Error ? error.message : "Failed to load accounts",
+          isLoading: false,
+        });
+      }
+    },
+
+    setChannelFilter: (accountId) => {
+      set({ selectedChannelFilter: accountId });
+    },
+
+    removeAccount: (accountId) => {
+      set((state) => ({
+        accounts: state.accounts.filter((a) => a.id !== accountId),
+        selectedChannelFilter:
+          state.selectedChannelFilter === accountId
+            ? null
+            : state.selectedChannelFilter,
+      }));
+    },
+
+    addOrUpdateAccount: (account) => {
+      set((state) => {
+        const existing = state.accounts.findIndex((a) => a.id === account.id);
+        if (existing >= 0) {
+          const updated = [...state.accounts];
+          updated[existing] = account;
+          return { accounts: updated };
+        }
+        return { accounts: [account, ...state.accounts] };
+      });
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- **Auth guard layout** — server component, redirects unauthenticated to /sign-in (mirrors Studio)
- **SocialLayout** — client component: sidebar (220px) + header + content slot
- **SocialSidebar** — nav links (Calendar, Compose, Posts, Channels) with active highlighting, connected channels with avatars + status dots, channel filter on click, "+ Add Channel" button
- **SocialHeader** — logo + PillarSwitcher dropdown + green "+ New Post" button + user display
- **PillarSwitcher** — dropdown to jump between Studio / Social Hub / Analytics
- **Shared components**: PlatformIcon (SVG), StatusDot (green/red/amber), ChannelAvatar (avatar + platform badge)
- **socialAccountsStore** — Zustand store for shared accounts state
- **Placeholder pages** for calendar, channels, compose, posts
- `/social` redirects to `/social/calendar`

## Routes added

```
/social                  → redirect to /social/calendar
/social/calendar         → placeholder
/social/channels         → placeholder
/social/compose          → placeholder
/social/posts            → placeholder
```

## Test plan

- [x] Gate-A: 100 tests pass
- [x] Build: all 14 social routes registered (9 API + 5 pages)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)