### PR TITLE
fix(rtl): guard document access for SSR

### DIFF
--- a/src/components/DirectionHydrator.tsx
+++ b/src/components/DirectionHydrator.tsx
@@ -6,7 +6,7 @@ import { useDirectionStore, type Locale } from "@/store/directionStore";
 export function DirectionHydrator({ locale }: { locale: Locale }) {
   const initialized = useRef(false);
 
-  if (!initialized.current) {
+  if (!initialized.current && typeof document !== "undefined") {
     initialized.current = true;
     const store = useDirectionStore.getState();
     if (store.locale !== locale) {

--- a/src/store/directionStore.ts
+++ b/src/store/directionStore.ts
@@ -25,10 +25,11 @@ export const useDirectionStore = create<DirectionState>((set) => ({
   setLocale: (locale: Locale) => {
     const direction = directionFromLocale(locale);
 
-    document.documentElement.dir = direction;
-    document.documentElement.lang = locale;
-
-    document.cookie = `${LOCALE_COOKIE_NAME}=${locale}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+    if (typeof document !== "undefined") {
+      document.documentElement.dir = direction;
+      document.documentElement.lang = locale;
+      document.cookie = `${LOCALE_COOKIE_NAME}=${locale}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+    }
 
     set({ locale, direction });
   },


### PR DESCRIPTION
## Summary

- Guard `document` access in `directionStore.setLocale()` with `typeof document !== "undefined"` check
- Guard `DirectionHydrator` init to only run on client side
- Fixes runtime error: `document is not defined` when switching to Arabic

## Test plan

- [ ] Switch to Arabic — no SSR error
- [ ] Reload page — direction persists correctly
- [ ] Switch back to English — works without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)