### PR TITLE
feat: harden R2 multi-tenant asset pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@types/three": "^0.182.0",
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^4.0.16",
+    "baseline-browser-mapping": "^2.10.12",
     "drizzle-kit": "^0.31.10",
     "jsdom": "^27.4.0",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.14(@types/node@24.10.1)(typescript@5.9.3))(tsx@4.21.0))
+      baseline-browser-mapping:
+        specifier: ^2.10.12
+        version: 2.10.12
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
@@ -3356,8 +3359,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.32:
-    resolution: {integrity: sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==}
+  baseline-browser-mapping@2.10.12:
+    resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   better-auth@1.5.5:
@@ -10201,7 +10205,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.32: {}
+  baseline-browser-mapping@2.10.12: {}
 
   better-auth@1.5.5(drizzle-kit@0.31.10)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(kysely@0.28.14)(pg@8.20.0))(mongodb@7.1.0)(next@16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.14(@types/node@24.10.1)(typescript@5.9.3))(tsx@4.21.0)):
     dependencies:
@@ -10318,7 +10322,7 @@ snapshots:
 
   browserslist@4.28.0:
     dependencies:
-      baseline-browser-mapping: 2.8.32
+      baseline-browser-mapping: 2.10.12
       caniuse-lite: 1.0.30001757
       electron-to-chromium: 1.5.263
       node-releases: 2.0.27
@@ -12206,7 +12210,7 @@ snapshots:
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.8.32
+      baseline-browser-mapping: 2.10.12
       caniuse-lite: 1.0.30001757
       postcss: 8.4.31
       react: 19.2.4

--- a/src/app/api/load-file/__tests__/route.test.ts
+++ b/src/app/api/load-file/__tests__/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function createRequest(body: unknown): NextRequest {
+  return {
+    headers: new Headers({ host: "localhost:3000" }),
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+describe("/api/load-file cloud guard", () => {
+  it("returns 501 in cloud mode", async () => {
+    vi.stubEnv("STORAGE_BACKEND", "s3");
+    vi.stubEnv("S3_BUCKET_NAME", "test-bucket");
+    vi.stubEnv("S3_REGION", "auto");
+    vi.stubEnv("S3_ACCESS_KEY_ID", "key");
+    vi.stubEnv("S3_SECRET_ACCESS_KEY", "secret");
+
+    const response = await POST(
+      createRequest({
+        filePath: "/tmp/file.png",
+      }),
+    );
+    const data = await response.json();
+    expect(response.status).toBe(501);
+    expect(data.success).toBe(false);
+  });
+});

--- a/src/app/api/load-file/route.ts
+++ b/src/app/api/load-file/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { readFile, stat } from "fs/promises";
 import path from "path";
 import os from "os";
+import { isCloudMode } from "@/lib/storage";
 
 const EXT_TO_MIME: Record<string, string> = {
   png: "image/png",
@@ -60,6 +61,13 @@ function getMimeTypeForPath(filePath: string): string {
 }
 
 export async function POST(request: NextRequest) {
+  if (isCloudMode()) {
+    return NextResponse.json(
+      { success: false, error: "This operation is only available in local mode." },
+      { status: 501 },
+    );
+  }
+
   if (!isLocalhostRequest(request)) {
     return NextResponse.json(
       { success: false, error: "Forbidden: localhost only" },

--- a/src/app/api/load-generation/__tests__/route.test.ts
+++ b/src/app/api/load-generation/__tests__/route.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function createRequest(body: unknown): NextRequest {
+  return {
+    headers: new Headers(),
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+describe("/api/load-generation cloud guard", () => {
+  it("returns 501 in cloud mode", async () => {
+    vi.stubEnv("STORAGE_BACKEND", "s3");
+    vi.stubEnv("S3_BUCKET_NAME", "test-bucket");
+    vi.stubEnv("S3_REGION", "auto");
+    vi.stubEnv("S3_ACCESS_KEY_ID", "key");
+    vi.stubEnv("S3_SECRET_ACCESS_KEY", "secret");
+
+    const response = await POST(
+      createRequest({
+        directoryPath: "/tmp/generations",
+        imageId: "abc",
+      }),
+    );
+    const data = await response.json();
+    expect(response.status).toBe(501);
+    expect(data.success).toBe(false);
+  });
+});

--- a/src/app/api/load-generation/route.ts
+++ b/src/app/api/load-generation/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { logger } from "@/utils/logger";
+import { isCloudMode } from "@/lib/storage";
 
 // Supported file extensions
 const SUPPORTED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'mp4', 'webm', 'mov'];
@@ -23,6 +24,13 @@ const EXT_TO_MIME: Record<string, string> = {
 
 // POST: Load a generated image or video from the generations folder by ID
 export async function POST(request: NextRequest) {
+  if (isCloudMode()) {
+    return NextResponse.json(
+      { success: false, error: "This operation is only available in local mode." },
+      { status: 501 },
+    );
+  }
+
   let directoryPath: string | undefined;
   let imageId: string | undefined;
   try {

--- a/src/app/api/save-generation/__tests__/route.test.ts
+++ b/src/app/api/save-generation/__tests__/route.test.ts
@@ -50,6 +50,7 @@ function createBase64DataUrl(content: string, mimeType = "image/png"): string {
 describe("/api/save-generation route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     // Reset fetch mock
     global.fetch = originalFetch;
   });
@@ -60,6 +61,26 @@ describe("/api/save-generation route", () => {
   });
 
   describe("POST - Save generation", () => {
+    it("returns 501 in cloud mode", async () => {
+      vi.stubEnv("STORAGE_BACKEND", "s3");
+      vi.stubEnv("S3_BUCKET_NAME", "test-bucket");
+      vi.stubEnv("S3_REGION", "auto");
+      vi.stubEnv("S3_ACCESS_KEY_ID", "key");
+      vi.stubEnv("S3_SECRET_ACCESS_KEY", "secret");
+
+      const request = createMockPostRequest({
+        directoryPath: "/test/generations",
+        image: createBase64DataUrl("content"),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(501);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("local mode");
+    });
+
     it("should save base64 image with hash-based filename", async () => {
       const imageContent = "test-image-content";
       const base64Image = createBase64DataUrl(imageContent, "image/png");

--- a/src/app/api/save-generation/route.ts
+++ b/src/app/api/save-generation/route.ts
@@ -100,6 +100,13 @@ async function findExistingFileByHash(
 
 // POST: Save a generated image or video to the generations folder (or outputs folder)
 export async function POST(request: NextRequest) {
+  if (isCloudMode()) {
+    return NextResponse.json(
+      { success: false, error: "This operation is only available in local mode." },
+      { status: 501 },
+    );
+  }
+
   let directoryPath: string | undefined;
   try {
     const body = await request.json();
@@ -136,56 +143,6 @@ export async function POST(request: NextRequest) {
         { success: false, error: "Missing required fields" },
         { status: 400 }
       );
-    }
-
-    // In cloud mode, skip filesystem save — assets go directly to R2 via studioAssetSync
-    if (isCloudMode()) {
-      let extension: string;
-      let contentHash: string;
-
-      if (isHttpUrl(content)) {
-        contentHash = crypto.createHash("md5").update(content).digest("hex");
-        extension = isAudio ? "mp3" : isVideo ? "mp4" : isModel ? "glb" : "png";
-      } else {
-        const dataUrlMatch = content.match(/^data:([\w/+-]+);base64,/);
-        extension = dataUrlMatch
-          ? getExtensionFromMime(dataUrlMatch[1])
-          : (isAudio ? "mp3" : isVideo ? "mp4" : "png");
-        const base64Data = dataUrlMatch
-          ? content.replace(/^data:[\w/+-]+;base64,/, "")
-          : content;
-        const buffer = Buffer.from(base64Data, "base64");
-        contentHash = computeContentHash(buffer);
-      }
-
-      // Safety net for "bin" extension
-      if (extension === "bin") {
-        extension = isModel ? "glb" : isAudio ? "mp3" : isVideo ? "mp4" : "png";
-      }
-
-      const promptSnippet = prompt
-        ? prompt.slice(0, 30).replace(/[^a-zA-Z0-9]/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "").toLowerCase()
-        : "generation";
-      const filename = customFilename
-        ? `${customFilename.replace(/[^a-zA-Z0-9-_]/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "")}_${contentHash}.${extension}`
-        : `${promptSnippet}_${contentHash}.${extension}`;
-
-      logger.info('file.save', 'Cloud mode: skipping filesystem save', {
-        filename,
-        contentHash,
-        isVideo,
-        isModel,
-        isAudio,
-      });
-
-      return NextResponse.json({
-        success: true,
-        filePath: null,
-        filename,
-        imageId: filename.replace(`.${extension}`, ''),
-        isDuplicate: false,
-        skippedLocalSave: true,
-      });
     }
 
     // Validate directory exists (or create if requested)

--- a/src/app/api/studio/assets/[assetId]/download/__tests__/route.test.ts
+++ b/src/app/api/studio/assets/[assetId]/download/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockAuthorizeStudioRequest = vi.fn();
+const mockGetAsset = vi.fn();
+const mockCreatePresignedDownload = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  canUseS3Storage: vi.fn(() => true),
+  createPresignedDownload: (...args: unknown[]) => mockCreatePresignedDownload(...args),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) => mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json({ success: false, error: result.error }, { status: result.status }),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getAsset: (...args: unknown[]) => mockGetAsset(...args),
+}));
+
+import { GET } from "../route";
+
+function createRequest(): NextRequest {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL("http://localhost:3000/api/studio/assets/asset_1/download"),
+  } as unknown as NextRequest;
+}
+
+describe("/api/studio/assets/[assetId]/download", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreatePresignedDownload.mockResolvedValue({
+      key: "env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/file.png",
+      downloadUrl: "https://example-download",
+      expiresInSeconds: 900,
+    });
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: false,
+      status: 401,
+      error: "Please sign in to access AI Studio.",
+    });
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({ assetId: "asset_1" }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 409 when upload is pending", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: true,
+      workspaceId: "ws_1",
+      role: "member",
+    });
+    mockGetAsset.mockResolvedValue({
+      id: "asset_1",
+      storageProvider: "s3",
+      storageKey: "env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/file.png",
+      metadata: { uploadState: "pending" },
+    });
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({ assetId: "asset_1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data).toEqual({
+      success: false,
+      error: "Asset upload is not ready.",
+    });
+  });
+
+  it("returns signed download URL for ready s3 asset", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: true,
+      workspaceId: "ws_1",
+      role: "member",
+    });
+    mockGetAsset.mockResolvedValue({
+      id: "asset_1",
+      storageProvider: "s3",
+      storageKey: "env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/file.png",
+      metadata: { uploadState: "ready" },
+    });
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({ assetId: "asset_1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      assetId: "asset_1",
+      key: "env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/file.png",
+      downloadUrl: "https://example-download",
+      expiresInSeconds: 900,
+    });
+  });
+});

--- a/src/app/api/studio/assets/[assetId]/download/route.ts
+++ b/src/app/api/studio/assets/[assetId]/download/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { canUseS3Storage, createPresignedDownload } from "@/lib/storage";
+import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
+import { getAsset } from "@/lib/studio/repository";
+
+interface AssetDownloadResponse {
+  success: boolean;
+  assetId?: string;
+  key?: string;
+  downloadUrl?: string;
+  expiresInSeconds?: number;
+  error?: string;
+}
+
+function isAssetReady(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return true;
+  }
+
+  const uploadState = (metadata as Record<string, unknown>).uploadState;
+  if (uploadState === "failed") return false;
+  if (uploadState === "pending") return false;
+  return true;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ assetId: string }> },
+): Promise<NextResponse<AssetDownloadResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
+      },
+      { status: 503 },
+    );
+  }
+
+  if (!canUseS3Storage()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const authz = await authorizeStudioRequest(request, {
+      route: "/api/studio/assets/[assetId]/download",
+      action: "read",
+    });
+    if (!authz.authorized) {
+      return authzErrorResponse(authz);
+    }
+
+    const { assetId } = await params;
+    const asset = await getAsset(authz.workspaceId, assetId);
+    if (!asset) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Asset not found.",
+        },
+        { status: 404 },
+      );
+    }
+
+    if (asset.storageProvider !== "s3") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Asset is not stored in S3/R2.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (!asset.storageKey?.trim()) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Asset has no storage key.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (!isAssetReady(asset.metadata)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Asset upload is not ready.",
+        },
+        { status: 409 },
+      );
+    }
+
+    const signed = await createPresignedDownload({
+      key: asset.storageKey,
+    });
+
+    return NextResponse.json({
+      success: true,
+      assetId: asset.id,
+      key: signed.key,
+      downloadUrl: signed.downloadUrl,
+      expiresInSeconds: signed.expiresInSeconds,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to create asset download URL",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/studio/assets/ingest/__tests__/route.test.ts
+++ b/src/app/api/studio/assets/ingest/__tests__/route.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockAuthorizeStudioRequest = vi.fn();
+const mockGetProject = vi.fn();
+const mockRecordPending = vi.fn();
+const mockFinalizeAssetUpload = vi.fn();
+const mockPutObjectToS3 = vi.fn();
+const mockBuildAssetObjectKey = vi.fn();
+const mockCreatePresignedDownload = vi.fn();
+
+const { MockStudioAssetQuotaExceededError } = vi.hoisted(() => {
+  class StudioAssetQuotaExceededError extends Error {
+    constructor() {
+      super("Workspace storage quota exceeded.");
+      this.name = "StudioAssetQuotaExceededError";
+    }
+  }
+
+  return { MockStudioAssetQuotaExceededError: StudioAssetQuotaExceededError };
+});
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  canUseS3Storage: vi.fn(() => true),
+  buildAssetObjectKey: (...args: unknown[]) => mockBuildAssetObjectKey(...args),
+  putObjectToS3: (...args: unknown[]) => mockPutObjectToS3(...args),
+  createPresignedDownload: (...args: unknown[]) => mockCreatePresignedDownload(...args),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) => mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json({ success: false, error: result.error }, { status: result.status }),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getProject: (...args: unknown[]) => mockGetProject(...args),
+  recordPendingS3AssetWithQuota: (...args: unknown[]) => mockRecordPending(...args),
+  finalizeAssetUpload: (...args: unknown[]) => mockFinalizeAssetUpload(...args),
+  StudioAssetQuotaExceededError: MockStudioAssetQuotaExceededError,
+}));
+
+import { POST } from "../route";
+
+function createRequest(body: unknown): NextRequest {
+  return {
+    headers: new Headers(),
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+describe("/api/studio/assets/ingest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildAssetObjectKey.mockReturnValue("env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/key.png");
+    mockRecordPending.mockResolvedValue({ id: "asset_1" });
+    mockFinalizeAssetUpload.mockResolvedValue({ id: "asset_1" });
+    mockCreatePresignedDownload.mockResolvedValue({
+      key: "env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/key.png",
+      downloadUrl: "https://example-download",
+      expiresInSeconds: 900,
+    });
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: false,
+      status: 401,
+      error: "Please sign in to access AI Studio.",
+    });
+
+    const response = await POST(
+      createRequest({
+        projectId: "proj_1",
+        assetType: "image",
+        sourceDataUrl: "data:image/png;base64,aGVsbG8=",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+  });
+
+  it("returns 400 when sourceDataUrl/sourceUrl contract is invalid", async () => {
+    const response = await POST(
+      createRequest({
+        projectId: "proj_1",
+        assetType: "image",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({
+      success: false,
+      error: "Exactly one of sourceDataUrl or sourceUrl is required.",
+    });
+  });
+
+  it("uploads and finalizes data-url ingest for authorized workspace member", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: true,
+      userId: "user_1",
+      workspaceId: "ws_1",
+      role: "member",
+    });
+    mockGetProject.mockResolvedValue({ id: "proj_1", workspaceId: "ws_1" });
+
+    const response = await POST(
+      createRequest({
+        projectId: "proj_1",
+        assetType: "image",
+        sourceDataUrl: "data:image/png;base64,aGVsbG8=",
+        fileName: "image.png",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      assetId: "asset_1",
+      key: "env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/key.png",
+      downloadUrl: "https://example-download",
+      expiresInSeconds: 900,
+    });
+    expect(mockPutObjectToS3).toHaveBeenCalled();
+    expect(mockFinalizeAssetUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        assetId: "asset_1",
+        uploadState: "ready",
+      }),
+    );
+  });
+
+  it("returns 403 when workspace quota is exceeded", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: true,
+      userId: "user_1",
+      workspaceId: "ws_1",
+      role: "member",
+    });
+    mockGetProject.mockResolvedValue({ id: "proj_1", workspaceId: "ws_1" });
+    mockRecordPending.mockRejectedValue(new MockStudioAssetQuotaExceededError());
+
+    const response = await POST(
+      createRequest({
+        projectId: "proj_1",
+        assetType: "image",
+        sourceDataUrl: "data:image/png;base64,aGVsbG8=",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toEqual({
+      success: false,
+      error: "Workspace storage quota exceeded.",
+    });
+  });
+});

--- a/src/app/api/studio/assets/ingest/route.ts
+++ b/src/app/api/studio/assets/ingest/route.ts
@@ -1,0 +1,346 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { assetTypeEnum } from "@/lib/db/schema";
+import {
+  buildAssetObjectKey,
+  canUseS3Storage,
+  createPresignedDownload,
+  putObjectToS3,
+} from "@/lib/storage";
+import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
+import {
+  finalizeAssetUpload,
+  getProject,
+  recordPendingS3AssetWithQuota,
+  StudioAssetQuotaExceededError,
+} from "@/lib/studio/repository";
+
+interface IngestRequest {
+  projectId?: string | null;
+  assetType: (typeof assetTypeEnum.enumValues)[number];
+  sourceDataUrl?: string;
+  sourceUrl?: string;
+  fileName?: string;
+  contentType?: string;
+}
+
+interface IngestResponse {
+  success: boolean;
+  assetId?: string;
+  key?: string;
+  downloadUrl?: string;
+  expiresInSeconds?: number;
+  error?: string;
+}
+
+const MAX_INGEST_BYTES = 500 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 60_000;
+
+function pickDefaultMimeType(assetType: IngestRequest["assetType"]): string {
+  if (assetType === "video") return "video/mp4";
+  if (assetType === "audio") return "audio/mpeg";
+  if (assetType === "model3d") return "model/gltf-binary";
+  return "image/png";
+}
+
+function getExtensionForMimeType(mimeType: string, fallback = "bin"): string {
+  const normalized = mimeType.toLowerCase().trim();
+  const map: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+    "video/mp4": "mp4",
+    "video/webm": "webm",
+    "video/quicktime": "mov",
+    "audio/mpeg": "mp3",
+    "audio/wav": "wav",
+    "audio/ogg": "ogg",
+    "audio/flac": "flac",
+    "audio/aac": "aac",
+    "model/gltf-binary": "glb",
+    "model/gltf+json": "gltf",
+    "model/obj": "obj",
+    "model/vnd.usdz+zip": "usdz",
+    "model/fbx": "fbx",
+    "model/stl": "stl",
+  };
+
+  return map[normalized] || fallback;
+}
+
+function getExtensionFromFileName(fileName?: string): string | null {
+  if (!fileName) return null;
+  const parts = fileName.split(".");
+  if (parts.length < 2) return null;
+  const ext = parts[parts.length - 1]?.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return ext || null;
+}
+
+function parseDataUrl(sourceDataUrl: string): { mimeType: string; bytes: Buffer } {
+  const match = sourceDataUrl.match(/^data:([^;]+);base64,(.+)$/);
+  if (!match) {
+    throw new Error("sourceDataUrl must be a valid base64 data URL.");
+  }
+
+  const mimeType = match[1].trim().toLowerCase();
+  const base64Data = match[2];
+  const bytes = Buffer.from(base64Data, "base64");
+  return { mimeType, bytes };
+}
+
+function sanitizeFileName(fileName?: string): string | null {
+  if (!fileName) return null;
+  const trimmed = fileName.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+async function fetchRemoteBytes(sourceUrl: string): Promise<{ mimeType: string | null; bytes: Buffer }> {
+  let parsed: URL;
+  try {
+    parsed = new URL(sourceUrl);
+  } catch {
+    throw new Error("sourceUrl must be a valid URL.");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("sourceUrl must use http or https.");
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(sourceUrl, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch sourceUrl: HTTP ${response.status}`);
+    }
+
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) {
+      const length = Number(contentLength);
+      if (Number.isFinite(length) && length > MAX_INGEST_BYTES) {
+        throw new Error(`Source size exceeds ${MAX_INGEST_BYTES} bytes.`);
+      }
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    if (arrayBuffer.byteLength > MAX_INGEST_BYTES) {
+      throw new Error(`Source size exceeds ${MAX_INGEST_BYTES} bytes.`);
+    }
+
+    const contentType = response.headers.get("content-type");
+    const mimeType = contentType ? contentType.split(";")[0].trim().toLowerCase() : null;
+
+    return {
+      mimeType,
+      bytes: Buffer.from(arrayBuffer),
+    };
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error(`sourceUrl fetch timed out after ${FETCH_TIMEOUT_MS}ms.`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<IngestResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
+      },
+      { status: 503 },
+    );
+  }
+
+  if (!canUseS3Storage()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
+      },
+      { status: 400 },
+    );
+  }
+
+  let createdAssetId: string | null = null;
+  let workspaceId: string | null = null;
+  let uploadMimeType: string | null = null;
+
+  try {
+    const body = (await request.json()) as IngestRequest;
+
+    if (!assetTypeEnum.enumValues.includes(body.assetType)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Unsupported asset type: ${body.assetType}`,
+        },
+        { status: 400 },
+      );
+    }
+
+    const hasDataUrl = typeof body.sourceDataUrl === "string" && body.sourceDataUrl.trim().length > 0;
+    const hasSourceUrl = typeof body.sourceUrl === "string" && body.sourceUrl.trim().length > 0;
+
+    if (hasDataUrl === hasSourceUrl) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Exactly one of sourceDataUrl or sourceUrl is required.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const authz = await authorizeStudioRequest(request, {
+      route: "/api/studio/assets/ingest",
+      action: "write",
+    });
+    if (!authz.authorized) {
+      return authzErrorResponse(authz);
+    }
+
+    workspaceId = authz.workspaceId;
+
+    const projectId = body.projectId?.trim() || null;
+    if (projectId) {
+      const project = await getProject(authz.workspaceId, projectId);
+      if (!project) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: "No access to this project.",
+          },
+          { status: 403 },
+        );
+      }
+    }
+
+    let bytes: Buffer;
+    let sourceMimeType: string | null;
+
+    if (hasDataUrl) {
+      const parsed = parseDataUrl(body.sourceDataUrl!);
+      bytes = parsed.bytes;
+      sourceMimeType = parsed.mimeType;
+    } else {
+      const fetched = await fetchRemoteBytes(body.sourceUrl!.trim());
+      bytes = fetched.bytes;
+      sourceMimeType = fetched.mimeType;
+    }
+
+    if (bytes.length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Source content is empty.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (bytes.length > MAX_INGEST_BYTES) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Source size exceeds ${MAX_INGEST_BYTES} bytes.`,
+        },
+        { status: 413 },
+      );
+    }
+
+    uploadMimeType = (body.contentType?.trim().toLowerCase() || sourceMimeType || pickDefaultMimeType(body.assetType));
+    const sanitizedName = sanitizeFileName(body.fileName);
+    const extension =
+      getExtensionFromFileName(sanitizedName || undefined) ||
+      getExtensionForMimeType(uploadMimeType, "bin");
+
+    const key = buildAssetObjectKey({
+      workspaceId: authz.workspaceId,
+      projectId,
+      assetType: body.assetType,
+      fileExtension: extension,
+    });
+
+    const pending = await recordPendingS3AssetWithQuota({
+      workspaceId: authz.workspaceId,
+      userId: authz.userId,
+      projectId,
+      type: body.assetType,
+      storageBucket: process.env.S3_BUCKET_NAME || null,
+      storageKey: key,
+      mimeType: uploadMimeType,
+      originalFileName: sanitizedName,
+      expectedSizeBytes: bytes.length,
+    });
+    createdAssetId = pending.id;
+
+    await putObjectToS3({
+      key,
+      body: bytes,
+      contentType: uploadMimeType,
+    });
+
+    await finalizeAssetUpload({
+      workspaceId: authz.workspaceId,
+      assetId: pending.id,
+      uploadState: "ready",
+      sizeBytes: bytes.length,
+      mimeType: uploadMimeType,
+    });
+
+    const signed = await createPresignedDownload({ key });
+
+    return NextResponse.json({
+      success: true,
+      assetId: pending.id,
+      key,
+      downloadUrl: signed.downloadUrl,
+      expiresInSeconds: signed.expiresInSeconds,
+    });
+  } catch (error) {
+    if (error instanceof StudioAssetQuotaExceededError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Workspace storage quota exceeded.",
+        },
+        { status: 403 },
+      );
+    }
+
+    if (workspaceId && createdAssetId) {
+      try {
+        await finalizeAssetUpload({
+          workspaceId,
+          assetId: createdAssetId,
+          uploadState: "failed",
+          mimeType: uploadMimeType || undefined,
+          error: error instanceof Error ? error.message : "Asset ingest failed",
+        });
+      } catch {
+        // best-effort failure finalization
+      }
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to ingest asset",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/studio/assets/legacy-download/__tests__/route.test.ts
+++ b/src/app/api/studio/assets/legacy-download/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockAuthorizeStudioRequest = vi.fn();
+const mockGetProject = vi.fn();
+const mockObjectExistsInS3 = vi.fn();
+const mockCreatePresignedDownload = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  canUseS3Storage: vi.fn(() => true),
+  objectExistsInS3: (...args: unknown[]) => mockObjectExistsInS3(...args),
+  createPresignedDownload: (...args: unknown[]) => mockCreatePresignedDownload(...args),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) => mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json({ success: false, error: result.error }, { status: result.status }),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getProject: (...args: unknown[]) => mockGetProject(...args),
+}));
+
+import { POST } from "../route";
+
+function createRequest(body: unknown): NextRequest {
+  return {
+    headers: new Headers(),
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+describe("/api/studio/assets/legacy-download", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreatePresignedDownload.mockResolvedValue({
+      key: "workflows/project_a/generations/file.png",
+      downloadUrl: "https://example-download",
+      expiresInSeconds: 900,
+    });
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: false,
+      status: 401,
+      error: "Please sign in to access AI Studio.",
+    });
+
+    const response = await POST(
+      createRequest({
+        projectId: "proj_1",
+        legacyKey: "workflows/project_a/generations/file.png",
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 when key is outside allowed project legacy prefix", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: true,
+      workspaceId: "ws_1",
+      role: "member",
+    });
+    mockGetProject.mockResolvedValue({
+      id: "proj_1",
+      sourceDirectoryPath: "project_a",
+    });
+
+    const response = await POST(
+      createRequest({
+        projectId: "proj_1",
+        legacyKey: "workflows/project_b/generations/file.png",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toEqual({
+      success: false,
+      error: "Legacy key does not belong to this project.",
+    });
+  });
+
+  it("returns signed URL for authorized project-owned legacy key", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: true,
+      workspaceId: "ws_1",
+      role: "member",
+    });
+    mockGetProject.mockResolvedValue({
+      id: "proj_1",
+      sourceDirectoryPath: "project_a",
+    });
+    mockObjectExistsInS3.mockResolvedValue(true);
+
+    const response = await POST(
+      createRequest({
+        projectId: "proj_1",
+        legacyKey: "workflows/project_a/generations/file.png",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      key: "workflows/project_a/generations/file.png",
+      downloadUrl: "https://example-download",
+      expiresInSeconds: 900,
+    });
+  });
+});

--- a/src/app/api/studio/assets/legacy-download/route.ts
+++ b/src/app/api/studio/assets/legacy-download/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { canUseS3Storage, createPresignedDownload, objectExistsInS3 } from "@/lib/storage";
+import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
+import { getProject } from "@/lib/studio/repository";
+
+interface LegacyDownloadRequest {
+  projectId?: string;
+  legacyKey?: string;
+}
+
+interface LegacyDownloadResponse {
+  success: boolean;
+  key?: string;
+  downloadUrl?: string;
+  expiresInSeconds?: number;
+  error?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<LegacyDownloadResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
+      },
+      { status: 503 },
+    );
+  }
+
+  if (!canUseS3Storage()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const body = (await request.json()) as LegacyDownloadRequest;
+    const projectId = body.projectId?.trim();
+    const legacyKey = body.legacyKey?.trim();
+
+    if (!projectId || !legacyKey) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "projectId and legacyKey are required.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const authz = await authorizeStudioRequest(request, {
+      route: "/api/studio/assets/legacy-download",
+      action: "read",
+    });
+    if (!authz.authorized) {
+      return authzErrorResponse(authz);
+    }
+
+    const project = await getProject(authz.workspaceId, projectId);
+    if (!project) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "No access to this project.",
+        },
+        { status: 403 },
+      );
+    }
+
+    if (!project.sourceDirectoryPath?.trim()) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Project has no legacy source directory path.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const allowedPrefix = `workflows/${encodeURIComponent(project.sourceDirectoryPath)}/`;
+    if (!legacyKey.startsWith(allowedPrefix)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Legacy key does not belong to this project.",
+        },
+        { status: 403 },
+      );
+    }
+
+    const exists = await objectExistsInS3({ key: legacyKey });
+    if (!exists) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Legacy asset not found.",
+        },
+        { status: 404 },
+      );
+    }
+
+    const signed = await createPresignedDownload({ key: legacyKey });
+
+    return NextResponse.json({
+      success: true,
+      key: signed.key,
+      downloadUrl: signed.downloadUrl,
+      expiresInSeconds: signed.expiresInSeconds,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to create legacy download URL",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/workflow-images/__tests__/route.test.ts
+++ b/src/app/api/workflow-images/__tests__/route.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/utils/logger", () => ({
   },
 }));
 
-import { POST } from "../route";
+import { GET, POST } from "../route";
 
 function createMockPostRequest(body: unknown): NextRequest {
   return {
@@ -30,6 +30,7 @@ function createMockPostRequest(body: unknown): NextRequest {
 describe("/api/workflow-images route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   afterEach(() => {
@@ -37,6 +38,28 @@ describe("/api/workflow-images route", () => {
   });
 
   describe("POST - Save workflow image", () => {
+    it("returns 501 in cloud mode", async () => {
+      vi.stubEnv("STORAGE_BACKEND", "s3");
+      vi.stubEnv("S3_BUCKET_NAME", "test-bucket");
+      vi.stubEnv("S3_REGION", "auto");
+      vi.stubEnv("S3_ACCESS_KEY_ID", "key");
+      vi.stubEnv("S3_SECRET_ACCESS_KEY", "secret");
+
+      const request = createMockPostRequest({
+        workflowPath: "/test/workflow",
+        imageId: "img_123",
+        folder: "inputs",
+        imageData: "data:image/png;base64,aGVsbG8=",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(501);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("local mode");
+    });
+
     it("should save image when workflow directory exists", async () => {
       mockStat.mockResolvedValue({
         isDirectory: () => true,
@@ -127,6 +150,27 @@ describe("/api/workflow-images route", () => {
       expect(response.status).toBe(400);
       expect(data.success).toBe(false);
       expect(data.error).toBe("Access to /etc is not allowed");
+    });
+  });
+
+  describe("GET - Load workflow image", () => {
+    it("returns 501 in cloud mode", async () => {
+      vi.stubEnv("STORAGE_BACKEND", "s3");
+      vi.stubEnv("S3_BUCKET_NAME", "test-bucket");
+      vi.stubEnv("S3_REGION", "auto");
+      vi.stubEnv("S3_ACCESS_KEY_ID", "key");
+      vi.stubEnv("S3_SECRET_ACCESS_KEY", "secret");
+
+      const request = {
+        nextUrl: new URL("http://localhost:3000/api/workflow-images?workflowPath=/test/workflow&imageId=img_123"),
+      } as unknown as NextRequest;
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(501);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("local mode");
     });
   });
 });

--- a/src/app/api/workflow-images/route.ts
+++ b/src/app/api/workflow-images/route.ts
@@ -49,6 +49,13 @@ function getMimeAndExtension(dataUrl: string): { mime: string; extension: string
 
 // POST: Save an image to the workflow's inputs or generations folder
 export async function POST(request: NextRequest) {
+  if (isCloudMode()) {
+    return NextResponse.json(
+      { success: false, error: "This operation is only available in local mode." },
+      { status: 501 },
+    );
+  }
+
   let workflowPath: string | undefined;
   let imageId: string | undefined;
   let folder: string | undefined;
@@ -249,6 +256,13 @@ export async function POST(request: NextRequest) {
 
 // GET: Load an image from the workflow's folders (inputs, generations, or legacy .images)
 export async function GET(request: NextRequest) {
+  if (isCloudMode()) {
+    return NextResponse.json(
+      { success: false, error: "This operation is only available in local mode." },
+      { status: 501 },
+    );
+  }
+
   const workflowPath = request.nextUrl.searchParams.get("workflowPath");
   const imageId = request.nextUrl.searchParams.get("imageId");
   const folder = request.nextUrl.searchParams.get("folder"); // Optional hint for which folder to check first

--- a/src/app/api/workflow/__tests__/route.test.ts
+++ b/src/app/api/workflow/__tests__/route.test.ts
@@ -42,6 +42,7 @@ function createMockGetRequest(params: Record<string, string>): NextRequest {
 describe("/api/workflow route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   afterEach(() => {
@@ -49,6 +50,27 @@ describe("/api/workflow route", () => {
   });
 
   describe("POST - Save workflow", () => {
+    it("returns 501 in cloud mode", async () => {
+      vi.stubEnv("STORAGE_BACKEND", "s3");
+      vi.stubEnv("S3_BUCKET_NAME", "test-bucket");
+      vi.stubEnv("S3_REGION", "auto");
+      vi.stubEnv("S3_ACCESS_KEY_ID", "key");
+      vi.stubEnv("S3_SECRET_ACCESS_KEY", "secret");
+
+      const request = createMockPostRequest({
+        directoryPath: "/test/dir",
+        filename: "workflow",
+        workflow: { nodes: [], edges: [] },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(501);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("local mode");
+    });
+
     it("should save workflow successfully", async () => {
       const mockWorkflow = {
         nodes: [{ id: "node1", type: "prompt" }],
@@ -365,6 +387,23 @@ describe("/api/workflow route", () => {
       expect(response.status).toBe(400);
       expect(data.success).toBe(false);
       expect(data.error).toBe("Path must be absolute");
+    });
+  });
+
+  describe("GET - Validate directory", () => {
+    it("returns 501 in cloud mode", async () => {
+      vi.stubEnv("STORAGE_BACKEND", "s3");
+      vi.stubEnv("S3_BUCKET_NAME", "test-bucket");
+      vi.stubEnv("S3_REGION", "auto");
+      vi.stubEnv("S3_ACCESS_KEY_ID", "key");
+      vi.stubEnv("S3_SECRET_ACCESS_KEY", "secret");
+
+      const response = await GET(createMockGetRequest({ path: "/test/dir" }));
+      const data = await response.json();
+
+      expect(response.status).toBe(501);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("local mode");
     });
   });
 });

--- a/src/app/api/workflow/route.ts
+++ b/src/app/api/workflow/route.ts
@@ -3,11 +3,19 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { logger } from "@/utils/logger";
 import { validateWorkflowPath } from "@/utils/pathValidation";
+import { isCloudMode } from "@/lib/storage";
 
 export const maxDuration = 300; // 5 minute timeout for large workflow files
 
 // POST: Save workflow to file
 export async function POST(request: NextRequest) {
+  if (isCloudMode()) {
+    return NextResponse.json(
+      { success: false, error: "This operation is only available in local mode." },
+      { status: 501 },
+    );
+  }
+
   let directoryPath: string | undefined;
   let filename: string | undefined;
   try {
@@ -143,6 +151,13 @@ export async function POST(request: NextRequest) {
 
 // GET: Validate directory path
 export async function GET(request: NextRequest) {
+  if (isCloudMode()) {
+    return NextResponse.json(
+      { success: false, error: "This operation is only available in local mode." },
+      { status: 501 },
+    );
+  }
+
   const directoryPath = request.nextUrl.searchParams.get("path");
 
   logger.info('file.load', 'Directory validation request received', {

--- a/src/components/nodes/Generate3DNode.tsx
+++ b/src/components/nodes/Generate3DNode.tsx
@@ -14,6 +14,7 @@ import { getModelPageUrl, getProviderDisplayName } from "@/utils/providerUrls";
 import { useInlineParameters } from "@/hooks/useInlineParameters";
 import { InlineParameterPanel } from "./InlineParameterPanel";
 import { browseRegistry } from "@/utils/browseRegistry";
+import { isCloudMode } from "@/lib/storage";
 
 // 3D generation capabilities
 const THREE_D_CAPABILITIES: ModelCapability[] = ["text-to-3d", "image-to-3d"];
@@ -361,7 +362,7 @@ export function Generate3DNode({ id, data, selected }: NodeProps<Generate3DNodeT
               <path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-2.25-1.313M21 7.5v2.25m0-2.25l-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3l2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75l2.25-1.313M12 21.75V19.5m0 2.25l-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25" />
             </svg>
             <span className="text-[11px] text-orange-400 font-medium">3D Model Generated</span>
-            {nodeData.savedFilename ? (
+            {nodeData.savedFilename && !isCloudMode() ? (
               <button
                 onClick={async (e) => {
                   e.stopPropagation();

--- a/src/components/nodes/GenerateAudioNode.tsx
+++ b/src/components/nodes/GenerateAudioNode.tsx
@@ -14,6 +14,8 @@ import { useAudioPlayback } from "@/hooks/useAudioPlayback";
 import { useInlineParameters } from "@/hooks/useInlineParameters";
 import { InlineParameterPanel } from "./InlineParameterPanel";
 import { browseRegistry } from "@/utils/browseRegistry";
+import { isCloudMode } from "@/lib/storage";
+import { getLegacyStudioAssetDownloadUrl, getStudioAssetDownloadUrl } from "@/lib/studio/client";
 
 type GenerateAudioNodeType = Node<GenerateAudioNodeData, "generateAudio">;
 
@@ -21,6 +23,7 @@ export function GenerateAudioNode({ id, data, selected }: NodeProps<GenerateAudi
   const nodeData = data;
   const updateNodeData = useWorkflowStore((state) => state.updateNodeData);
   const generationsPath = useWorkflowStore((state) => state.generationsPath);
+  const workflowId = useWorkflowStore((state) => state.workflowId);
   const [isBrowseDialogOpen, setIsBrowseDialogOpen] = useState(false);
   const [isLoadingCarouselAudio, setIsLoadingCarouselAudio] = useState(false);
 
@@ -116,6 +119,20 @@ export function GenerateAudioNode({ id, data, selected }: NodeProps<GenerateAudi
 
   // Load audio by ID from generations folder
   const loadAudioById = useCallback(async (audioId: string) => {
+    if (isCloudMode()) {
+      try {
+        const signed = audioId.startsWith("asset_")
+          ? await getStudioAssetDownloadUrl(audioId)
+          : workflowId
+            ? await getLegacyStudioAssetDownloadUrl({ projectId: workflowId, legacyKey: audioId })
+            : null;
+        return signed?.downloadUrl || null;
+      } catch (error) {
+        console.warn("Error loading cloud audio:", error);
+        return null;
+      }
+    }
+
     if (!generationsPath) {
       console.error("Generations path not configured");
       return null;
@@ -141,7 +158,7 @@ export function GenerateAudioNode({ id, data, selected }: NodeProps<GenerateAudi
       console.warn("Error loading audio:", error);
       return null;
     }
-  }, [generationsPath]);
+  }, [generationsPath, workflowId]);
 
   // Carousel navigation handlers
   const handleCarouselPrevious = useCallback(async () => {

--- a/src/components/nodes/GenerateImageNode.tsx
+++ b/src/components/nodes/GenerateImageNode.tsx
@@ -16,6 +16,8 @@ import { useInlineParameters } from "@/hooks/useInlineParameters";
 import { InlineParameterPanel } from "./InlineParameterPanel";
 import { browseRegistry } from "@/utils/browseRegistry";
 import { useAdaptiveImageSrc } from "@/hooks/useAdaptiveImageSrc";
+import { isCloudMode } from "@/lib/storage";
+import { getLegacyStudioAssetDownloadUrl, getStudioAssetDownloadUrl } from "@/lib/studio/client";
 
 /** Reorder items so they read column-first in a row-based CSS grid.
  *  e.g. [1,2,3,4,5,6,7,8] with 2 cols → [1,5,2,6,3,7,4,8] */
@@ -58,6 +60,7 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
   const adaptiveOutputImage = useAdaptiveImageSrc(data.outputImage, id);
   const updateNodeData = useWorkflowStore((state) => state.updateNodeData);
   const generationsPath = useWorkflowStore((state) => state.generationsPath);
+  const workflowId = useWorkflowStore((state) => state.workflowId);
   // Use stable selector for API keys to prevent unnecessary re-fetches
   const { replicateApiKey, falApiKey, kieApiKey, replicateEnabled, kieEnabled } = useProviderApiKeys();
   const [isLoadingCarouselImage, setIsLoadingCarouselImage] = useState(false);
@@ -313,6 +316,20 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
   }, [id, regenerateNode]);
 
   const loadImageById = useCallback(async (imageId: string) => {
+    if (isCloudMode()) {
+      try {
+        const signed = imageId.startsWith("asset_")
+          ? await getStudioAssetDownloadUrl(imageId)
+          : workflowId
+            ? await getLegacyStudioAssetDownloadUrl({ projectId: workflowId, legacyKey: imageId })
+            : null;
+        return signed?.downloadUrl || null;
+      } catch (error) {
+        console.warn("Error loading cloud image:", error);
+        return null;
+      }
+    }
+
     if (!generationsPath) {
       console.error("Generations path not configured");
       return null;
@@ -339,7 +356,7 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
       console.warn("Error loading image:", error);
       return null;
     }
-  }, [generationsPath]);
+  }, [generationsPath, workflowId]);
 
   const handleCarouselPrevious = useCallback(async () => {
     const history = nodeData.imageHistory || [];

--- a/src/components/nodes/GenerateVideoNode.tsx
+++ b/src/components/nodes/GenerateVideoNode.tsx
@@ -17,6 +17,8 @@ import { useVideoAutoplay } from "@/hooks/useVideoAutoplay";
 import { useInlineParameters } from "@/hooks/useInlineParameters";
 import { InlineParameterPanel } from "./InlineParameterPanel";
 import { browseRegistry } from "@/utils/browseRegistry";
+import { isCloudMode } from "@/lib/storage";
+import { getLegacyStudioAssetDownloadUrl, getStudioAssetDownloadUrl } from "@/lib/studio/client";
 
 // Video generation capabilities
 const VIDEO_CAPABILITIES: ModelCapability[] = ["text-to-video", "image-to-video"];
@@ -49,6 +51,7 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
   // Use stable selector for API keys to prevent unnecessary re-fetches
   const { geminiApiKey, replicateApiKey, falApiKey, kieApiKey, replicateEnabled, kieEnabled } = useProviderApiKeys();
   const generationsPath = useWorkflowStore((state) => state.generationsPath);
+  const workflowId = useWorkflowStore((state) => state.workflowId);
   const [externalModels, setExternalModels] = useState<ProviderModel[]>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
   const [modelsFetchError, setModelsFetchError] = useState<string | null>(null);
@@ -229,6 +232,20 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
 
   // Load video by ID from generations folder
   const loadVideoById = useCallback(async (videoId: string) => {
+    if (isCloudMode()) {
+      try {
+        const signed = videoId.startsWith("asset_")
+          ? await getStudioAssetDownloadUrl(videoId)
+          : workflowId
+            ? await getLegacyStudioAssetDownloadUrl({ projectId: workflowId, legacyKey: videoId })
+            : null;
+        return signed?.downloadUrl || null;
+      } catch (error) {
+        console.warn("Error loading cloud video:", error);
+        return null;
+      }
+    }
+
     if (!generationsPath) {
       console.error("Generations path not configured");
       return null;
@@ -255,7 +272,7 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
       console.warn("Error loading video:", error);
       return null;
     }
-  }, [generationsPath]);
+  }, [generationsPath, workflowId]);
 
   // Carousel navigation handlers
   const handleCarouselPrevious = useCallback(async () => {

--- a/src/lib/storage/__tests__/s3.test.ts
+++ b/src/lib/storage/__tests__/s3.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAssetObjectKey } from "../s3";
+
+describe("buildAssetObjectKey", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("builds canonical env/workspace/project/type/date key layout", () => {
+    vi.stubEnv("STORAGE_ENV", "production");
+
+    const key = buildAssetObjectKey({
+      workspaceId: "ws_123",
+      projectId: "proj_456",
+      assetType: "image",
+      fileExtension: "png",
+    });
+
+    expect(key).toMatch(
+      /^env\/production\/ws\/ws_123\/proj\/proj_456\/image\/\d{4}\/\d{2}\/\d{2}\/\d+-[a-f0-9-]+\.png$/,
+    );
+  });
+
+  it("sanitizes unsafe segments and never allows nested path injection", () => {
+    vi.stubEnv("STORAGE_ENV", "Prod/../Unsafe");
+
+    const key = buildAssetObjectKey({
+      workspaceId: "WS/../../A",
+      projectId: "proj//nested",
+      assetType: "image/raw",
+      fileExtension: ".pn/g",
+    });
+
+    expect(key).toContain("env/prod_unsafe/ws/ws_a/proj/proj_nested/image_raw/");
+    expect(key).not.toContain("..");
+    expect(key).not.toContain("//");
+  });
+
+  it("uses unscoped project fallback when projectId is null", () => {
+    const key = buildAssetObjectKey({
+      workspaceId: "ws_1",
+      projectId: null,
+      assetType: "audio",
+      fileExtension: "mp3",
+    });
+
+    expect(key).toContain("/proj/unscoped/audio/");
+    expect(key.endsWith(".mp3")).toBe(true);
+  });
+});

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,6 +1,15 @@
-import { buildAssetObjectKey, createPresignedUpload, isS3Configured } from "./s3";
+import {
+  buildAssetObjectKey,
+  createPresignedDownload,
+  createPresignedUpload,
+  objectExistsInS3,
+  putObjectToS3,
+  isS3Configured,
+} from "./s3";
 
 export type StorageBackend = "local" | "s3";
+const CLOUD_MODE_STORAGE_KEY = "node-banana-cloud-mode";
+let runtimeCloudModeOverride: boolean | null = null;
 
 export function getStorageBackend(): StorageBackend {
   const configured = process.env.STORAGE_BACKEND?.toLowerCase();
@@ -13,16 +22,53 @@ export function canUseS3Storage(): boolean {
 }
 
 /**
+ * Allows client code to cache server-detected cloud mode.
+ * This avoids relying on server-only env vars in browser bundles.
+ */
+export function setRuntimeCloudModeOverride(value: boolean | null): void {
+  runtimeCloudModeOverride = value;
+  if (typeof window === "undefined") return;
+
+  if (value === null) {
+    window.localStorage.removeItem(CLOUD_MODE_STORAGE_KEY);
+    return;
+  }
+
+  window.localStorage.setItem(CLOUD_MODE_STORAGE_KEY, value ? "true" : "false");
+}
+
+function getStoredClientCloudMode(): boolean | null {
+  if (typeof window === "undefined") return null;
+  const stored = window.localStorage.getItem(CLOUD_MODE_STORAGE_KEY);
+  if (stored === "true") return true;
+  if (stored === "false") return false;
+  return null;
+}
+
+/**
  * Returns true when the app should use cloud storage (R2/S3 + DB) instead of local filesystem.
  * Alias for canUseS3Storage — named for clarity at call sites.
  */
 export function isCloudMode(): boolean {
+  if (typeof window !== "undefined") {
+    if (runtimeCloudModeOverride !== null) {
+      return runtimeCloudModeOverride;
+    }
+
+    const storedClientMode = getStoredClientCloudMode();
+    if (storedClientMode !== null) {
+      return storedClientMode;
+    }
+  }
+
   return canUseS3Storage();
 }
 
 export {
   buildAssetObjectKey,
+  createPresignedDownload,
   createPresignedUpload,
+  objectExistsInS3,
+  putObjectToS3,
   isS3Configured,
 };
-

--- a/src/lib/storage/s3.ts
+++ b/src/lib/storage/s3.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 export interface S3StorageConfig {
@@ -16,6 +21,45 @@ export interface PresignedUploadResult {
   uploadUrl: string;
   downloadUrl: string;
   expiresInSeconds: number;
+}
+
+export interface PresignedDownloadResult {
+  key: string;
+  downloadUrl: string;
+  expiresInSeconds: number;
+}
+
+export async function putObjectToS3(params: {
+  key: string;
+  body: Uint8Array | Buffer;
+  contentType: string;
+}): Promise<void> {
+  const config = getS3ConfigFromEnv();
+  const client = createS3Client(config);
+  await client.send(
+    new PutObjectCommand({
+      Bucket: config.bucket,
+      Key: params.key,
+      Body: params.body,
+      ContentType: params.contentType,
+    }),
+  );
+}
+
+export async function objectExistsInS3(params: { key: string }): Promise<boolean> {
+  const config = getS3ConfigFromEnv();
+  const client = createS3Client(config);
+  try {
+    await client.send(
+      new HeadObjectCommand({
+        Bucket: config.bucket,
+        Key: params.key,
+      }),
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getS3ConfigFromEnv(): S3StorageConfig {
@@ -52,15 +96,38 @@ function createS3Client(config: S3StorageConfig): S3Client {
   });
 }
 
+function sanitizeKeySegment(value: string | null | undefined, fallback: string): string {
+  const normalized = (value || "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return normalized || fallback;
+}
+
 export function buildAssetObjectKey(params: {
   workspaceId: string;
   projectId?: string | null;
   assetType: string;
   fileExtension?: string;
 }) {
-  const ext = params.fileExtension?.replace(/^\./, "") || "bin";
-  const projectSegment = params.projectId || "unscoped";
-  return `${params.workspaceId}/${projectSegment}/${params.assetType}/${Date.now()}-${randomUUID()}.${ext}`;
+  const environment = sanitizeKeySegment(
+    process.env.STORAGE_ENV ||
+      process.env.VERCEL_ENV ||
+      process.env.NODE_ENV ||
+      "development",
+    "development",
+  );
+  const workspaceSegment = sanitizeKeySegment(params.workspaceId, "workspace");
+  const projectSegment = sanitizeKeySegment(params.projectId || "unscoped", "unscoped");
+  const typeSegment = sanitizeKeySegment(params.assetType, "asset");
+  const ext = sanitizeKeySegment(params.fileExtension?.replace(/^\./, "") || "bin", "bin");
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
+  return `env/${environment}/ws/${workspaceSegment}/proj/${projectSegment}/${typeSegment}/${year}/${month}/${day}/${Date.now()}-${randomUUID()}.${ext}`;
 }
 
 export async function createPresignedUpload(params: {
@@ -96,6 +163,28 @@ export async function createPresignedUpload(params: {
   };
 }
 
+export async function createPresignedDownload(params: {
+  key: string;
+  expiresInSeconds?: number;
+}): Promise<PresignedDownloadResult> {
+  const config = getS3ConfigFromEnv();
+  const client = createS3Client(config);
+  const expiresInSeconds = params.expiresInSeconds ?? 900;
+  const getCommand = new GetObjectCommand({
+    Bucket: config.bucket,
+    Key: params.key,
+  });
+  const downloadUrl = await getSignedUrl(client, getCommand, {
+    expiresIn: expiresInSeconds,
+  });
+
+  return {
+    key: params.key,
+    downloadUrl,
+    expiresInSeconds,
+  };
+}
+
 export function isS3Configured(): boolean {
   return Boolean(
     process.env.S3_BUCKET_NAME &&
@@ -104,4 +193,3 @@ export function isS3Configured(): boolean {
       process.env.S3_SECRET_ACCESS_KEY,
   );
 }
-

--- a/src/lib/studio/client.ts
+++ b/src/lib/studio/client.ts
@@ -188,6 +188,29 @@ export interface StudioAssetFinalizeInput {
   error?: string;
 }
 
+export interface StudioAssetDownloadResult {
+  assetId: string;
+  key: string;
+  downloadUrl: string;
+  expiresInSeconds: number;
+}
+
+export interface StudioAssetIngestInput {
+  projectId?: string | null;
+  assetType: "image" | "video" | "audio" | "model3d" | "workflow";
+  sourceDataUrl?: string;
+  sourceUrl?: string;
+  fileName?: string;
+  contentType?: string;
+}
+
+export interface StudioAssetIngestResult {
+  assetId: string;
+  key: string;
+  downloadUrl: string;
+  expiresInSeconds: number;
+}
+
 function parseWorkspace(value: unknown): StudioWorkspace | null {
   const row = asRecord(value);
   if (!row) return null;
@@ -384,6 +407,80 @@ export async function finalizeStudioAssetUpload(
 
   setActiveWorkspaceId(asset.workspaceId);
   return asset;
+}
+
+export async function getStudioAssetDownloadUrl(
+  assetId: string,
+): Promise<StudioAssetDownloadResult> {
+  const data = await fetchApi(
+    `/api/studio/assets/${encodeURIComponent(assetId)}/download`,
+  );
+
+  const parsedAssetId = asString(data.assetId);
+  const key = asString(data.key);
+  const downloadUrl = asString(data.downloadUrl);
+  const expiresInSeconds = asNumber(data.expiresInSeconds);
+
+  if (!parsedAssetId || !key || !downloadUrl || expiresInSeconds === null) {
+    throw new Error("Asset download payload is invalid");
+  }
+
+  return {
+    assetId: parsedAssetId,
+    key,
+    downloadUrl,
+    expiresInSeconds,
+  };
+}
+
+export async function ingestStudioAsset(
+  input: StudioAssetIngestInput,
+): Promise<StudioAssetIngestResult> {
+  const data = await fetchApi("/api/studio/assets/ingest", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  const assetId = asString(data.assetId);
+  const key = asString(data.key);
+  const downloadUrl = asString(data.downloadUrl);
+  const expiresInSeconds = asNumber(data.expiresInSeconds);
+
+  if (!assetId || !key || !downloadUrl || expiresInSeconds === null) {
+    throw new Error("Asset ingest payload is invalid");
+  }
+
+  return {
+    assetId,
+    key,
+    downloadUrl,
+    expiresInSeconds,
+  };
+}
+
+export async function getLegacyStudioAssetDownloadUrl(
+  input: { projectId: string; legacyKey: string },
+): Promise<{ key: string; downloadUrl: string; expiresInSeconds: number }> {
+  const data = await fetchApi("/api/studio/assets/legacy-download", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  const key = asString(data.key);
+  const downloadUrl = asString(data.downloadUrl);
+  const expiresInSeconds = asNumber(data.expiresInSeconds);
+
+  if (!key || !downloadUrl || expiresInSeconds === null) {
+    throw new Error("Legacy asset download payload is invalid");
+  }
+
+  return {
+    key,
+    downloadUrl,
+    expiresInSeconds,
+  };
 }
 
 export function isWorkflowFile(value: unknown): value is WorkflowFile {

--- a/src/store/execution/generate3dExecutor.ts
+++ b/src/store/execution/generate3dExecutor.ts
@@ -7,7 +7,8 @@
 
 import type { Generate3DNodeData } from "@/types";
 import { buildGenerateHeaders } from "@/store/utils/buildApiHeaders";
-import { syncStudioAssetFromSaveResult } from "./studioAssetSync";
+import { isCloudMode } from "@/lib/storage";
+import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
 import type { NodeExecutionContext } from "./types";
 
 export interface Generate3DOptions {
@@ -122,8 +123,25 @@ export async function executeGenerate3D(
         addIncurredCost(nodeData.selectedModel.pricing.amount);
       }
 
-      // Auto-save 3D model to generations folder if configured
-      if (generationsPath) {
+      if (isCloudMode()) {
+        const savePromise = syncStudioAssetFromSource({
+          assetType: "model3d",
+          source: result.model3dUrl,
+          projectId: (get() as { workflowId?: string | null }).workflowId || null,
+          getStoreState: () => get(),
+        })
+          .then((assetId) => {
+            updateNodeData(node.id, {
+              savedFilename: null,
+              savedFilePath: assetId,
+            });
+          })
+          .catch((syncError) => {
+            console.error("Failed to sync studio 3D asset:", syncError);
+          });
+
+        trackSaveGeneration(`3d-${Date.now()}`, savePromise);
+      } else if (generationsPath) {
         const savePromise = fetch("/api/save-generation", {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/src/store/execution/generateAudioExecutor.ts
+++ b/src/store/execution/generateAudioExecutor.ts
@@ -7,7 +7,8 @@
 
 import type { GenerateAudioNodeData } from "@/types";
 import { buildGenerateHeaders } from "@/store/utils/buildApiHeaders";
-import { syncStudioAssetFromSaveResult } from "./studioAssetSync";
+import { isCloudMode } from "@/lib/storage";
+import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
 import type { NodeExecutionContext } from "./types";
 
 export interface GenerateAudioOptions {
@@ -139,6 +140,7 @@ export async function executeGenerateAudio(
 
       updateNodeData(node.id, {
         outputAudio: audioData,
+        outputAudioRef: audioId,
         status: "complete",
         error: null,
         audioHistory: updatedHistory,
@@ -150,8 +152,34 @@ export async function executeGenerateAudio(
         addIncurredCost(nodeData.selectedModel.pricing.amount);
       }
 
-      // Auto-save to generations folder if configured
-      if (generationsPath) {
+      if (isCloudMode()) {
+        const source = typeof audioData === "string" ? audioData : "";
+        const savePromise = syncStudioAssetFromSource({
+          assetType: "audio",
+          source,
+          projectId: (get() as { workflowId?: string | null }).workflowId || null,
+          getStoreState: () => get(),
+        })
+          .then((assetId) => {
+            const currentNode = getNodes().find((n) => n.id === node.id);
+            if (!currentNode) return;
+            const currentData = currentNode.data as GenerateAudioNodeData;
+            const histCopy = [...(currentData.audioHistory || [])];
+            const entryIndex = histCopy.findIndex((h) => h.id === audioId);
+            if (entryIndex !== -1) {
+              histCopy[entryIndex] = { ...histCopy[entryIndex], id: assetId };
+            }
+            updateNodeData(node.id, {
+              audioHistory: histCopy,
+              outputAudioRef: assetId,
+            });
+          })
+          .catch((err) => {
+            console.error("Failed to ingest cloud audio generation:", err);
+          });
+
+        trackSaveGeneration(audioId, savePromise);
+      } else if (generationsPath) {
         const savePromise = fetch("/api/save-generation", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -172,7 +200,7 @@ export async function executeGenerateAudio(
                 const entryIndex = histCopy.findIndex((h) => h.id === audioId);
                 if (entryIndex !== -1) {
                   histCopy[entryIndex] = { ...histCopy[entryIndex], id: saveResult.imageId };
-                  updateNodeData(node.id, { audioHistory: histCopy });
+                  updateNodeData(node.id, { audioHistory: histCopy, outputAudioRef: saveResult.imageId });
                 }
               }
             }

--- a/src/store/execution/generateVideoExecutor.ts
+++ b/src/store/execution/generateVideoExecutor.ts
@@ -7,7 +7,8 @@
 
 import type { GenerateVideoNodeData } from "@/types";
 import { buildGenerateHeaders } from "@/store/utils/buildApiHeaders";
-import { syncStudioAssetFromSaveResult } from "./studioAssetSync";
+import { isCloudMode } from "@/lib/storage";
+import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
 import type { NodeExecutionContext } from "./types";
 
 export interface GenerateVideoOptions {
@@ -143,6 +144,7 @@ export async function executeGenerateVideo(
 
       updateNodeData(node.id, {
         outputVideo: outputContent,
+        outputVideoRef: videoId,
         status: "complete",
         error: null,
         videoHistory: updatedHistory,
@@ -154,8 +156,34 @@ export async function executeGenerateVideo(
         addIncurredCost(nodeData.selectedModel.pricing.amount);
       }
 
-      // Auto-save to generations folder if configured
-      if (generationsPath) {
+      if (isCloudMode()) {
+        const source = typeof outputContent === "string" ? outputContent : "";
+        const savePromise = syncStudioAssetFromSource({
+          assetType: "video",
+          source,
+          projectId: (get() as { workflowId?: string | null }).workflowId || null,
+          getStoreState: () => get(),
+        })
+          .then((assetId) => {
+            const currentNode = getNodes().find((n) => n.id === node.id);
+            if (!currentNode) return;
+            const currentData = currentNode.data as GenerateVideoNodeData;
+            const histCopy = [...(currentData.videoHistory || [])];
+            const entryIndex = histCopy.findIndex((h) => h.id === videoId);
+            if (entryIndex !== -1) {
+              histCopy[entryIndex] = { ...histCopy[entryIndex], id: assetId };
+            }
+            updateNodeData(node.id, {
+              videoHistory: histCopy,
+              outputVideoRef: assetId,
+            });
+          })
+          .catch((err) => {
+            console.error("Failed to ingest cloud video generation:", err);
+          });
+
+        trackSaveGeneration(videoId, savePromise);
+      } else if (generationsPath) {
         const saveContent = videoData
           ? { video: videoData }
           : { image: result.image };
@@ -180,7 +208,7 @@ export async function executeGenerateVideo(
                 const entryIndex = histCopy.findIndex((h) => h.id === videoId);
                 if (entryIndex !== -1) {
                   histCopy[entryIndex] = { ...histCopy[entryIndex], id: saveResult.imageId };
-                  updateNodeData(node.id, { videoHistory: histCopy });
+                  updateNodeData(node.id, { videoHistory: histCopy, outputVideoRef: saveResult.imageId });
                 }
               }
             }

--- a/src/store/execution/nanoBananaExecutor.ts
+++ b/src/store/execution/nanoBananaExecutor.ts
@@ -10,7 +10,8 @@ import type {
 } from "@/types";
 import { calculateGenerationCost } from "@/utils/costCalculator";
 import { buildGenerateHeaders } from "@/store/utils/buildApiHeaders";
-import { syncStudioAssetFromSaveResult } from "./studioAssetSync";
+import { isCloudMode } from "@/lib/storage";
+import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
 import type { NodeExecutionContext } from "./types";
 
 export interface NanoBananaOptions {
@@ -169,6 +170,7 @@ export async function executeNanoBanana(
 
       updateNodeData(node.id, {
         outputImage: result.image,
+        outputImageRef: imageId,
         status: "complete",
         error: null,
         imageHistory: updatedHistory,
@@ -195,8 +197,33 @@ export async function executeNanoBanana(
         addIncurredCost(generationCost);
       }
 
-      // Auto-save to generations folder if configured
-      if (generationsPath) {
+      // Persist generated media:
+      // - cloud mode: direct Studio ingest (assetId becomes canonical ref/history ID)
+      // - local mode: save file locally, then optional Studio sync
+      if (isCloudMode()) {
+        const savePromise = syncStudioAssetFromSource({
+          assetType: "image",
+          source: result.image,
+          projectId: (get() as { workflowId?: string | null }).workflowId || null,
+          getStoreState: () => get(),
+        })
+          .then((assetId) => {
+            const currentNode = getNodes().find((n) => n.id === node.id);
+            if (!currentNode) return;
+            const currentData = currentNode.data as NanoBananaNodeData;
+            const histCopy = [...(currentData.imageHistory || [])];
+            const entryIndex = histCopy.findIndex((h) => h.id === imageId);
+            if (entryIndex !== -1) {
+              histCopy[entryIndex] = { ...histCopy[entryIndex], id: assetId };
+            }
+            updateNodeData(node.id, { imageHistory: histCopy, outputImageRef: assetId });
+          })
+          .catch((err) => {
+            console.error("Failed to ingest cloud generation:", err);
+          });
+
+        trackSaveGeneration(imageId, savePromise);
+      } else if (generationsPath) {
         const savePromise = fetch("/api/save-generation", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -217,7 +244,7 @@ export async function executeNanoBanana(
                 const entryIndex = histCopy.findIndex((h) => h.id === imageId);
                 if (entryIndex !== -1) {
                   histCopy[entryIndex] = { ...histCopy[entryIndex], id: saveResult.imageId };
-                  updateNodeData(node.id, { imageHistory: histCopy });
+                  updateNodeData(node.id, { imageHistory: histCopy, outputImageRef: saveResult.imageId });
                 }
               }
             }

--- a/src/store/execution/simpleNodeExecutors.ts
+++ b/src/store/execution/simpleNodeExecutors.ts
@@ -20,7 +20,8 @@ import type {
 import type { NodeExecutionContext } from "./types";
 import { parseTextToArray } from "@/utils/arrayParser";
 import { parseVarTags } from "@/utils/parseVarTags";
-import { syncStudioAssetFromSaveResult } from "./studioAssetSync";
+import { isCloudMode } from "@/lib/storage";
+import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
 
 /**
  * Annotation node: receives upstream image as source, passes through if no annotations.
@@ -202,34 +203,44 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
       contentType: "audio",
     });
 
-    // Save to /outputs directory if we have a project path
-    if (saveDirectoryPath) {
+    // Persist output media:
+    // - cloud mode: direct Studio ingest
+    // - local mode: save to /outputs folder then optional Studio sync
+    if (isCloudMode() || saveDirectoryPath) {
       const outputNodeData = node.data as OutputNodeData;
-      const outputsPath = `${saveDirectoryPath}/outputs`;
-
-      const savePromise = fetch("/api/save-generation", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          directoryPath: outputsPath,
-          audio: audioContent,
-          customFilename: outputNodeData.outputFilename || undefined,
-          createDirectory: true,
-        }),
-      })
-        .then((res) => res.json())
-        .then((saveResult) =>
-          syncStudioAssetFromSaveResult({
-            saveResult,
+      const savePromise = isCloudMode()
+        ? syncStudioAssetFromSource({
             assetType: "audio",
+            source: audioContent,
+            fileName: outputNodeData.outputFilename || undefined,
+            projectId: (get() as { workflowId?: string | null }).workflowId || null,
             getStoreState: () => get(),
           }).catch((syncError) => {
             console.error("Failed to sync studio output audio asset:", syncError);
-          }),
-        )
-        .catch((err) => {
-          console.error("Failed to save output:", err);
-        });
+          })
+        : fetch("/api/save-generation", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              directoryPath: `${saveDirectoryPath}/outputs`,
+              audio: audioContent,
+              customFilename: outputNodeData.outputFilename || undefined,
+              createDirectory: true,
+            }),
+          })
+            .then((res) => res.json())
+            .then((saveResult) =>
+              syncStudioAssetFromSaveResult({
+                saveResult,
+                assetType: "audio",
+                getStoreState: () => get(),
+              }).catch((syncError) => {
+                console.error("Failed to sync studio output audio asset:", syncError);
+              }),
+            )
+            .catch((err) => {
+              console.error("Failed to save output:", err);
+            });
 
       trackSaveGeneration(`output-${node.id}-audio-${Date.now()}`, savePromise);
     }
@@ -245,34 +256,41 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
       contentType: "video",
     });
 
-    // Save to /outputs directory if we have a project path
-    if (saveDirectoryPath) {
+    if (isCloudMode() || saveDirectoryPath) {
       const outputNodeData = node.data as OutputNodeData;
-      const outputsPath = `${saveDirectoryPath}/outputs`;
-
-      const savePromise = fetch("/api/save-generation", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          directoryPath: outputsPath,
-          video: videoContent,
-          customFilename: outputNodeData.outputFilename || undefined,
-          createDirectory: true,
-        }),
-      })
-        .then((res) => res.json())
-        .then((saveResult) =>
-          syncStudioAssetFromSaveResult({
-            saveResult,
+      const savePromise = isCloudMode()
+        ? syncStudioAssetFromSource({
             assetType: "video",
+            source: videoContent,
+            fileName: outputNodeData.outputFilename || undefined,
+            projectId: (get() as { workflowId?: string | null }).workflowId || null,
             getStoreState: () => get(),
           }).catch((syncError) => {
             console.error("Failed to sync studio output video asset:", syncError);
-          }),
-        )
-        .catch((err) => {
-          console.error("Failed to save output:", err);
-        });
+          })
+        : fetch("/api/save-generation", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              directoryPath: `${saveDirectoryPath}/outputs`,
+              video: videoContent,
+              customFilename: outputNodeData.outputFilename || undefined,
+              createDirectory: true,
+            }),
+          })
+            .then((res) => res.json())
+            .then((saveResult) =>
+              syncStudioAssetFromSaveResult({
+                saveResult,
+                assetType: "video",
+                getStoreState: () => get(),
+              }).catch((syncError) => {
+                console.error("Failed to sync studio output video asset:", syncError);
+              }),
+            )
+            .catch((err) => {
+              console.error("Failed to save output:", err);
+            });
 
       trackSaveGeneration(`output-${node.id}-video-${Date.now()}`, savePromise);
     }
@@ -299,35 +317,42 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
       });
     }
 
-    // Save to /outputs directory if we have a project path
-    if (saveDirectoryPath) {
+    if (isCloudMode() || saveDirectoryPath) {
       const outputNodeData = node.data as OutputNodeData;
-      const outputsPath = `${saveDirectoryPath}/outputs`;
-
-      const savePromise = fetch("/api/save-generation", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          directoryPath: outputsPath,
-          image: isVideoContent ? undefined : content,
-          video: isVideoContent ? content : undefined,
-          customFilename: outputNodeData.outputFilename || undefined,
-          createDirectory: true,
-        }),
-      })
-        .then((res) => res.json())
-        .then((saveResult) =>
-          syncStudioAssetFromSaveResult({
-            saveResult,
+      const savePromise = isCloudMode()
+        ? syncStudioAssetFromSource({
             assetType: isVideoContent ? "video" : "image",
+            source: content,
+            fileName: outputNodeData.outputFilename || undefined,
+            projectId: (get() as { workflowId?: string | null }).workflowId || null,
             getStoreState: () => get(),
           }).catch((syncError) => {
             console.error("Failed to sync studio output asset:", syncError);
-          }),
-        )
-        .catch((err) => {
-          console.error("Failed to save output:", err);
-        });
+          })
+        : fetch("/api/save-generation", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              directoryPath: `${saveDirectoryPath}/outputs`,
+              image: isVideoContent ? undefined : content,
+              video: isVideoContent ? content : undefined,
+              customFilename: outputNodeData.outputFilename || undefined,
+              createDirectory: true,
+            }),
+          })
+            .then((res) => res.json())
+            .then((saveResult) =>
+              syncStudioAssetFromSaveResult({
+                saveResult,
+                assetType: isVideoContent ? "video" : "image",
+                getStoreState: () => get(),
+              }).catch((syncError) => {
+                console.error("Failed to sync studio output asset:", syncError);
+              }),
+            )
+            .catch((err) => {
+              console.error("Failed to save output:", err);
+            });
 
       trackSaveGeneration(
         `output-${node.id}-${isVideoContent ? "video" : "image"}-${Date.now()}`,

--- a/src/store/execution/simpleNodeExecutors.ts
+++ b/src/store/execution/simpleNodeExecutors.ts
@@ -215,7 +215,8 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
             fileName: outputNodeData.outputFilename || undefined,
             projectId: (get() as { workflowId?: string | null }).workflowId || null,
             getStoreState: () => get(),
-          }).catch((syncError) => {
+          }).then(() => undefined)
+          .catch((syncError) => {
             console.error("Failed to sync studio output audio asset:", syncError);
           })
         : fetch("/api/save-generation", {
@@ -265,7 +266,8 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
             fileName: outputNodeData.outputFilename || undefined,
             projectId: (get() as { workflowId?: string | null }).workflowId || null,
             getStoreState: () => get(),
-          }).catch((syncError) => {
+          }).then(() => undefined)
+          .catch((syncError) => {
             console.error("Failed to sync studio output video asset:", syncError);
           })
         : fetch("/api/save-generation", {
@@ -326,7 +328,8 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
             fileName: outputNodeData.outputFilename || undefined,
             projectId: (get() as { workflowId?: string | null }).workflowId || null,
             getStoreState: () => get(),
-          }).catch((syncError) => {
+          }).then(() => undefined)
+          .catch((syncError) => {
             console.error("Failed to sync studio output asset:", syncError);
           })
         : fetch("/api/save-generation", {

--- a/src/store/execution/studioAssetSync.ts
+++ b/src/store/execution/studioAssetSync.ts
@@ -2,6 +2,7 @@ import {
   createStudioAssetPresign,
   finalizeStudioAssetUpload,
   getActiveWorkspaceId,
+  ingestStudioAsset,
   listStudioWorkspaces,
   StudioApiError,
 } from "@/lib/studio/client";
@@ -77,7 +78,7 @@ async function recordLocalStudioAsset(params: {
   filePath: string;
   mimeType: string;
   prompt?: string | null;
-}): Promise<void> {
+}): Promise<string | null> {
   const response = await fetch("/api/studio/assets", {
     method: "POST",
     headers: {
@@ -116,6 +117,16 @@ async function recordLocalStudioAsset(params: {
   if (!response.ok || record?.success !== true) {
     throw new Error(errorMessage);
   }
+
+  const asset = record?.asset;
+  if (asset && typeof asset === "object" && !Array.isArray(asset)) {
+    const maybeId = (asset as Record<string, unknown>).id;
+    if (typeof maybeId === "string" && maybeId.trim()) {
+      return maybeId;
+    }
+  }
+
+  return null;
 }
 
 async function readSavedFileBlob(filePath: string, mimeType: string): Promise<Blob> {
@@ -155,16 +166,16 @@ export async function syncStudioAssetFromSaveResult(params: {
   prompt?: string | null;
   getStoreState: () => unknown;
   contentBlob?: Blob;
-}): Promise<void> {
-  if (!params.saveResult?.success) return;
+}): Promise<string | null> {
+  if (!params.saveResult?.success) return null;
   const filePath = params.saveResult.filePath;
-  if (!filePath && !params.contentBlob) return;
+  if (!filePath && !params.contentBlob) return null;
 
   if (!getActiveWorkspaceId()) {
     await listStudioWorkspaces();
   }
   const workspaceId = getActiveWorkspaceId();
-  if (!workspaceId) return;
+  if (!workspaceId) return null;
 
   const state = params.getStoreState() as WorkflowStoreLike;
   const projectId =
@@ -208,10 +219,10 @@ export async function syncStudioAssetFromSaveResult(params: {
       sizeBytes: blob.size,
       mimeType,
     });
-    return;
+    return presign.assetId;
   } catch (error) {
     if (isS3ConfigFallbackError(error) && filePath) {
-      await recordLocalStudioAsset({
+      return await recordLocalStudioAsset({
         workspaceId,
         projectId,
         assetType: params.assetType,
@@ -219,7 +230,6 @@ export async function syncStudioAssetFromSaveResult(params: {
         mimeType,
         prompt: params.prompt,
       });
-      return;
     }
 
     if (
@@ -248,4 +258,61 @@ export async function syncStudioAssetFromSaveResult(params: {
 
     throw new Error(`Studio asset upload failed: ${uploadError}`);
   }
+}
+
+function resolveProjectId(
+  explicitProjectId: string | null | undefined,
+  getStoreState: () => unknown,
+): string | null {
+  if (typeof explicitProjectId === "string" && explicitProjectId.trim()) {
+    return explicitProjectId.trim();
+  }
+
+  const state = getStoreState() as WorkflowStoreLike;
+  return typeof state.workflowId === "string" && state.workflowId.trim()
+    ? state.workflowId
+    : null;
+}
+
+export async function syncStudioAssetFromSource(params: {
+  assetType: StudioAssetType;
+  source: string;
+  fileName?: string;
+  contentType?: string;
+  projectId?: string | null;
+  getStoreState: () => unknown;
+}): Promise<string> {
+  const source = params.source?.trim();
+  if (!source) {
+    throw new Error("Missing source for studio asset ingest.");
+  }
+
+  if (!getActiveWorkspaceId()) {
+    await listStudioWorkspaces();
+  }
+  const workspaceId = getActiveWorkspaceId();
+  if (!workspaceId) {
+    throw new Error("Select a workspace to continue.");
+  }
+
+  const projectId = resolveProjectId(params.projectId, params.getStoreState);
+  const sourceUrl = source.startsWith("http://") || source.startsWith("https:")
+    ? source
+    : undefined;
+  const sourceDataUrl = source.startsWith("data:") ? source : undefined;
+
+  if (!sourceUrl && !sourceDataUrl) {
+    throw new Error("Unsupported media source format.");
+  }
+
+  const ingested = await ingestStudioAsset({
+    projectId,
+    assetType: params.assetType,
+    sourceUrl,
+    sourceDataUrl,
+    fileName: params.fileName,
+    contentType: params.contentType,
+  });
+
+  return ingested.assetId;
 }

--- a/src/store/execution/studioAssetSync.ts
+++ b/src/store/execution/studioAssetSync.ts
@@ -78,7 +78,7 @@ async function recordLocalStudioAsset(params: {
   filePath: string;
   mimeType: string;
   prompt?: string | null;
-}): Promise<string | null> {
+}): Promise<void> {
   const response = await fetch("/api/studio/assets", {
     method: "POST",
     headers: {
@@ -118,15 +118,7 @@ async function recordLocalStudioAsset(params: {
     throw new Error(errorMessage);
   }
 
-  const asset = record?.asset;
-  if (asset && typeof asset === "object" && !Array.isArray(asset)) {
-    const maybeId = (asset as Record<string, unknown>).id;
-    if (typeof maybeId === "string" && maybeId.trim()) {
-      return maybeId;
-    }
-  }
-
-  return null;
+  return;
 }
 
 async function readSavedFileBlob(filePath: string, mimeType: string): Promise<Blob> {
@@ -166,16 +158,16 @@ export async function syncStudioAssetFromSaveResult(params: {
   prompt?: string | null;
   getStoreState: () => unknown;
   contentBlob?: Blob;
-}): Promise<string | null> {
-  if (!params.saveResult?.success) return null;
+}): Promise<void> {
+  if (!params.saveResult?.success) return;
   const filePath = params.saveResult.filePath;
-  if (!filePath && !params.contentBlob) return null;
+  if (!filePath && !params.contentBlob) return;
 
   if (!getActiveWorkspaceId()) {
     await listStudioWorkspaces();
   }
   const workspaceId = getActiveWorkspaceId();
-  if (!workspaceId) return null;
+  if (!workspaceId) return;
 
   const state = params.getStoreState() as WorkflowStoreLike;
   const projectId =
@@ -219,10 +211,10 @@ export async function syncStudioAssetFromSaveResult(params: {
       sizeBytes: blob.size,
       mimeType,
     });
-    return presign.assetId;
+    return;
   } catch (error) {
     if (isS3ConfigFallbackError(error) && filePath) {
-      return await recordLocalStudioAsset({
+      await recordLocalStudioAsset({
         workspaceId,
         projectId,
         assetType: params.assetType,
@@ -230,6 +222,7 @@ export async function syncStudioAssetFromSaveResult(params: {
         mimeType,
         prompt: params.prompt,
       });
+      return;
     }
 
     if (

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -296,7 +296,7 @@ interface WorkflowStore {
   imageRefBasePath: string | null;  // Directory from which current imageRefs are valid
 
   // Auto-save actions
-  setWorkflowMetadata: (id: string, name: string, path: string, generationsPath?: string | null) => void;
+  setWorkflowMetadata: (id: string, name: string, path: string | null, generationsPath?: string | null) => void;
   setWorkflowName: (name: string) => void;
   setGenerationsPath: (path: string | null) => void;
   setAutoSaveEnabled: (enabled: boolean) => void;
@@ -1704,11 +1704,14 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
     // Determine the workflow directory path (passed in, from saved config, or embedded in legacy workflow JSON)
     const directoryPath = workflowPath || savedConfig?.directoryPath || workflow.directoryPath || null;
 
-    // Hydrate images if we have a directory path and the workflow has image refs
+    // Hydrate external refs (local filesystem refs or cloud asset IDs/legacy keys)
     let hydratedWorkflow = workflow;
-    if (directoryPath) {
+    if (directoryPath || isCloudMode()) {
       try {
-        hydratedWorkflow = await hydrateWorkflowImages(workflow, directoryPath);
+        hydratedWorkflow = await hydrateWorkflowImages(workflow, {
+          workflowPath: directoryPath,
+          projectId: workflow.id || null,
+        });
       } catch (error) {
         console.error("Failed to hydrate workflow images:", error);
         // Continue with original workflow if hydration fails
@@ -1744,7 +1747,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
       // Restore cost data
       incurredCost: costData?.incurredCost || 0,
       // Track where imageRefs are valid from
-      imageRefBasePath: directoryPath || null,
+      imageRefBasePath: isCloudMode() ? null : directoryPath || null,
       // Restore image storage setting (default to true for backwards compatibility)
       useExternalImageStorage: savedConfig?.useExternalImageStorage ?? true,
       // Reset viewed comments when loading new workflow
@@ -1804,15 +1807,16 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
   },
 
   // Auto-save actions
-  setWorkflowMetadata: (id: string, name: string, path: string, generationsPath?: string | null) => {
+  setWorkflowMetadata: (id: string, name: string, path: string | null, generationsPath?: string | null) => {
+    const normalizedPath = path?.trim() ? path.trim() : null;
     // Auto-derive generationsPath: use provided value, fall back to existing, then auto-derive
     const currentGenPath = get().generationsPath;
-    const derivedGenerationsPath = generationsPath ?? currentGenPath ?? `${path}/generations`;
+    const derivedGenerationsPath = generationsPath ?? currentGenPath ?? (normalizedPath ? `${normalizedPath}/generations` : null);
 
     set({
       workflowId: id,
       workflowName: name,
-      saveDirectoryPath: path,
+      saveDirectoryPath: normalizedPath,
       generationsPath: derivedGenerationsPath,
     });
   },
@@ -1882,7 +1886,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
 
       // If saving to a different directory than where refs point, clear refs
       // so images will be re-saved to the new location
-      const isNewDirectory = useExternalImageStorage && (
+      const isNewDirectory = !isCloudMode() && useExternalImageStorage && (
         // Case 1: Known different directory
         (imageRefBasePath !== null && imageRefBasePath !== saveDirectoryPath) ||
         // Case 2: Has refs but unknown where they came from - treat as new directory to be safe
@@ -1916,8 +1920,11 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
       // If external image storage is enabled, externalize images before saving
       // saveDirectoryPath is guaranteed non-null here: in local mode the early return checks it,
       // in cloud mode it's used as a logical project identifier for R2 key paths
-      if (useExternalImageStorage && saveDirectoryPath) {
-        workflow = await externalizeWorkflowImages(workflow, saveDirectoryPath);
+      if (useExternalImageStorage && (saveDirectoryPath || isCloudMode())) {
+        workflow = await externalizeWorkflowImages(workflow, {
+          workflowPath: saveDirectoryPath,
+          projectId: workflowId,
+        });
       }
 
       let saveSuccess = false;
@@ -2006,14 +2013,15 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
             lastSavedAt: timestamp,
             hasUnsavedChanges: false,
             // Update imageRefBasePath to reflect new save location
-            imageRefBasePath: saveDirectoryPath,
+            imageRefBasePath: isCloudMode() ? null : saveDirectoryPath,
           });
         } else {
           set({
             lastSavedAt: timestamp,
             hasUnsavedChanges: false,
             // Update imageRefBasePath to reflect save location
-            imageRefBasePath: useExternalImageStorage ? saveDirectoryPath : null,
+            imageRefBasePath:
+              useExternalImageStorage && !isCloudMode() ? saveDirectoryPath : null,
           });
         }
 
@@ -2077,7 +2085,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
     }
 
     const { saveDirectoryPath, workflowId: prevId, workflowName: prevName, hasUnsavedChanges: prevUnsaved } = get();
-    if (!saveDirectoryPath) {
+    if (!isCloudMode() && !saveDirectoryPath) {
       return false;
     }
 

--- a/src/utils/__tests__/imageStorage.test.ts
+++ b/src/utils/__tests__/imageStorage.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { externalizeWorkflowImages, hydrateWorkflowImages } from "../imageStorage";
+import type { WorkflowFile } from "@/store/workflowStore";
+
+const mockIsCloudMode = vi.fn();
+const mockIngestStudioAsset = vi.fn();
+const mockGetStudioAssetDownloadUrl = vi.fn();
+const mockGetLegacyStudioAssetDownloadUrl = vi.fn();
+
+vi.mock("@/lib/storage", () => ({
+  isCloudMode: () => mockIsCloudMode(),
+}));
+
+vi.mock("@/lib/studio/client", () => ({
+  ingestStudioAsset: (...args: unknown[]) => mockIngestStudioAsset(...args),
+  getStudioAssetDownloadUrl: (...args: unknown[]) => mockGetStudioAssetDownloadUrl(...args),
+  getLegacyStudioAssetDownloadUrl: (...args: unknown[]) => mockGetLegacyStudioAssetDownloadUrl(...args),
+}));
+
+describe("imageStorage cloud mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsCloudMode.mockReturnValue(true);
+    mockIngestStudioAsset.mockResolvedValue({
+      assetId: "asset_1",
+      key: "env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/file.png",
+      downloadUrl: "https://example-download",
+      expiresInSeconds: 900,
+    });
+    mockGetStudioAssetDownloadUrl.mockResolvedValue({
+      assetId: "asset_1",
+      key: "env/dev/ws/ws_1/proj/proj_1/image/2026/03/29/file.png",
+      downloadUrl: "https://example-download",
+      expiresInSeconds: 900,
+    });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => ({
+        type: "image/png",
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+      }),
+    }) as unknown as typeof fetch;
+  });
+
+  it("externalizes base64 refs to canonical asset IDs without requiring workflowPath", async () => {
+    const workflow: WorkflowFile = {
+      version: 1,
+      id: "proj_1",
+      name: "Test",
+      nodes: [
+        {
+          id: "img-1",
+          type: "imageInput",
+          position: { x: 0, y: 0 },
+          data: {
+            image: "data:image/png;base64,aGVsbG8=",
+            imageRef: undefined,
+          },
+        },
+      ] as WorkflowFile["nodes"],
+      edges: [],
+      edgeStyle: "angular",
+    };
+
+    const externalized = await externalizeWorkflowImages(workflow, {
+      workflowPath: null,
+      projectId: "proj_1",
+    });
+
+    const nodeData = externalized.nodes[0].data as { image: string | null; imageRef?: string };
+    expect(nodeData.image).toBeNull();
+    expect(nodeData.imageRef).toBe("asset_1");
+    expect(mockIngestStudioAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj_1",
+        assetType: "image",
+      }),
+    );
+  });
+
+  it("hydrates cloud assetId refs via authorized download URLs", async () => {
+    const workflow: WorkflowFile = {
+      version: 1,
+      id: "proj_1",
+      name: "Hydrate",
+      nodes: [
+        {
+          id: "img-1",
+          type: "imageInput",
+          position: { x: 0, y: 0 },
+          data: {
+            image: null,
+            imageRef: "asset_1",
+          },
+        },
+      ] as WorkflowFile["nodes"],
+      edges: [],
+      edgeStyle: "angular",
+    };
+
+    const hydrated = await hydrateWorkflowImages(workflow, {
+      projectId: "proj_1",
+    });
+    const nodeData = hydrated.nodes[0].data as { image: string | null };
+
+    expect(nodeData.image?.startsWith("data:image/png;base64,")).toBe(true);
+    expect(mockGetStudioAssetDownloadUrl).toHaveBeenCalledWith("asset_1");
+  });
+});

--- a/src/utils/imageStorage.ts
+++ b/src/utils/imageStorage.ts
@@ -1,6 +1,12 @@
 import { WorkflowNode, WorkflowNodeData } from "@/types";
 import { WorkflowFile } from "@/store/workflowStore";
 import crypto from "crypto";
+import { isCloudMode } from "@/lib/storage";
+import {
+  getLegacyStudioAssetDownloadUrl,
+  getStudioAssetDownloadUrl,
+  ingestStudioAsset,
+} from "@/lib/studio/client";
 
 /**
  * Fetch with timeout support using AbortController
@@ -58,13 +64,35 @@ function isBase64DataUrl(str: string | null | undefined): str is string {
   return typeof str === "string" && str.startsWith("data:");
 }
 
+const ASSET_ID_PREFIX = "asset_";
+
+function isAssetIdRef(value: string): boolean {
+  return value.startsWith(ASSET_ID_PREFIX);
+}
+
+function canPreserveExistingRef(existingRef: string | undefined, expectedRef?: string | null): boolean {
+  if (!existingRef) return false;
+  if (isCloudMode() && !isAssetIdRef(existingRef)) {
+    return false;
+  }
+  if (expectedRef === undefined || expectedRef === null) {
+    return true;
+  }
+  return existingRef === expectedRef;
+}
+
+interface WorkflowImageStorageContext {
+  workflowPath?: string | null;
+  projectId?: string | null;
+}
+
 /**
  * Extract and save all images from a workflow, replacing base64 data with refs
  * Returns a new workflow object with image refs instead of base64 data
  */
 export async function externalizeWorkflowImages(
   workflow: WorkflowFile,
-  workflowPath: string
+  context: WorkflowImageStorageContext
 ): Promise<WorkflowFile> {
   const savedImageIds = new Map<string, string>(); // base64 hash -> imageId (for deduplication)
 
@@ -76,7 +104,7 @@ export async function externalizeWorkflowImages(
     const batch = workflow.nodes.slice(i, i + BATCH_SIZE);
     const results = await Promise.all(
       batch.map((node, batchIndex) =>
-        externalizeNodeImages(node, workflowPath, savedImageIds)
+        externalizeNodeImages(node, context, savedImageIds)
           .then(result => ({ index: i + batchIndex, result }))
       )
     );
@@ -97,7 +125,7 @@ export async function externalizeWorkflowImages(
  */
 async function externalizeNodeImages(
   node: WorkflowNode,
-  workflowPath: string,
+  context: WorkflowImageStorageContext,
   savedImageIds: Map<string, string>
 ): Promise<WorkflowNode> {
   const data = node.data as WorkflowNodeData;
@@ -107,10 +135,10 @@ async function externalizeNodeImages(
     case "imageInput": {
       const d = data as import("@/types").ImageInputNodeData;
       // Skip if already has a valid imageRef (prevents duplicates on re-save after hydration)
-      if (d.imageRef && isBase64DataUrl(d.image)) {
+      if (canPreserveExistingRef(d.imageRef) && isBase64DataUrl(d.image)) {
         newData = { ...d, image: null };
       } else if (isBase64DataUrl(d.image)) {
-        const imageId = await saveImageAndGetId(d.image, workflowPath, savedImageIds, "inputs");
+        const imageId = await saveImageAndGetId(d.image, context, savedImageIds, "inputs");
         newData = { ...d, image: null, imageRef: imageId };
       } else {
         newData = d;
@@ -127,16 +155,16 @@ async function externalizeNodeImages(
 
       // Annotation images are user-created, save to inputs
       // Skip if already has ref (prevents duplicates on re-save after hydration)
-      if (d.sourceImageRef && isBase64DataUrl(d.sourceImage)) {
+      if (canPreserveExistingRef(d.sourceImageRef) && isBase64DataUrl(d.sourceImage)) {
         sourceImage = null;
       } else if (isBase64DataUrl(d.sourceImage)) {
-        sourceImageRef = await saveImageAndGetId(d.sourceImage, workflowPath, savedImageIds, "inputs");
+        sourceImageRef = await saveImageAndGetId(d.sourceImage, context, savedImageIds, "inputs");
         sourceImage = null;
       }
-      if (d.outputImageRef && isBase64DataUrl(d.outputImage)) {
+      if (canPreserveExistingRef(d.outputImageRef) && isBase64DataUrl(d.outputImage)) {
         outputImage = null;
       } else if (isBase64DataUrl(d.outputImage)) {
-        outputImageRef = await saveImageAndGetId(d.outputImage, workflowPath, savedImageIds, "inputs");
+        outputImageRef = await saveImageAndGetId(d.outputImage, context, savedImageIds, "inputs");
         outputImage = null;
       }
 
@@ -163,17 +191,16 @@ async function externalizeNodeImages(
       const expectedRef = d.imageHistory?.[selectedIndex]?.id;
 
       if (d.outputImageRef && isBase64DataUrl(d.outputImage)) {
-        // Verify existing ref matches expected history ID
-        if (d.outputImageRef === expectedRef) {
+        if (canPreserveExistingRef(d.outputImageRef, expectedRef)) {
           outputImage = null; // Ref is correct, just clear base64
         } else {
           // Ref doesn't match history - re-save with correct ID
-          outputImageRef = await saveImageAndGetId(d.outputImage, workflowPath, savedImageIds, "generations", expectedRef);
+          outputImageRef = await saveImageAndGetId(d.outputImage, context, savedImageIds, "generations", expectedRef);
           outputImage = null;
         }
       } else if (isBase64DataUrl(d.outputImage)) {
         // No existing ref - save with expected history ID for consistency
-        outputImageRef = await saveImageAndGetId(d.outputImage, workflowPath, savedImageIds, "generations", expectedRef);
+        outputImageRef = await saveImageAndGetId(d.outputImage, context, savedImageIds, "generations", expectedRef);
         outputImage = null;
       }
 
@@ -182,10 +209,10 @@ async function externalizeNodeImages(
       for (let i = 0; i < (d.inputImages?.length || 0); i++) {
         const img = d.inputImages[i];
         const existingRef = d.inputImageRefs?.[i];
-        if (existingRef && isBase64DataUrl(img)) {
+        if (canPreserveExistingRef(existingRef) && isBase64DataUrl(img)) {
           inputImages.push(""); // Already has ref, just clear the base64
         } else if (isBase64DataUrl(img)) {
-          const ref = await saveImageAndGetId(img, workflowPath, savedImageIds, "inputs");
+          const ref = await saveImageAndGetId(img, context, savedImageIds, "inputs");
           inputImageRefs[i] = ref;
           inputImages.push(""); // Empty placeholder
         } else {
@@ -213,10 +240,10 @@ async function externalizeNodeImages(
       for (let i = 0; i < (d.inputImages?.length || 0); i++) {
         const img = d.inputImages[i];
         const existingRef = d.inputImageRefs?.[i];
-        if (existingRef && isBase64DataUrl(img)) {
+        if (canPreserveExistingRef(existingRef) && isBase64DataUrl(img)) {
           inputImages.push(""); // Already has ref, just clear the base64
         } else if (isBase64DataUrl(img)) {
-          const ref = await saveImageAndGetId(img, workflowPath, savedImageIds, "inputs");
+          const ref = await saveImageAndGetId(img, context, savedImageIds, "inputs");
           inputImageRefs[i] = ref;
           inputImages.push(""); // Empty placeholder
         } else {
@@ -242,10 +269,10 @@ async function externalizeNodeImages(
       for (let i = 0; i < (d.inputImages?.length || 0); i++) {
         const img = d.inputImages[i];
         const existingRef = d.inputImageRefs?.[i];
-        if (existingRef && isBase64DataUrl(img)) {
+        if (canPreserveExistingRef(existingRef) && isBase64DataUrl(img)) {
           inputImages.push(""); // Already has ref, just clear the base64
         } else if (isBase64DataUrl(img)) {
-          const ref = await saveImageAndGetId(img, workflowPath, savedImageIds, "inputs");
+          const ref = await saveImageAndGetId(img, context, savedImageIds, "inputs");
           inputImageRefs[i] = ref;
           inputImages.push(""); // Empty placeholder
         } else {
@@ -274,10 +301,10 @@ async function externalizeNodeImages(
       const d = data as import("@/types").SplitGridNodeData;
       // SplitGrid source is input content, save to inputs
       // Skip if already has ref (prevents duplicates on re-save after hydration)
-      if (d.sourceImageRef && isBase64DataUrl(d.sourceImage)) {
+      if (canPreserveExistingRef(d.sourceImageRef) && isBase64DataUrl(d.sourceImage)) {
         newData = { ...d, sourceImage: null };
       } else if (isBase64DataUrl(d.sourceImage)) {
-        const imageId = await saveImageAndGetId(d.sourceImage, workflowPath, savedImageIds, "inputs");
+        const imageId = await saveImageAndGetId(d.sourceImage, context, savedImageIds, "inputs");
         newData = { ...d, sourceImage: null, sourceImageRef: imageId };
       } else {
         newData = d;
@@ -305,7 +332,7 @@ const inFlightSaves = new Map<string, Promise<string>>();
  */
 async function saveImageAndGetId(
   imageData: string,
-  workflowPath: string,
+  context: WorkflowImageStorageContext,
   savedImageIds: Map<string, string>,
   folder: "inputs" | "generations" = "inputs",
   existingId?: string
@@ -329,6 +356,22 @@ async function saveImageAndGetId(
   const imageId = existingId || generateImageId();
 
   const savePromise = (async () => {
+    if (isCloudMode()) {
+      const projectId = context.projectId?.trim() || null;
+      const ingested = await ingestStudioAsset({
+        projectId,
+        assetType: "image",
+        sourceDataUrl: imageData,
+      });
+      savedImageIds.set(hash, ingested.assetId);
+      return ingested.assetId;
+    }
+
+    const workflowPath = context.workflowPath?.trim();
+    if (!workflowPath) {
+      throw new Error("workflowPath is required when externalizing images in local mode.");
+    }
+
     const response = await fetchWithTimeout(
       "/api/workflow-images",
       {
@@ -372,13 +415,13 @@ async function saveImageAndGetId(
  */
 export async function hydrateWorkflowImages(
   workflow: WorkflowFile,
-  workflowPath: string
+  context: WorkflowImageStorageContext
 ): Promise<WorkflowFile> {
   const hydratedNodes: WorkflowNode[] = [];
   const loadedImages = new Map<string, string>(); // imageId -> base64 (for caching)
 
   for (const node of workflow.nodes) {
-    const newNode = await hydrateNodeImages(node, workflowPath, loadedImages);
+    const newNode = await hydrateNodeImages(node, context, loadedImages);
     hydratedNodes.push(newNode);
   }
 
@@ -393,7 +436,7 @@ export async function hydrateWorkflowImages(
  */
 async function hydrateNodeImages(
   node: WorkflowNode,
-  workflowPath: string,
+  context: WorkflowImageStorageContext,
   loadedImages: Map<string, string>
 ): Promise<WorkflowNode> {
   const data = node.data as WorkflowNodeData;
@@ -403,7 +446,7 @@ async function hydrateNodeImages(
     case "imageInput": {
       const d = data as import("@/types").ImageInputNodeData;
       if (d.imageRef && !d.image) {
-        const image = await loadImageById(d.imageRef, workflowPath, loadedImages, "inputs");
+        const image = await loadImageById(d.imageRef, context, loadedImages, "inputs");
         newData = {
           ...d,
           image,
@@ -420,10 +463,10 @@ async function hydrateNodeImages(
       let outputImage = d.outputImage;
 
       if (d.sourceImageRef && !d.sourceImage) {
-        sourceImage = await loadImageById(d.sourceImageRef, workflowPath, loadedImages, "inputs");
+        sourceImage = await loadImageById(d.sourceImageRef, context, loadedImages, "inputs");
       }
       if (d.outputImageRef && !d.outputImage) {
-        outputImage = await loadImageById(d.outputImageRef, workflowPath, loadedImages, "inputs");
+        outputImage = await loadImageById(d.outputImageRef, context, loadedImages, "inputs");
       }
 
       newData = {
@@ -440,7 +483,7 @@ async function hydrateNodeImages(
       const inputImages = [...(d.inputImages || [])];
 
       if (d.outputImageRef && !d.outputImage) {
-        outputImage = await loadImageById(d.outputImageRef, workflowPath, loadedImages, "generations");
+        outputImage = await loadImageById(d.outputImageRef, context, loadedImages, "generations");
       }
 
       // Hydrate input images from refs
@@ -448,7 +491,7 @@ async function hydrateNodeImages(
         for (let i = 0; i < d.inputImageRefs.length; i++) {
           const ref = d.inputImageRefs[i];
           if (ref) {
-            inputImages[i] = await loadImageById(ref, workflowPath, loadedImages, "inputs");
+            inputImages[i] = await loadImageById(ref, context, loadedImages, "inputs");
           }
         }
       }
@@ -470,7 +513,7 @@ async function hydrateNodeImages(
         for (let i = 0; i < d.inputImageRefs.length; i++) {
           const ref = d.inputImageRefs[i];
           if (ref) {
-            inputImages[i] = await loadImageById(ref, workflowPath, loadedImages, "inputs");
+            inputImages[i] = await loadImageById(ref, context, loadedImages, "inputs");
           }
         }
       }
@@ -491,7 +534,7 @@ async function hydrateNodeImages(
         for (let i = 0; i < d.inputImageRefs.length; i++) {
           const ref = d.inputImageRefs[i];
           if (ref) {
-            inputImages[i] = await loadImageById(ref, workflowPath, loadedImages, "inputs");
+            inputImages[i] = await loadImageById(ref, context, loadedImages, "inputs");
           }
         }
       }
@@ -513,7 +556,7 @@ async function hydrateNodeImages(
     case "splitGrid": {
       const d = data as import("@/types").SplitGridNodeData;
       if (d.sourceImageRef && !d.sourceImage) {
-        const sourceImage = await loadImageById(d.sourceImageRef, workflowPath, loadedImages, "inputs");
+        const sourceImage = await loadImageById(d.sourceImageRef, context, loadedImages, "inputs");
         newData = {
           ...d,
           sourceImage,
@@ -540,12 +583,53 @@ async function hydrateNodeImages(
  */
 async function loadImageById(
   imageId: string,
-  workflowPath: string,
+  context: WorkflowImageStorageContext,
   loadedImages: Map<string, string>,
   folder?: "inputs" | "generations"
 ): Promise<string> {
   if (loadedImages.has(imageId)) {
     return loadedImages.get(imageId)!;
+  }
+
+  if (isCloudMode()) {
+    try {
+      const signed = isAssetIdRef(imageId)
+        ? await getStudioAssetDownloadUrl(imageId)
+        : context.projectId
+          ? await getLegacyStudioAssetDownloadUrl({
+              projectId: context.projectId,
+              legacyKey: imageId,
+            })
+          : null;
+      if (!signed?.downloadUrl) {
+        return "";
+      }
+
+      const imgResponse = await fetch(signed.downloadUrl);
+      if (!imgResponse.ok) {
+        return "";
+      }
+      const blob = await imgResponse.blob();
+      const arrayBuffer = await blob.arrayBuffer();
+      const base64 = btoa(
+        new Uint8Array(arrayBuffer).reduce(
+          (data, byte) => data + String.fromCharCode(byte),
+          "",
+        ),
+      );
+      const mimeType = blob.type || "image/png";
+      const dataUrl = `data:${mimeType};base64,${base64}`;
+      loadedImages.set(imageId, dataUrl);
+      return dataUrl;
+    } catch (error) {
+      console.log("Image not found:", imageId, error);
+      return "";
+    }
+  }
+
+  const workflowPath = context.workflowPath?.trim();
+  if (!workflowPath) {
+    return "";
   }
 
   const params = new URLSearchParams({


### PR DESCRIPTION
## Summary
- harden cloud storage around workspace-authorized Studio asset APIs
- add canonical R2 keying and temporary legacy cloud-ref compatibility reader
- migrate workflow/executor cloud media refs to canonical asset IDs and remove local-path dependency in cloud mode
- enforce 501 local-only guards for filesystem APIs in cloud mode
- add broad route/store/executor/unit test coverage for the new behavior

## Testing
- pnpm test:run src/lib/storage/__tests__/s3.test.ts src/utils/__tests__/imageStorage.test.ts src/app/api/studio/assets/ingest/__tests__/route.test.ts 'src/app/api/studio/assets/[assetId]/download/__tests__/route.test.ts' src/app/api/studio/assets/legacy-download/__tests__/route.test.ts src/app/api/workflow/__tests__/route.test.ts src/app/api/workflow-images/__tests__/route.test.ts src/app/api/save-generation/__tests__/route.test.ts src/app/api/load-generation/__tests__/route.test.ts src/app/api/load-file/__tests__/route.test.ts src/store/execution/__tests__/nanoBananaExecutor.test.ts src/store/execution/__tests__/generateVideoExecutor.test.ts src/store/execution/__tests__/simpleNodeExecutors.test.ts src/store/__tests__/workflowStore.integration.test.ts
- pnpm test:run (fails on existing WelcomeModal branding assertions unrelated to this PR)