### PR TITLE
feat(social): Media Pool and live platform preview panel

### DIFF
--- a/src/components/social/compose/ComposeView.tsx
+++ b/src/components/social/compose/ComposeView.tsx
@@ -10,9 +10,10 @@ import {
   Loader2Icon,
 } from "lucide-react"
 import { useSocialComposerStore } from "@/store/socialComposerStore"
-import { useSocialAccountsStore } from "@/store/socialAccountsStore"
 import { PlatformSelector } from "./PlatformSelector"
 import { PostEditor } from "./PostEditor"
+import { PreviewPanel } from "./PreviewPanel"
+import { MediaPool } from "./MediaPool"
 import { SchedulePicker } from "./SchedulePicker"
 import { MediaAttachments } from "./MediaAttachments"
 import {
@@ -31,6 +32,7 @@ export function ComposeView() {
   const [isSubmitting, setIsSubmitting] = useState<
     "draft" | "schedule" | "publish" | null
   >(null)
+  const [mediaPoolOpen, setMediaPoolOpen] = useState(false)
 
   const {
     content,
@@ -41,8 +43,6 @@ export function ComposeView() {
     isDirty,
     reset,
   } = useSocialComposerStore()
-
-  const accounts = useSocialAccountsStore((s) => s.accounts)
 
   const hasContent = content.trim().length > 0 || mediaUrls.length > 0
   const hasChannels = selectedAccountIds.length > 0
@@ -162,76 +162,14 @@ export function ComposeView() {
         <div className="flex flex-1 flex-col gap-5 overflow-y-auto p-6">
           <PlatformSelector />
           <PostEditor />
-          <MediaAttachments />
+          <MediaAttachments onOpenMediaPool={() => setMediaPoolOpen(true)} />
+          <MediaPool open={mediaPoolOpen} onOpenChange={setMediaPoolOpen} />
           <SchedulePicker />
         </div>
 
-        {/* Right: preview placeholder (Issue #24) */}
-        <div className="hidden w-[340px] flex-col border-l bg-muted/30 lg:flex">
-          <div className="p-4">
-            <h3 className="text-xs font-medium text-muted-foreground">
-              Live Preview
-            </h3>
-          </div>
-          <div className="flex flex-1 items-center justify-center p-4">
-            {selectedAccountIds.length === 0 ? (
-              <p className="text-center text-xs text-muted-foreground">
-                Select a channel to see preview
-              </p>
-            ) : content.trim().length === 0 ? (
-              <p className="text-center text-xs text-muted-foreground">
-                Start typing to see preview
-              </p>
-            ) : (
-              <div className="w-full space-y-3">
-                {selectedAccountIds.map((id) => {
-                  const account = accounts.find((a) => a.id === id)
-                  if (!account) return null
-                  return (
-                    <div
-                      key={id}
-                      className="rounded-lg border bg-card p-3"
-                    >
-                      <div className="mb-2 flex items-center gap-2">
-                        <div className="size-8 rounded-full bg-muted" />
-                        <div>
-                          <p className="text-xs font-medium">
-                            {account.displayName}
-                          </p>
-                          <p className="text-[10px] text-muted-foreground">
-                            {account.platform} · Just now
-                          </p>
-                        </div>
-                      </div>
-                      <p className="text-xs leading-relaxed">
-                        {content.length > 200
-                          ? content.slice(0, 200) + "..."
-                          : content}
-                      </p>
-                      {mediaUrls.length > 0 && (
-                        <div className="mt-2 grid grid-cols-2 gap-1">
-                          {mediaUrls.slice(0, 4).map((m, i) => (
-                            <div
-                              key={i}
-                              className="aspect-square rounded bg-muted"
-                            >
-                              {m.type === "image" && (
-                                <img
-                                  src={m.url}
-                                  alt=""
-                                  className="size-full rounded object-cover"
-                                />
-                              )}
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-          </div>
+        {/* Right: live preview panel */}
+        <div className="hidden w-[340px] border-l bg-muted/30 lg:flex lg:flex-col">
+          <PreviewPanel />
         </div>
       </div>
 

--- a/src/components/social/compose/MediaPool.tsx
+++ b/src/components/social/compose/MediaPool.tsx
@@ -1,0 +1,227 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { ImageIcon, VideoIcon, Loader2Icon, CheckIcon } from "lucide-react"
+import { useSocialComposerStore, type ComposerMediaItem } from "@/store/socialComposerStore"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { getActiveWorkspaceId } from "@/lib/studio/client"
+
+interface AssetItem {
+  id: string
+  type: string
+  storageKey: string
+  mimeType?: string
+  sizeBytes?: number
+  metadata?: Record<string, unknown>
+}
+
+type FilterTab = "all" | "image" | "video"
+
+// Module-level cache
+let assetCache: AssetItem[] | null = null
+
+async function fetchAssets(): Promise<AssetItem[]> {
+  if (assetCache) return assetCache
+
+  const workspaceId = getActiveWorkspaceId()
+  if (!workspaceId) return []
+
+  const res = await fetch("/api/studio/assets", {
+    headers: { "x-workspace-id": workspaceId },
+  })
+  const data = await res.json()
+  if (data.success && Array.isArray(data.assets)) {
+    assetCache = data.assets
+    return data.assets
+  }
+  return []
+}
+
+interface MediaPoolProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function MediaPool({ open, onOpenChange }: MediaPoolProps) {
+  const [assets, setAssets] = useState<AssetItem[]>(assetCache ?? [])
+  const [isLoading, setIsLoading] = useState(false)
+  const [filter, setFilter] = useState<FilterTab>("all")
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const addMedia = useSocialComposerStore((s) => s.addMedia)
+  const initialized = useRef(false)
+
+  // Fetch on open — no useEffect
+  if (open && !initialized.current) {
+    initialized.current = true
+    if (!assetCache) {
+      setIsLoading(true)
+      fetchAssets()
+        .then((data) => {
+          setAssets(data)
+          setIsLoading(false)
+        })
+        .catch(() => setIsLoading(false))
+    }
+  }
+
+  // Reset selection when closed
+  if (!open && initialized.current) {
+    initialized.current = false
+  }
+
+  const filtered = assets.filter((a) => {
+    if (filter === "all") return true
+    return a.type === filter
+  })
+
+  function toggleSelect(assetId: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(assetId)) {
+        next.delete(assetId)
+      } else {
+        next.add(assetId)
+      }
+      return next
+    })
+  }
+
+  function handleInsert() {
+    const items: ComposerMediaItem[] = assets
+      .filter((a) => selected.has(a.id))
+      .map((a) => ({
+        type: (a.type === "video" ? "video" : "image") as "image" | "video",
+        url: a.storageKey,
+        mimeType: a.mimeType,
+      }))
+
+    addMedia(items)
+    setSelected(new Set())
+    onOpenChange(false)
+  }
+
+  const TABS: { value: FilterTab; label: string }[] = [
+    { value: "all", label: "All" },
+    { value: "image", label: "Images" },
+    { value: "video", label: "Videos" },
+  ]
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Media Pool</DialogTitle>
+          <DialogDescription>
+            Select assets from your workspace library
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Filter tabs */}
+        <div className="flex gap-1 border-b pb-2">
+          {TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setFilter(tab.value)}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                filter === tab.value
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-accent"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Asset grid */}
+        <div className="max-h-64 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              {assets.length === 0
+                ? "No media assets in your workspace yet"
+                : "No matching assets"}
+            </div>
+          ) : (
+            <div className="grid grid-cols-4 gap-2">
+              {filtered.map((asset) => {
+                const isSelected = selected.has(asset.id)
+                return (
+                  <button
+                    key={asset.id}
+                    onClick={() => toggleSelect(asset.id)}
+                    className={`group relative aspect-square overflow-hidden rounded-lg border transition-all ${
+                      isSelected
+                        ? "border-primary ring-2 ring-primary/30"
+                        : "border-border hover:border-muted-foreground"
+                    }`}
+                  >
+                    {asset.type === "image" && asset.storageKey ? (
+                      <img
+                        src={asset.storageKey}
+                        alt=""
+                        className="size-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex size-full items-center justify-center bg-muted">
+                        {asset.type === "video" ? (
+                          <VideoIcon className="size-6 text-muted-foreground" />
+                        ) : (
+                          <ImageIcon className="size-6 text-muted-foreground" />
+                        )}
+                      </div>
+                    )}
+
+                    {/* Selection checkmark */}
+                    {isSelected && (
+                      <div className="absolute inset-0 flex items-center justify-center bg-primary/20">
+                        <div className="flex size-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                          <CheckIcon className="size-4" />
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Type badge */}
+                    <Badge
+                      variant="secondary"
+                      className="absolute bottom-1 right-1 px-1 py-0 text-[8px]"
+                    >
+                      {asset.type}
+                    </Badge>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <div className="flex w-full items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              {selected.size} selected
+            </span>
+            <Button
+              size="sm"
+              onClick={handleInsert}
+              disabled={selected.size === 0}
+            >
+              Insert Selected
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/social/compose/MediaPool.tsx
+++ b/src/components/social/compose/MediaPool.tsx
@@ -1,7 +1,13 @@
 "use client"
 
 import { useRef, useState } from "react"
-import { ImageIcon, VideoIcon, Loader2Icon, CheckIcon } from "lucide-react"
+import {
+  ImageIcon,
+  VideoIcon,
+  Loader2Icon,
+  CheckIcon,
+  UploadCloudIcon,
+} from "lucide-react"
 import { useSocialComposerStore, type ComposerMediaItem } from "@/store/socialComposerStore"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -13,7 +19,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { getActiveWorkspaceId } from "@/lib/studio/client"
+import {
+  getActiveWorkspaceId,
+  createStudioAssetPresign,
+  finalizeStudioAssetUpload,
+} from "@/lib/studio/client"
+import { useToast } from "@/components/Toast"
 
 interface AssetItem {
   id: string
@@ -24,6 +35,7 @@ interface AssetItem {
   metadata?: Record<string, unknown>
 }
 
+type PoolTab = "library" | "upload"
 type FilterTab = "all" | "image" | "video"
 
 // Module-level cache
@@ -46,6 +58,21 @@ async function fetchAssets(): Promise<AssetItem[]> {
   return []
 }
 
+function invalidateAssetCache() {
+  assetCache = null
+}
+
+function getAssetType(mimeType: string): "image" | "video" | "audio" {
+  if (mimeType.startsWith("video/")) return "video"
+  if (mimeType.startsWith("audio/")) return "audio"
+  return "image"
+}
+
+function getFileExtension(file: File): string {
+  const parts = file.name.split(".")
+  return parts.length > 1 ? parts[parts.length - 1].toLowerCase() : "bin"
+}
+
 interface MediaPoolProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -54,10 +81,15 @@ interface MediaPoolProps {
 export function MediaPool({ open, onOpenChange }: MediaPoolProps) {
   const [assets, setAssets] = useState<AssetItem[]>(assetCache ?? [])
   const [isLoading, setIsLoading] = useState(false)
+  const [activeTab, setActiveTab] = useState<PoolTab>("library")
   const [filter, setFilter] = useState<FilterTab>("all")
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [isUploading, setIsUploading] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState<string | null>(null)
   const addMedia = useSocialComposerStore((s) => s.addMedia)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const initialized = useRef(false)
+  const { show: showToast } = useToast()
 
   // Fetch on open — no useEffect
   if (open && !initialized.current) {
@@ -73,7 +105,7 @@ export function MediaPool({ open, onOpenChange }: MediaPoolProps) {
     }
   }
 
-  // Reset selection when closed
+  // Reset when closed
   if (!open && initialized.current) {
     initialized.current = false
   }
@@ -95,7 +127,7 @@ export function MediaPool({ open, onOpenChange }: MediaPoolProps) {
     })
   }
 
-  function handleInsert() {
+  function handleInsertSelected() {
     const items: ComposerMediaItem[] = assets
       .filter((a) => selected.has(a.id))
       .map((a) => ({
@@ -109,7 +141,79 @@ export function MediaPool({ open, onOpenChange }: MediaPoolProps) {
     onOpenChange(false)
   }
 
-  const TABS: { value: FilterTab; label: string }[] = [
+  async function handleFileUpload(files: FileList | null) {
+    if (!files || files.length === 0) return
+
+    setIsUploading(true)
+    const uploaded: ComposerMediaItem[] = []
+
+    try {
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i]
+        setUploadProgress(`Uploading ${i + 1} of ${files.length}...`)
+
+        const assetType = getAssetType(file.type)
+        const ext = getFileExtension(file)
+
+        // 1. Get presigned URL
+        const presign = await createStudioAssetPresign({
+          assetType,
+          contentType: file.type,
+          expectedSizeBytes: file.size,
+          fileName: file.name,
+        })
+
+        // 2. Upload to S3/R2 via presigned PUT
+        const uploadRes = await fetch(presign.uploadUrl, {
+          method: "PUT",
+          headers: { "Content-Type": file.type },
+          body: file,
+        })
+
+        if (!uploadRes.ok) {
+          throw new Error(`Upload failed for ${file.name}`)
+        }
+
+        // 3. Finalize
+        await finalizeStudioAssetUpload(presign.assetId, {
+          uploadState: "ready",
+          sizeBytes: file.size,
+          mimeType: file.type,
+        })
+
+        uploaded.push({
+          type: assetType === "video" ? "video" : "image",
+          url: presign.downloadUrl,
+          mimeType: file.type,
+        })
+      }
+
+      // Add uploaded media to composer
+      addMedia(uploaded)
+
+      // Invalidate cache so library tab refreshes
+      invalidateAssetCache()
+
+      showToast(
+        `${uploaded.length} file${uploaded.length > 1 ? "s" : ""} uploaded`,
+        "success",
+      )
+      onOpenChange(false)
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : "Upload failed",
+        "error",
+      )
+    } finally {
+      setIsUploading(false)
+      setUploadProgress(null)
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ""
+      }
+    }
+  }
+
+  const FILTER_TABS: { value: FilterTab; label: string }[] = [
     { value: "all", label: "All" },
     { value: "image", label: "Images" },
     { value: "video", label: "Videos" },
@@ -121,106 +225,182 @@ export function MediaPool({ open, onOpenChange }: MediaPoolProps) {
         <DialogHeader>
           <DialogTitle>Media Pool</DialogTitle>
           <DialogDescription>
-            Select assets from your workspace library
+            Browse your library or upload from your device
           </DialogDescription>
         </DialogHeader>
 
-        {/* Filter tabs */}
+        {/* Pool tabs: Library / Upload */}
         <div className="flex gap-1 border-b pb-2">
-          {TABS.map((tab) => (
-            <button
-              key={tab.value}
-              onClick={() => setFilter(tab.value)}
-              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-                filter === tab.value
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:bg-accent"
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+          <button
+            onClick={() => setActiveTab("library")}
+            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              activeTab === "library"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-accent"
+            }`}
+          >
+            <ImageIcon className="size-3.5" />
+            Library
+          </button>
+          <button
+            onClick={() => setActiveTab("upload")}
+            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              activeTab === "upload"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-accent"
+            }`}
+          >
+            <UploadCloudIcon className="size-3.5" />
+            Upload
+          </button>
         </div>
 
-        {/* Asset grid */}
-        <div className="max-h-64 overflow-y-auto">
-          {isLoading ? (
-            <div className="flex items-center justify-center py-12">
-              <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
-            </div>
-          ) : filtered.length === 0 ? (
-            <div className="py-12 text-center text-sm text-muted-foreground">
-              {assets.length === 0
-                ? "No media assets in your workspace yet"
-                : "No matching assets"}
-            </div>
-          ) : (
-            <div className="grid grid-cols-4 gap-2">
-              {filtered.map((asset) => {
-                const isSelected = selected.has(asset.id)
-                return (
-                  <button
-                    key={asset.id}
-                    onClick={() => toggleSelect(asset.id)}
-                    className={`group relative aspect-square overflow-hidden rounded-lg border transition-all ${
-                      isSelected
-                        ? "border-primary ring-2 ring-primary/30"
-                        : "border-border hover:border-muted-foreground"
-                    }`}
-                  >
-                    {asset.type === "image" && asset.storageKey ? (
-                      <img
-                        src={asset.storageKey}
-                        alt=""
-                        className="size-full object-cover"
-                      />
-                    ) : (
-                      <div className="flex size-full items-center justify-center bg-muted">
-                        {asset.type === "video" ? (
-                          <VideoIcon className="size-6 text-muted-foreground" />
-                        ) : (
-                          <ImageIcon className="size-6 text-muted-foreground" />
-                        )}
-                      </div>
-                    )}
+        {activeTab === "upload" ? (
+          /* ─── Upload tab ─── */
+          <div className="py-4">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*,video/*"
+              multiple
+              onChange={(e) => handleFileUpload(e.target.files)}
+              className="hidden"
+            />
 
-                    {/* Selection checkmark */}
-                    {isSelected && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-primary/20">
-                        <div className="flex size-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                          <CheckIcon className="size-4" />
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Type badge */}
-                    <Badge
-                      variant="secondary"
-                      className="absolute bottom-1 right-1 px-1 py-0 text-[8px]"
-                    >
-                      {asset.type}
-                    </Badge>
-                  </button>
-                )
-              })}
-            </div>
-          )}
-        </div>
-
-        <DialogFooter>
-          <div className="flex w-full items-center justify-between">
-            <span className="text-xs text-muted-foreground">
-              {selected.size} selected
-            </span>
-            <Button
-              size="sm"
-              onClick={handleInsert}
-              disabled={selected.size === 0}
-            >
-              Insert Selected
-            </Button>
+            {isUploading ? (
+              <div className="flex flex-col items-center gap-3 py-8">
+                <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">{uploadProgress}</p>
+              </div>
+            ) : (
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="flex w-full flex-col items-center gap-3 rounded-lg border-2 border-dashed border-border py-10 transition-colors hover:border-muted-foreground hover:bg-accent/50"
+              >
+                <UploadCloudIcon className="size-8 text-muted-foreground" />
+                <div className="text-center">
+                  <p className="text-sm font-medium">
+                    Click to upload files
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Images and videos supported
+                  </p>
+                </div>
+              </button>
+            )}
           </div>
-        </DialogFooter>
+        ) : (
+          /* ─── Library tab ─── */
+          <>
+            {/* Filter tabs */}
+            <div className="flex gap-1">
+              {FILTER_TABS.map((tab) => (
+                <button
+                  key={tab.value}
+                  onClick={() => setFilter(tab.value)}
+                  className={`rounded-md px-2.5 py-1 text-[10px] font-medium transition-colors ${
+                    filter === tab.value
+                      ? "bg-secondary text-secondary-foreground"
+                      : "text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Asset grid */}
+            <div className="max-h-64 overflow-y-auto">
+              {isLoading ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : filtered.length === 0 ? (
+                <div className="py-12 text-center">
+                  <p className="text-sm text-muted-foreground">
+                    {assets.length === 0
+                      ? "No media assets yet"
+                      : "No matching assets"}
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="mt-3"
+                    onClick={() => setActiveTab("upload")}
+                  >
+                    <UploadCloudIcon className="size-3.5" />
+                    Upload files
+                  </Button>
+                </div>
+              ) : (
+                <div className="grid grid-cols-4 gap-2">
+                  {filtered.map((asset) => {
+                    const isSelected = selected.has(asset.id)
+                    return (
+                      <button
+                        key={asset.id}
+                        onClick={() => toggleSelect(asset.id)}
+                        className={`group relative aspect-square overflow-hidden rounded-lg border transition-all ${
+                          isSelected
+                            ? "border-primary ring-2 ring-primary/30"
+                            : "border-border hover:border-muted-foreground"
+                        }`}
+                      >
+                        {asset.type === "image" && asset.storageKey ? (
+                          <img
+                            src={asset.storageKey}
+                            alt=""
+                            className="size-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex size-full items-center justify-center bg-muted">
+                            {asset.type === "video" ? (
+                              <VideoIcon className="size-6 text-muted-foreground" />
+                            ) : (
+                              <ImageIcon className="size-6 text-muted-foreground" />
+                            )}
+                          </div>
+                        )}
+
+                        {isSelected && (
+                          <div className="absolute inset-0 flex items-center justify-center bg-primary/20">
+                            <div className="flex size-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                              <CheckIcon className="size-4" />
+                            </div>
+                          </div>
+                        )}
+
+                        <Badge
+                          variant="secondary"
+                          className="absolute bottom-1 right-1 px-1 py-0 text-[8px]"
+                        >
+                          {asset.type}
+                        </Badge>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {activeTab === "library" && (
+          <DialogFooter>
+            <div className="flex w-full items-center justify-between">
+              <span className="text-xs text-muted-foreground">
+                {selected.size} selected
+              </span>
+              <Button
+                size="sm"
+                onClick={handleInsertSelected}
+                disabled={selected.size === 0}
+              >
+                Insert Selected
+              </Button>
+            </div>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/src/components/social/compose/PreviewPanel.tsx
+++ b/src/components/social/compose/PreviewPanel.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { useSocialComposerStore } from "@/store/socialComposerStore"
+import { useSocialAccountsStore } from "@/store/socialAccountsStore"
+import { PlatformIcon } from "@/components/social/shared/PlatformIcon"
+import { PLATFORM_LABELS } from "@/lib/social/constants"
+import { Badge } from "@/components/ui/badge"
+import { LinkedInPreview } from "./previews/LinkedInPreview"
+import { XPreview } from "./previews/XPreview"
+import { InstagramPreview } from "./previews/InstagramPreview"
+import { FacebookPreview } from "./previews/FacebookPreview"
+import { TikTokPreview } from "./previews/TikTokPreview"
+import { YouTubePreview } from "./previews/YouTubePreview"
+import type { SocialPlatform } from "@/lib/db/schema"
+
+const PREVIEW_COMPONENTS: Record<
+  string,
+  React.ComponentType<{
+    displayName: string
+    username?: string | null
+    content: string
+    media: { type: "image" | "video"; url: string; alt?: string; mimeType?: string }[]
+  }>
+> = {
+  linkedin: LinkedInPreview,
+  x: XPreview,
+  instagram: InstagramPreview,
+  facebook: FacebookPreview,
+  tiktok: TikTokPreview,
+  youtube: YouTubePreview,
+}
+
+export function PreviewPanel() {
+  const { content, selectedAccountIds, mediaUrls } = useSocialComposerStore()
+  const accounts = useSocialAccountsStore((s) => s.accounts)
+
+  if (selectedAccountIds.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <p className="text-center text-xs text-muted-foreground">
+          Select a channel to see preview
+        </p>
+      </div>
+    )
+  }
+
+  if (content.trim().length === 0 && mediaUrls.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <p className="text-center text-xs text-muted-foreground">
+          Start typing to see preview
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4 overflow-y-auto p-4">
+      <h3 className="text-xs font-medium text-muted-foreground">
+        Live Preview
+      </h3>
+
+      {selectedAccountIds.map((accountId) => {
+        const account = accounts.find((a) => a.id === accountId)
+        if (!account) return null
+
+        const platform = account.platform as SocialPlatform
+        const PreviewComponent = PREVIEW_COMPONENTS[platform]
+
+        if (!PreviewComponent) {
+          return (
+            <div key={accountId} className="rounded-lg border bg-card p-3">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <PlatformIcon platform={platform} size={14} />
+                <span>
+                  {PLATFORM_LABELS[platform]} preview not available
+                </span>
+              </div>
+            </div>
+          )
+        }
+
+        return (
+          <div key={accountId}>
+            <div className="mb-1.5 flex items-center gap-1.5">
+              <PlatformIcon platform={platform} size={12} />
+              <span className="text-[10px] font-medium text-muted-foreground">
+                {PLATFORM_LABELS[platform]}
+              </span>
+            </div>
+            <PreviewComponent
+              displayName={account.displayName}
+              username={account.username}
+              content={content}
+              media={mediaUrls}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/social/compose/previews/FacebookPreview.tsx
+++ b/src/components/social/compose/previews/FacebookPreview.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import type { ComposerMediaItem } from "@/store/socialComposerStore"
+
+interface FacebookPreviewProps {
+  displayName: string
+  content: string
+  media: ComposerMediaItem[]
+}
+
+export function FacebookPreview({ displayName, content, media }: FacebookPreviewProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card">
+      {/* Header */}
+      <div className="flex items-center gap-2.5 px-3 pt-3">
+        <div className="size-9 rounded-full bg-muted" />
+        <div>
+          <p className="text-xs font-semibold">{displayName}</p>
+          <p className="text-[10px] text-muted-foreground">Just now · 🌐</p>
+        </div>
+      </div>
+      {/* Content */}
+      <div className="px-3 py-2">
+        <p className="whitespace-pre-line text-xs leading-relaxed">{content}</p>
+      </div>
+      {/* Media */}
+      {media.length > 0 && (
+        <div className={media.length === 1 ? "" : "grid grid-cols-2 gap-px"}>
+          {media.slice(0, 4).map((m, i) => (
+            <div key={i} className="aspect-video bg-muted">
+              {m.type === "image" && m.url && (
+                <img src={m.url} alt="" className="size-full object-cover" />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {/* Engagement */}
+      <div className="flex gap-4 border-t px-3 py-2 text-[10px] text-muted-foreground">
+        <span>👍 Like</span>
+        <span>💬 Comment</span>
+        <span>↗ Share</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/social/compose/previews/InstagramPreview.tsx
+++ b/src/components/social/compose/previews/InstagramPreview.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import type { ComposerMediaItem } from "@/store/socialComposerStore"
+
+interface InstagramPreviewProps {
+  displayName: string
+  content: string
+  media: ComposerMediaItem[]
+}
+
+export function InstagramPreview({ displayName, content, media }: InstagramPreviewProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card">
+      {/* Header */}
+      <div className="flex items-center gap-2.5 px-3 py-2.5">
+        <div className="size-8 rounded-full bg-muted" />
+        <span className="text-xs font-semibold">{displayName}</span>
+      </div>
+      {/* Media (full width) */}
+      {media.length > 0 ? (
+        <div className="aspect-square bg-muted">
+          {media[0].type === "image" && media[0].url && (
+            <img src={media[0].url} alt="" className="size-full object-cover" />
+          )}
+        </div>
+      ) : (
+        <div className="aspect-square bg-muted" />
+      )}
+      {/* Engagement */}
+      <div className="flex gap-3 px-3 py-2">
+        <span className="text-xs">❤️</span>
+        <span className="text-xs">💬</span>
+        <span className="text-xs">📤</span>
+      </div>
+      {/* Caption */}
+      <div className="px-3 pb-3">
+        <p className="text-xs leading-relaxed">
+          <span className="font-semibold">{displayName}</span>{" "}
+          {content}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/social/compose/previews/LinkedInPreview.tsx
+++ b/src/components/social/compose/previews/LinkedInPreview.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import type { ComposerMediaItem } from "@/store/socialComposerStore"
+
+interface LinkedInPreviewProps {
+  displayName: string
+  content: string
+  media: ComposerMediaItem[]
+}
+
+export function LinkedInPreview({ displayName, content, media }: LinkedInPreviewProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card">
+      {/* Header */}
+      <div className="flex items-center gap-2.5 px-3 pt-3">
+        <div className="size-10 rounded-full bg-muted" />
+        <div>
+          <p className="text-xs font-semibold">{displayName}</p>
+          <p className="text-[10px] text-muted-foreground">LinkedIn · Just now</p>
+        </div>
+      </div>
+      {/* Content */}
+      <div className="px-3 py-2">
+        <p className="whitespace-pre-line text-xs leading-relaxed">{content}</p>
+      </div>
+      {/* Media */}
+      {media.length > 0 && (
+        <div className={media.length === 1 ? "" : "grid grid-cols-2 gap-px"}>
+          {media.slice(0, 4).map((m, i) => (
+            <div key={i} className="aspect-video bg-muted">
+              {m.type === "image" && m.url && (
+                <img src={m.url} alt="" className="size-full object-cover" />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {/* Engagement */}
+      <div className="flex gap-4 border-t px-3 py-2 text-[10px] text-muted-foreground">
+        <span>Like</span>
+        <span>Comment</span>
+        <span>Repost</span>
+        <span>Send</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/social/compose/previews/TikTokPreview.tsx
+++ b/src/components/social/compose/previews/TikTokPreview.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import type { ComposerMediaItem } from "@/store/socialComposerStore"
+
+interface TikTokPreviewProps {
+  displayName: string
+  username?: string | null
+  content: string
+  media: ComposerMediaItem[]
+}
+
+export function TikTokPreview({ displayName, username, content, media }: TikTokPreviewProps) {
+  return (
+    <div className="relative overflow-hidden rounded-lg border bg-black" style={{ aspectRatio: "9/14" }}>
+      {/* Media background */}
+      {media.length > 0 && media[0].type === "image" && media[0].url ? (
+        <img src={media[0].url} alt="" className="size-full object-cover opacity-80" />
+      ) : (
+        <div className="size-full bg-neutral-900" />
+      )}
+
+      {/* Overlay content */}
+      <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/80 to-transparent p-3">
+        <p className="text-[10px] font-medium text-white">
+          @{username || displayName}
+        </p>
+        <p className="mt-0.5 line-clamp-3 text-[10px] leading-relaxed text-white/80">
+          {content}
+        </p>
+      </div>
+
+      {/* Right sidebar engagement */}
+      <div className="absolute bottom-8 right-2 flex flex-col items-center gap-3">
+        <div className="flex flex-col items-center">
+          <div className="flex size-7 items-center justify-center rounded-full bg-white/20 text-[10px] text-white">
+            ❤️
+          </div>
+          <span className="mt-0.5 text-[8px] text-white/70">1.2K</span>
+        </div>
+        <div className="flex flex-col items-center">
+          <div className="flex size-7 items-center justify-center rounded-full bg-white/20 text-[10px] text-white">
+            💬
+          </div>
+          <span className="mt-0.5 text-[8px] text-white/70">48</span>
+        </div>
+        <div className="flex flex-col items-center">
+          <div className="flex size-7 items-center justify-center rounded-full bg-white/20 text-[10px] text-white">
+            ↗
+          </div>
+          <span className="mt-0.5 text-[8px] text-white/70">12</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/social/compose/previews/XPreview.tsx
+++ b/src/components/social/compose/previews/XPreview.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import type { ComposerMediaItem } from "@/store/socialComposerStore"
+
+interface XPreviewProps {
+  displayName: string
+  username?: string | null
+  content: string
+  media: ComposerMediaItem[]
+}
+
+export function XPreview({ displayName, username, content, media }: XPreviewProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card p-3">
+      <div className="flex gap-2.5">
+        <div className="size-9 flex-shrink-0 rounded-full bg-muted" />
+        <div className="min-w-0 flex-1">
+          {/* Header */}
+          <div className="flex items-center gap-1">
+            <span className="text-xs font-semibold">{displayName}</span>
+            <span className="text-[10px] text-muted-foreground">
+              {username ? `@${username}` : ""} · now
+            </span>
+          </div>
+          {/* Content */}
+          <p className="mt-1 whitespace-pre-line text-xs leading-relaxed">{content}</p>
+          {/* Media */}
+          {media.length > 0 && (
+            <div
+              className={`mt-2 overflow-hidden rounded-xl ${
+                media.length === 1
+                  ? ""
+                  : media.length === 2
+                    ? "grid grid-cols-2 gap-px"
+                    : "grid grid-cols-2 gap-px"
+              }`}
+            >
+              {media.slice(0, 4).map((m, i) => (
+                <div
+                  key={i}
+                  className={`bg-muted ${
+                    media.length === 1 ? "aspect-video" : "aspect-square"
+                  }`}
+                >
+                  {m.type === "image" && m.url && (
+                    <img src={m.url} alt="" className="size-full object-cover" />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {/* Engagement */}
+          <div className="mt-2 flex gap-6 text-[10px] text-muted-foreground">
+            <span>Reply</span>
+            <span>Repost</span>
+            <span>Like</span>
+            <span>Views</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/social/compose/previews/YouTubePreview.tsx
+++ b/src/components/social/compose/previews/YouTubePreview.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import type { ComposerMediaItem } from "@/store/socialComposerStore"
+
+interface YouTubePreviewProps {
+  displayName: string
+  content: string
+  media: ComposerMediaItem[]
+}
+
+export function YouTubePreview({ displayName, content, media }: YouTubePreviewProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card">
+      {/* Video thumbnail */}
+      <div className="relative aspect-video bg-muted">
+        {media.length > 0 && media[0].url && (
+          <img src={media[0].url} alt="" className="size-full object-cover" />
+        )}
+        <div className="absolute bottom-1 right-1 rounded bg-black/80 px-1 py-0.5 text-[9px] text-white">
+          0:00
+        </div>
+      </div>
+      {/* Info */}
+      <div className="flex gap-2.5 p-3">
+        <div className="size-8 flex-shrink-0 rounded-full bg-muted" />
+        <div className="min-w-0 flex-1">
+          <p className="line-clamp-2 text-xs font-medium leading-snug">
+            {content || "Untitled video"}
+          </p>
+          <p className="mt-0.5 text-[10px] text-muted-foreground">
+            {displayName}
+          </p>
+          <p className="text-[10px] text-muted-foreground">
+            0 views · Just now
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Media Pool** — modal to browse workspace R2 assets (via Studio API), filter by type (All/Images/Videos), multi-select with checkmarks, module-level cache (no useEffect)
- **Preview Panel** — scrollable right panel with real-time platform previews from composer Zustand store
- **6 platform previews**: LinkedIn (card + engagement row), X (threaded tweet), Instagram (full-width media + caption), Facebook (card + Like/Comment/Share), TikTok (vertical 9:16 with overlay), YouTube (thumbnail + channel info)
- **ComposeView wired** — MediaPool opens from attachments button, PreviewPanel replaces placeholder

## Test plan

- [x] Build succeeds with all routes
- [x] No useEffect for data fetching (module-level cache for assets)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)