### PR TITLE
feat(social): Postiz parity migration across social routes

### DIFF
--- a/src/app/api/social/accounts/[accountId]/route.ts
+++ b/src/app/api/social/accounts/[accountId]/route.ts
@@ -2,8 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { isDatabaseConfigured } from "@/lib/db";
 import { withApiPermission } from "@/lib/studio/authz";
 import {
+  countSocialPostsForAccount,
   disconnectSocialAccount,
   getSocialAccount,
+  updateSocialAccount,
   SocialAccountNotFoundError,
 } from "@/lib/social/repository";
 
@@ -11,6 +13,12 @@ interface AccountResponse {
   success: boolean;
   account?: Record<string, unknown>;
   error?: string;
+}
+
+interface AccountPatchRequest {
+  displayName?: string;
+  disabled?: boolean;
+  additionalSettings?: Record<string, unknown> | null;
 }
 
 export async function GET(
@@ -86,6 +94,23 @@ export async function DELETE(
     }
 
     const { accountId } = await params;
+    const force = new URL(request.url).searchParams.get("force") === "true";
+    if (!force) {
+      const linkedPosts = await countSocialPostsForAccount(
+        result.session.workspace.id,
+        accountId,
+      );
+      if (linkedPosts > 0) {
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              "This channel has existing posts. Delete or move those posts first, or retry with force=true.",
+          },
+          { status: 409 },
+        );
+      }
+    }
     await disconnectSocialAccount(result.session.workspace.id, accountId);
 
     return NextResponse.json({ success: true });
@@ -103,6 +128,99 @@ export async function DELETE(
           error instanceof Error
             ? error.message
             : "Failed to disconnect account",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ accountId: string }> },
+): Promise<NextResponse<AccountResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/accounts",
+      permission: "social:manage",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { accountId } = await params;
+    const body = (await request.json()) as AccountPatchRequest;
+
+    if (
+      body.displayName !== undefined &&
+      (typeof body.displayName !== "string" || body.displayName.trim().length === 0)
+    ) {
+      return NextResponse.json(
+        { success: false, error: "displayName must be a non-empty string." },
+        { status: 400 },
+      );
+    }
+    if (body.disabled !== undefined && typeof body.disabled !== "boolean") {
+      return NextResponse.json(
+        { success: false, error: "disabled must be a boolean." },
+        { status: 400 },
+      );
+    }
+    if (
+      body.additionalSettings !== undefined &&
+      body.additionalSettings !== null &&
+      (typeof body.additionalSettings !== "object" ||
+        Array.isArray(body.additionalSettings))
+    ) {
+      return NextResponse.json(
+        { success: false, error: "additionalSettings must be an object." },
+        { status: 400 },
+      );
+    }
+
+    const account = await updateSocialAccount(
+      result.session.workspace.id,
+      accountId,
+      {
+        ...(body.displayName !== undefined
+          ? { displayName: body.displayName.trim() }
+          : {}),
+        ...(body.disabled !== undefined ? { disabled: body.disabled } : {}),
+        ...(body.additionalSettings !== undefined
+          ? { additionalSettings: body.additionalSettings }
+          : {}),
+      },
+    );
+
+    const {
+      accessTokenEncrypted,
+      refreshTokenEncrypted,
+      accessTokenSecret,
+      ...safeAccount
+    } = account;
+
+    return NextResponse.json({ success: true, account: safeAccount });
+  } catch (error) {
+    if (error instanceof SocialAccountNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to update account",
       },
       { status: 500 },
     );

--- a/src/app/api/social/accounts/[accountId]/route.ts
+++ b/src/app/api/social/accounts/[accountId]/route.ts
@@ -184,6 +184,15 @@ export async function PATCH(
         { status: 400 },
       );
     }
+    if (
+      body.additionalSettings &&
+      JSON.stringify(body.additionalSettings).length > 10_240
+    ) {
+      return NextResponse.json(
+        { success: false, error: "additionalSettings exceeds maximum size (10 KB)." },
+        { status: 400 },
+      );
+    }
 
     const account = await updateSocialAccount(
       result.session.workspace.id,

--- a/src/app/api/social/accounts/__tests__/route.test.ts
+++ b/src/app/api/social/accounts/__tests__/route.test.ts
@@ -5,10 +5,14 @@ const mockWithApiPermission = vi.fn();
 const mockListSocialAccounts = vi.fn();
 const mockGetSocialAccount = vi.fn();
 const mockDisconnectSocialAccount = vi.fn();
+const mockUpdateSocialAccount = vi.fn();
+const mockCountSocialPostsForAccount = vi.fn();
 const mockCreateOAuthState = vi.fn();
 const mockConsumeOAuthState = vi.fn();
+const mockGetOAuthStateByState = vi.fn();
 const mockCreateOAuthSelectionSession = vi.fn();
 const mockConsumeOAuthSelectionSession = vi.fn();
+const mockGetOAuthSelectionSession = vi.fn();
 const mockCountActiveSocialAccounts = vi.fn();
 const mockUpsertSocialAccount = vi.fn();
 const mockGetProvider = vi.fn();
@@ -30,10 +34,16 @@ vi.mock("@/lib/social/repository", () => ({
   listSocialAccounts: (...args: unknown[]) => mockListSocialAccounts(...args),
   getSocialAccount: (...args: unknown[]) => mockGetSocialAccount(...args),
   disconnectSocialAccount: (...args: unknown[]) => mockDisconnectSocialAccount(...args),
+  updateSocialAccount: (...args: unknown[]) => mockUpdateSocialAccount(...args),
+  countSocialPostsForAccount: (...args: unknown[]) =>
+    mockCountSocialPostsForAccount(...args),
   createOAuthState: (...args: unknown[]) => mockCreateOAuthState(...args),
   consumeOAuthState: (...args: unknown[]) => mockConsumeOAuthState(...args),
+  getOAuthStateByState: (...args: unknown[]) => mockGetOAuthStateByState(...args),
   createOAuthSelectionSession: (...args: unknown[]) => mockCreateOAuthSelectionSession(...args),
   consumeOAuthSelectionSession: (...args: unknown[]) => mockConsumeOAuthSelectionSession(...args),
+  getOAuthSelectionSession: (...args: unknown[]) =>
+    mockGetOAuthSelectionSession(...args),
   countActiveSocialAccounts: (...args: unknown[]) => mockCountActiveSocialAccounts(...args),
   upsertSocialAccount: (...args: unknown[]) => mockUpsertSocialAccount(...args),
   SocialAccountNotFoundError: class extends Error {
@@ -97,6 +107,7 @@ function createRequest(
 describe("/api/social/accounts GET", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCountSocialPostsForAccount.mockResolvedValue(0);
   });
 
   it("returns 401 for unauthenticated requests", async () => {
@@ -407,7 +418,7 @@ describe("/api/social/accounts/select-page POST", () => {
 
   it("uses selection session to complete page connect without raw client tokens", async () => {
     authorized();
-    mockConsumeOAuthSelectionSession.mockResolvedValue({
+    const selectionSession = {
       id: "sosel_1",
       workspaceId: "ws_1",
       platform: "facebook",
@@ -416,7 +427,9 @@ describe("/api/social/accounts/select-page POST", () => {
       accessTokenSecret: null,
       tokenExpiresAt: new Date("2026-01-01T00:00:00.000Z"),
       expiresAt: new Date("2026-01-01T00:10:00.000Z"),
-    });
+    };
+    mockGetOAuthSelectionSession.mockResolvedValue(selectionSession);
+    mockConsumeOAuthSelectionSession.mockResolvedValue(selectionSession);
     mockDecryptToken.mockReturnValue("plain_access");
     mockGetProvider.mockReturnValue({
       fetchPageInformation: vi.fn().mockResolvedValue([
@@ -448,6 +461,11 @@ describe("/api/social/accounts/select-page POST", () => {
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
     expect(data.account).not.toHaveProperty("accessTokenEncrypted");
+    expect(mockGetOAuthSelectionSession).toHaveBeenCalledWith({
+      selectionSessionId: "sosel_1",
+      workspaceId: "ws_1",
+      platform: "facebook",
+    });
     expect(mockConsumeOAuthSelectionSession).toHaveBeenCalledWith({
       selectionSessionId: "sosel_1",
       workspaceId: "ws_1",
@@ -473,6 +491,7 @@ describe("/api/social/accounts/[accountId] DELETE", () => {
 
   it("disconnects account successfully", async () => {
     authorized();
+    mockCountSocialPostsForAccount.mockResolvedValue(0);
     mockDisconnectSocialAccount.mockResolvedValue(undefined);
 
     const mod = await import("../../accounts/[accountId]/route");
@@ -484,11 +503,13 @@ describe("/api/social/accounts/[accountId] DELETE", () => {
 
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
+    expect(mockCountSocialPostsForAccount).toHaveBeenCalledWith("ws_1", "sacct_1");
     expect(mockDisconnectSocialAccount).toHaveBeenCalledWith("ws_1", "sacct_1");
   });
 
   it("returns 404 for unknown account", async () => {
     authorized();
+    mockCountSocialPostsForAccount.mockResolvedValue(0);
     const { SocialAccountNotFoundError } = await import("@/lib/social/repository");
     mockDisconnectSocialAccount.mockRejectedValue(new SocialAccountNotFoundError("sacct_missing"));
 
@@ -499,5 +520,38 @@ describe("/api/social/accounts/[accountId] DELETE", () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it("returns 409 when account has linked posts without force", async () => {
+    authorized();
+    mockCountSocialPostsForAccount.mockResolvedValue(3);
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.DELETE(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+
+    expect(response.status).toBe(409);
+    expect(mockDisconnectSocialAccount).not.toHaveBeenCalled();
+  });
+
+  it("allows force disconnect when account has linked posts", async () => {
+    authorized();
+    mockCountSocialPostsForAccount.mockResolvedValue(3);
+    mockDisconnectSocialAccount.mockResolvedValue(undefined);
+
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.DELETE(
+      createRequest(
+        "http://localhost:3000/api/social/accounts/sacct_1?force=true",
+        { method: "DELETE" },
+      ),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDisconnectSocialAccount).toHaveBeenCalledWith("ws_1", "sacct_1");
   });
 });

--- a/src/app/api/social/accounts/__tests__/route.test.ts
+++ b/src/app/api/social/accounts/__tests__/route.test.ts
@@ -555,3 +555,163 @@ describe("/api/social/accounts/[accountId] DELETE", () => {
     expect(mockDisconnectSocialAccount).toHaveBeenCalledWith("ws_1", "sacct_1");
   });
 });
+
+describe("/api/social/accounts/[accountId] PATCH", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    unauthorized(401);
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.PATCH(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", {
+        method: "PATCH",
+        body: JSON.stringify({ displayName: "New Name" }),
+      }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("updates displayName successfully", async () => {
+    authorized();
+    mockUpdateSocialAccount.mockResolvedValue({
+      id: "sacct_1",
+      platform: "linkedin",
+      displayName: "New Name",
+      accessTokenEncrypted: "enc_secret",
+      refreshTokenEncrypted: "enc_refresh",
+      accessTokenSecret: null,
+    });
+
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.PATCH(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", {
+        method: "PATCH",
+        body: JSON.stringify({ displayName: "New Name" }),
+      }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.account.displayName).toBe("New Name");
+    expect(data.account).not.toHaveProperty("accessTokenEncrypted");
+    expect(mockUpdateSocialAccount).toHaveBeenCalledWith("ws_1", "sacct_1", {
+      displayName: "New Name",
+    });
+  });
+
+  it("returns 400 for empty displayName", async () => {
+    authorized();
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.PATCH(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", {
+        method: "PATCH",
+        body: JSON.stringify({ displayName: "" }),
+      }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("displayName");
+  });
+
+  it("returns 400 for non-boolean disabled", async () => {
+    authorized();
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.PATCH(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", {
+        method: "PATCH",
+        body: JSON.stringify({ disabled: "yes" }),
+      }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("disabled");
+  });
+
+  it("returns 400 for non-object additionalSettings", async () => {
+    authorized();
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.PATCH(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", {
+        method: "PATCH",
+        body: JSON.stringify({ additionalSettings: "invalid" }),
+      }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("additionalSettings");
+  });
+
+  it("returns 400 for oversized additionalSettings", async () => {
+    authorized();
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.PATCH(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", {
+        method: "PATCH",
+        body: JSON.stringify({ additionalSettings: { data: "x".repeat(11_000) } }),
+      }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("maximum size");
+  });
+
+  it("returns 404 for unknown account", async () => {
+    authorized();
+    const { SocialAccountNotFoundError } = await import("@/lib/social/repository");
+    mockUpdateSocialAccount.mockRejectedValue(new SocialAccountNotFoundError("sacct_missing"));
+
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.PATCH(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_missing", {
+        method: "PATCH",
+        body: JSON.stringify({ displayName: "Test" }),
+      }),
+      { params: Promise.resolve({ accountId: "sacct_missing" }) },
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("updates disabled flag successfully", async () => {
+    authorized();
+    mockUpdateSocialAccount.mockResolvedValue({
+      id: "sacct_1",
+      platform: "linkedin",
+      displayName: "Test",
+      disabled: true,
+      accessTokenEncrypted: "enc_secret",
+      refreshTokenEncrypted: "enc_refresh",
+      accessTokenSecret: null,
+    });
+
+    const mod = await import("../../accounts/[accountId]/route");
+    const response = await mod.PATCH(
+      createRequest("http://localhost:3000/api/social/accounts/sacct_1", {
+        method: "PATCH",
+        body: JSON.stringify({ disabled: true }),
+      }),
+      { params: Promise.resolve({ accountId: "sacct_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.account.disabled).toBe(true);
+    expect(mockUpdateSocialAccount).toHaveBeenCalledWith("ws_1", "sacct_1", {
+      disabled: true,
+    });
+  });
+});

--- a/src/app/api/social/accounts/callback/route.ts
+++ b/src/app/api/social/accounts/callback/route.ts
@@ -7,6 +7,7 @@ import { encryptToken } from "@/lib/social/crypto";
 import {
   createOAuthSelectionSession,
   consumeOAuthState,
+  getOAuthStateByState,
   upsertSocialAccount,
   OAuthStateNotFoundError,
   OAuthStateExpiredError,
@@ -31,6 +32,70 @@ interface CallbackResponse {
 }
 
 const OAUTH_SELECTION_SESSION_TTL_MS = 10 * 60 * 1000;
+
+function socialChannelsRedirect(
+  request: NextRequest,
+  params: Record<string, string | undefined>,
+) {
+  const url = new URL("/social/channels", request.url);
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return NextResponse.redirect(url);
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse> {
+  const incoming = new URL(request.url);
+  const code = incoming.searchParams.get("code");
+  const state = incoming.searchParams.get("state");
+  const oauthToken = incoming.searchParams.get("oauth_token");
+  const oauthVerifier = incoming.searchParams.get("oauth_verifier");
+  const error = incoming.searchParams.get("error");
+  const errorDescription =
+    incoming.searchParams.get("error_description") ||
+    incoming.searchParams.get("message");
+
+  if (error) {
+    return socialChannelsRedirect(request, {
+      error: errorDescription || error,
+    });
+  }
+
+  const normalizedCode = code || oauthVerifier || "";
+  const normalizedState = state || oauthToken || "";
+  if (!normalizedCode || !normalizedState) {
+    return socialChannelsRedirect(request, {
+      error: "OAuth callback is missing required parameters.",
+    });
+  }
+
+  let platform = incoming.searchParams.get("platform") || "";
+  if (!platform) {
+    try {
+      const oauthState = await getOAuthStateByState(normalizedState);
+      platform = oauthState?.platform || "";
+    } catch {
+      platform = "";
+    }
+  }
+
+  if (!platform) {
+    return socialChannelsRedirect(request, {
+      error: "Missing OAuth platform. Please reconnect the channel.",
+    });
+  }
+
+  return socialChannelsRedirect(request, {
+    platform,
+    ...(code && state
+      ? { code: normalizedCode, state: normalizedState }
+      : { oauth_token: normalizedState, oauth_verifier: normalizedCode }),
+  });
+}
 
 export async function POST(
   request: NextRequest,

--- a/src/app/api/social/accounts/callback/route.ts
+++ b/src/app/api/social/accounts/callback/route.ts
@@ -16,6 +16,8 @@ import type { SocialPlatform } from "@/lib/db/schema";
 import type { PageInfo } from "@/lib/social/provider-interface";
 import { logger } from "@/utils/logger";
 
+const OAUTH_CALLBACK_COOKIE = "social_oauth_cb";
+
 interface CallbackRequest {
   platform: string;
   code: string;
@@ -76,6 +78,9 @@ export async function GET(
   let platform = incoming.searchParams.get("platform") || "";
   if (!platform) {
     try {
+      // Intentionally does not check expiration — the actual consume in the
+      // POST handler will reject expired states. This lookup only resolves the
+      // platform for the redirect.
       const oauthState = await getOAuthStateByState(normalizedState);
       platform = oauthState?.platform || "";
     } catch {
@@ -89,12 +94,25 @@ export async function GET(
     });
   }
 
-  return socialChannelsRedirect(request, {
+  // Store callback params in a short-lived HTTP-only cookie instead of
+  // forwarding raw code/state as query parameters (prevents leaking the
+  // authorization code via URL bar, browser history, and Referer headers).
+  const callbackData = JSON.stringify({
     platform,
-    ...(code && state
-      ? { code: normalizedCode, state: normalizedState }
-      : { oauth_token: normalizedState, oauth_verifier: normalizedCode }),
+    code: normalizedCode,
+    state: normalizedState,
   });
+  const redirectUrl = new URL("/social/channels", request.url);
+  redirectUrl.searchParams.set("oauth_pending", "1");
+  const response = NextResponse.redirect(redirectUrl);
+  response.cookies.set(OAUTH_CALLBACK_COOKIE, callbackData, {
+    httpOnly: true,
+    secure: incoming.protocol === "https:",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 120, // 2 minutes — enough to complete the redirect round-trip
+  });
+  return response;
 }
 
 export async function POST(

--- a/src/app/api/social/accounts/connect/route.ts
+++ b/src/app/api/social/accounts/connect/route.ts
@@ -5,12 +5,18 @@ import { withApiPermission } from "@/lib/studio/authz";
 import "@/lib/social/runtime-bootstrap";
 import { getProvider, isProviderRegistered } from "@/lib/social/provider-registry";
 import { getSocialPlanLimits, quotaExceededPayload } from "@/lib/social/limits";
-import { countActiveSocialAccounts, createOAuthState } from "@/lib/social/repository";
+import {
+  countActiveSocialAccounts,
+  createOAuthState,
+  getSocialAccount,
+  SocialAccountNotFoundError,
+} from "@/lib/social/repository";
 import type { SocialPlatform } from "@/lib/db/schema";
 import { logger } from "@/utils/logger";
 
 interface ConnectRequest {
   platform: string;
+  accountId?: string;
 }
 
 interface ConnectResponse {
@@ -59,19 +65,38 @@ export async function POST(
       );
     }
 
-    const limits = getSocialPlanLimits(result.session.planTier);
-    const activeChannels = await countActiveSocialAccounts(
-      result.session.workspace.id,
-    );
-    if (activeChannels >= limits.channels) {
-      return NextResponse.json(
-        quotaExceededPayload({
-          section: "channels",
-          current: activeChannels,
-          limit: limits.channels,
-        }),
-        { status: 402 },
+    let reconnectAccountId: string | null = null;
+    if (body.accountId?.trim()) {
+      const reconnectAccount = await getSocialAccount(
+        result.session.workspace.id,
+        body.accountId.trim(),
       );
+      if (reconnectAccount.platform !== body.platform) {
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              "Reconnect platform does not match the selected channel platform.",
+          },
+          { status: 400 },
+        );
+      }
+      reconnectAccountId = reconnectAccount.id;
+    } else {
+      const limits = getSocialPlanLimits(result.session.planTier);
+      const activeChannels = await countActiveSocialAccounts(
+        result.session.workspace.id,
+      );
+      if (activeChannels >= limits.channels) {
+        return NextResponse.json(
+          quotaExceededPayload({
+            section: "channels",
+            current: activeChannels,
+            limit: limits.channels,
+          }),
+          { status: 402 },
+        );
+      }
     }
 
     const provider = getProvider(body.platform);
@@ -89,7 +114,10 @@ export async function POST(
       platform: body.platform as SocialPlatform,
       state: authResult.state,
       codeVerifier: authResult.codeVerifier,
-      metadata: { callbackUrl },
+      metadata: {
+        callbackUrl,
+        ...(reconnectAccountId ? { reconnectAccountId } : {}),
+      },
       expiresAt: new Date(Date.now() + OAUTH_STATE_TTL_MS),
     });
     logger.info("system", "Social connect OAuth flow initialized", {
@@ -103,6 +131,13 @@ export async function POST(
 
     return NextResponse.json({ success: true, authUrl: authResult.url });
   } catch (error) {
+    if (error instanceof SocialAccountNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
     return NextResponse.json(
       {
         success: false,

--- a/src/app/api/social/accounts/route.ts
+++ b/src/app/api/social/accounts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isDatabaseConfigured } from "@/lib/db";
-import { withApiPermission, authzErrorResponse } from "@/lib/studio/authz";
+import { withApiPermission } from "@/lib/studio/authz";
 import { listSocialAccounts } from "@/lib/social/repository";
 
 interface AccountsResponse {

--- a/src/app/api/social/accounts/select-page/route.ts
+++ b/src/app/api/social/accounts/select-page/route.ts
@@ -6,6 +6,7 @@ import { getProvider } from "@/lib/social/provider-registry";
 import { decryptToken, encryptToken } from "@/lib/social/crypto";
 import {
   consumeOAuthSelectionSession,
+  getOAuthSelectionSession,
   upsertSocialAccount,
   OAuthSelectionSessionNotFoundError,
   OAuthSelectionSessionExpiredError,
@@ -70,7 +71,7 @@ export async function POST(
       );
     }
 
-    const selectionSession = await consumeOAuthSelectionSession({
+    const selectionSession = await getOAuthSelectionSession({
       selectionSessionId: body.selectionSessionId,
       workspaceId: result.session.workspace.id,
       platform: body.platform as SocialPlatform,
@@ -88,10 +89,17 @@ export async function POST(
       );
     }
 
+    // Consume only after selection is validated so users can retry selection safely.
+    const consumedSession = await consumeOAuthSelectionSession({
+      selectionSessionId: body.selectionSessionId,
+      workspaceId: result.session.workspace.id,
+      platform: body.platform as SocialPlatform,
+    });
+
     // Use page-specific token if available, otherwise use the original token
     const accessTokenEncrypted = selectedPage.accessToken
       ? encryptToken(selectedPage.accessToken)
-      : selectionSession.accessTokenEncrypted;
+      : consumedSession.accessTokenEncrypted;
 
     const account = await upsertSocialAccount({
       workspaceId: result.session.workspace.id,
@@ -101,9 +109,9 @@ export async function POST(
       username: selectedPage.username,
       avatarUrl: selectedPage.picture,
       accessTokenEncrypted,
-      refreshTokenEncrypted: selectionSession.refreshTokenEncrypted ?? undefined,
-      accessTokenSecret: selectionSession.accessTokenSecret ?? undefined,
-      tokenExpiresAt: selectionSession.tokenExpiresAt ?? undefined,
+      refreshTokenEncrypted: consumedSession.refreshTokenEncrypted ?? undefined,
+      accessTokenSecret: consumedSession.accessTokenSecret ?? undefined,
+      tokenExpiresAt: consumedSession.tokenExpiresAt ?? undefined,
       createdByUserId: result.session.user.id,
     });
     logger.info("system", "Social page selection completed", {

--- a/src/app/api/social/automation/rules/[ruleId]/__tests__/route.test.ts
+++ b/src/app/api/social/automation/rules/[ruleId]/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockWithApiPermission = vi.fn();
+const mockGetAutomationRule = vi.fn();
+const mockUpdateAutomationRule = vi.fn();
+const mockDeleteAutomationRule = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json({ success: false, error: result.error }, { status: result.status }),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  getAutomationRule: (...args: unknown[]) => mockGetAutomationRule(...args),
+  updateAutomationRule: (...args: unknown[]) => mockUpdateAutomationRule(...args),
+  deleteAutomationRule: (...args: unknown[]) => mockDeleteAutomationRule(...args),
+  AutomationRuleNotFoundError: class extends Error {
+    constructor(id?: string) {
+      super(`Automation rule "${id}" not found.`);
+      this.name = "AutomationRuleNotFoundError";
+    }
+  },
+}));
+
+const mockSession = {
+  user: { id: "user_1", name: "Test", email: "test@example.com" },
+  workspace: { id: "ws_1", organizationId: "org_1" },
+  role: "owner" as const,
+  planTier: "pro" as const,
+  permissions: ["social:view", "social:publish"],
+};
+
+function authorized() {
+  mockWithApiPermission.mockResolvedValue({
+    authorized: true,
+    session: mockSession,
+  });
+}
+
+function request(url: string, init?: RequestInit): NextRequest {
+  return new NextRequest(url, init);
+}
+
+describe("/api/social/automation/rules/[ruleId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads rule", async () => {
+    authorized();
+    mockGetAutomationRule.mockResolvedValue({ id: "arule_1", name: "Rule 1" });
+
+    const { GET } = await import("../route");
+    const response = await GET(
+      request("http://localhost:3000/api/social/automation/rules/arule_1"),
+      { params: Promise.resolve({ ruleId: "arule_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockGetAutomationRule).toHaveBeenCalledWith("ws_1", "arule_1");
+  });
+
+  it("updates rule", async () => {
+    authorized();
+    mockUpdateAutomationRule.mockResolvedValue({
+      id: "arule_1",
+      name: "Rule 1",
+      enabled: false,
+    });
+
+    const { PATCH } = await import("../route");
+    const response = await PATCH(
+      request("http://localhost:3000/api/social/automation/rules/arule_1", {
+        method: "PATCH",
+        body: JSON.stringify({ enabled: false }),
+      }),
+      { params: Promise.resolve({ ruleId: "arule_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockUpdateAutomationRule).toHaveBeenCalledWith(
+      "ws_1",
+      "arule_1",
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("deletes rule", async () => {
+    authorized();
+    mockDeleteAutomationRule.mockResolvedValue({});
+
+    const { DELETE } = await import("../route");
+    const response = await DELETE(
+      request("http://localhost:3000/api/social/automation/rules/arule_1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ ruleId: "arule_1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteAutomationRule).toHaveBeenCalledWith("ws_1", "arule_1");
+  });
+});

--- a/src/app/api/social/automation/rules/[ruleId]/route.ts
+++ b/src/app/api/social/automation/rules/[ruleId]/route.ts
@@ -8,15 +8,12 @@ import {
   AutomationRuleNotFoundError,
 } from "@/lib/social/repository";
 import { validateAutomationRulePayload } from "@/lib/social/automation-guards";
+import { isRecord } from "@/lib/social/utils";
 
 interface RuleResponse {
   success: boolean;
   rule?: Awaited<ReturnType<typeof getAutomationRule>>;
   error?: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function readString(value: unknown): string | undefined {

--- a/src/app/api/social/automation/rules/[ruleId]/route.ts
+++ b/src/app/api/social/automation/rules/[ruleId]/route.ts
@@ -1,0 +1,261 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import {
+  deleteAutomationRule,
+  getAutomationRule,
+  updateAutomationRule,
+  AutomationRuleNotFoundError,
+} from "@/lib/social/repository";
+import { validateAutomationRulePayload } from "@/lib/social/automation-guards";
+
+interface RuleResponse {
+  success: boolean;
+  rule?: Awaited<ReturnType<typeof getAutomationRule>>;
+  error?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readOptionalInt(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isInteger(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ ruleId: string }> },
+): Promise<NextResponse<RuleResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const auth = await withApiPermission(request, {
+      route: "/api/social/automation/rules",
+      permission: "social:view",
+    });
+    if (!auth.authorized) {
+      return auth.response;
+    }
+
+    const { ruleId } = await params;
+    const rule = await getAutomationRule(auth.session.workspace.id, ruleId);
+    return NextResponse.json({ success: true, rule });
+  } catch (error) {
+    if (error instanceof AutomationRuleNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to load automation rule",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ ruleId: string }> },
+): Promise<NextResponse<RuleResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const auth = await withApiPermission(request, {
+      route: "/api/social/automation/rules",
+      permission: "social:publish",
+    });
+    if (!auth.authorized) {
+      return auth.response;
+    }
+
+    const body = (await request.json()) as unknown;
+    if (!isRecord(body)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid JSON body." },
+        { status: 400 },
+      );
+    }
+
+    const { ruleId } = await params;
+    const existingRule = await getAutomationRule(auth.session.workspace.id, ruleId);
+    const name = body.name === null ? "" : readString(body.name);
+    const triggerSource = readString(body.triggerSource);
+    const repeatIntervalSeconds = readOptionalInt(body.repeatIntervalSeconds);
+    const maxRuns = readOptionalInt(body.maxRuns);
+    const actionType = readString(body.actionType);
+    const actionConfig =
+      body.actionConfig === null
+        ? null
+        : isRecord(body.actionConfig)
+          ? body.actionConfig
+          : undefined;
+    const triggerFilters =
+      body.triggerFilters === null
+        ? null
+        : isRecord(body.triggerFilters)
+          ? body.triggerFilters
+          : undefined;
+
+    if (body.enabled !== undefined && typeof body.enabled !== "boolean") {
+      return NextResponse.json(
+        { success: false, error: "enabled must be a boolean." },
+        { status: 400 },
+      );
+    }
+    if (
+      body.repeatIntervalSeconds !== undefined &&
+      readOptionalInt(body.repeatIntervalSeconds) === undefined
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "repeatIntervalSeconds must be an integer or null.",
+        },
+        { status: 400 },
+      );
+    }
+    if (body.maxRuns !== undefined && readOptionalInt(body.maxRuns) === undefined) {
+      return NextResponse.json(
+        { success: false, error: "maxRuns must be an integer or null." },
+        { status: 400 },
+      );
+    }
+    if (body.totalRuns !== undefined && readOptionalInt(body.totalRuns) === undefined) {
+      return NextResponse.json(
+        { success: false, error: "totalRuns must be an integer when provided." },
+        { status: 400 },
+      );
+    }
+    if (body.name !== undefined && !name) {
+      return NextResponse.json(
+        { success: false, error: "name must be a non-empty string when provided." },
+        { status: 400 },
+      );
+    }
+
+    const guardError = validateAutomationRulePayload({
+      triggerSource: triggerSource ?? existingRule.triggerSource,
+      repeatIntervalSeconds:
+        repeatIntervalSeconds === undefined
+          ? existingRule.repeatIntervalSeconds
+          : repeatIntervalSeconds,
+      maxRuns: maxRuns === undefined ? existingRule.maxRuns : maxRuns,
+      triggerFilters:
+        triggerFilters === undefined
+          ? (existingRule.triggerFilters as Record<string, unknown> | null)
+          : triggerFilters,
+      actionType: actionType ?? existingRule.actionType,
+      actionConfig:
+        actionConfig === undefined
+          ? (existingRule.actionConfig as Record<string, unknown> | null)
+          : actionConfig,
+    });
+    if (guardError) {
+      return NextResponse.json(
+        { success: false, error: guardError },
+        { status: 400 },
+      );
+    }
+
+    const rule = await updateAutomationRule(auth.session.workspace.id, ruleId, {
+      ...(name ? { name } : {}),
+      ...(triggerSource !== undefined ? { triggerSource } : {}),
+      ...(triggerFilters !== undefined ? { triggerFilters } : {}),
+      ...(repeatIntervalSeconds !== undefined ? { repeatIntervalSeconds } : {}),
+      ...(maxRuns !== undefined ? { maxRuns } : {}),
+      ...(body.totalRuns !== undefined
+        ? { totalRuns: readOptionalInt(body.totalRuns) ?? undefined }
+        : {}),
+      ...(actionType !== undefined ? { actionType } : {}),
+      ...(actionConfig !== undefined ? { actionConfig } : {}),
+      ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
+    });
+
+    return NextResponse.json({ success: true, rule });
+  } catch (error) {
+    if (error instanceof AutomationRuleNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to update automation rule",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ ruleId: string }> },
+): Promise<NextResponse<{ success: boolean; error?: string }>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const auth = await withApiPermission(request, {
+      route: "/api/social/automation/rules",
+      permission: "social:publish",
+    });
+    if (!auth.authorized) {
+      return auth.response;
+    }
+
+    const { ruleId } = await params;
+    await deleteAutomationRule(auth.session.workspace.id, ruleId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof AutomationRuleNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to delete automation rule",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/automation/rules/route.ts
+++ b/src/app/api/social/automation/rules/route.ts
@@ -8,6 +8,7 @@ import {
   listAutomationRules,
 } from "@/lib/social/repository";
 import { validateAutomationRulePayload } from "@/lib/social/automation-guards";
+import { isRecord } from "@/lib/social/utils";
 
 interface RulesGetResponse {
   success: boolean;
@@ -20,10 +21,6 @@ interface RulesPostResponse {
   rule?: Awaited<ReturnType<typeof createAutomationRule>>;
   initialTask?: Awaited<ReturnType<typeof createAutomationTask>>;
   error?: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 function readString(value: unknown): string | undefined {

--- a/src/app/api/social/automation/tasks/[taskId]/__tests__/route.test.ts
+++ b/src/app/api/social/automation/tasks/[taskId]/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockWithApiPermission = vi.fn();
+const mockGetAutomationTask = vi.fn();
+const mockUpdateAutomationTask = vi.fn();
+const mockDeleteAutomationTask = vi.fn();
+const mockSocialPostBelongsToWorkspace = vi.fn();
+const mockSocialEventBelongsToWorkspace = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json({ success: false, error: result.error }, { status: result.status }),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  getAutomationTask: (...args: unknown[]) => mockGetAutomationTask(...args),
+  updateAutomationTask: (...args: unknown[]) => mockUpdateAutomationTask(...args),
+  deleteAutomationTask: (...args: unknown[]) => mockDeleteAutomationTask(...args),
+  socialPostBelongsToWorkspace: (...args: unknown[]) =>
+    mockSocialPostBelongsToWorkspace(...args),
+  socialEventBelongsToWorkspace: (...args: unknown[]) =>
+    mockSocialEventBelongsToWorkspace(...args),
+  AutomationTaskNotFoundError: class extends Error {
+    constructor(id?: string) {
+      super(`Automation task "${id}" not found.`);
+      this.name = "AutomationTaskNotFoundError";
+    }
+  },
+}));
+
+const mockSession = {
+  user: { id: "user_1", name: "Test", email: "test@example.com" },
+  workspace: { id: "ws_1", organizationId: "org_1" },
+  role: "owner" as const,
+  planTier: "pro" as const,
+  permissions: ["social:view", "social:publish"],
+};
+
+function authorized() {
+  mockWithApiPermission.mockResolvedValue({
+    authorized: true,
+    session: mockSession,
+  });
+}
+
+function request(url: string, init?: RequestInit): NextRequest {
+  return new NextRequest(url, init);
+}
+
+describe("/api/social/automation/tasks/[taskId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAutomationTask.mockResolvedValue({
+      id: "atask_1",
+      workspaceId: "ws_1",
+      runIndex: 1,
+      input: {},
+    });
+    mockSocialPostBelongsToWorkspace.mockResolvedValue(true);
+    mockSocialEventBelongsToWorkspace.mockResolvedValue(true);
+  });
+
+  it("loads task", async () => {
+    authorized();
+    const { GET } = await import("../route");
+    const response = await GET(
+      request("http://localhost:3000/api/social/automation/tasks/atask_1"),
+      { params: Promise.resolve({ taskId: "atask_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockGetAutomationTask).toHaveBeenCalledWith("ws_1", "atask_1");
+  });
+
+  it("updates task state", async () => {
+    authorized();
+    mockUpdateAutomationTask.mockResolvedValue({
+      id: "atask_1",
+      workspaceId: "ws_1",
+      state: "cancelled",
+    });
+
+    const { PATCH } = await import("../route");
+    const response = await PATCH(
+      request("http://localhost:3000/api/social/automation/tasks/atask_1", {
+        method: "PATCH",
+        body: JSON.stringify({ state: "cancelled" }),
+      }),
+      { params: Promise.resolve({ taskId: "atask_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockUpdateAutomationTask).toHaveBeenCalledWith(
+      "ws_1",
+      "atask_1",
+      expect.objectContaining({ state: "cancelled" }),
+    );
+  });
+
+  it("deletes task", async () => {
+    authorized();
+    mockDeleteAutomationTask.mockResolvedValue({});
+
+    const { DELETE } = await import("../route");
+    const response = await DELETE(
+      request("http://localhost:3000/api/social/automation/tasks/atask_1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ taskId: "atask_1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteAutomationTask).toHaveBeenCalledWith("ws_1", "atask_1");
+  });
+});

--- a/src/app/api/social/automation/tasks/[taskId]/route.ts
+++ b/src/app/api/social/automation/tasks/[taskId]/route.ts
@@ -11,15 +11,12 @@ import {
 } from "@/lib/social/repository";
 import type { AutomationTaskState } from "@/lib/db/schema";
 import { validateAutomationTaskPayload } from "@/lib/social/automation-guards";
+import { isRecord } from "@/lib/social/utils";
 
 interface TaskResponse {
   success: boolean;
   task?: Awaited<ReturnType<typeof getAutomationTask>>;
   error?: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function readOptionalDate(value: unknown): Date | null | undefined {

--- a/src/app/api/social/automation/tasks/[taskId]/route.ts
+++ b/src/app/api/social/automation/tasks/[taskId]/route.ts
@@ -1,0 +1,333 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+import {
+  deleteAutomationTask,
+  getAutomationTask,
+  updateAutomationTask,
+  AutomationTaskNotFoundError,
+  socialEventBelongsToWorkspace,
+  socialPostBelongsToWorkspace,
+} from "@/lib/social/repository";
+import type { AutomationTaskState } from "@/lib/db/schema";
+import { validateAutomationTaskPayload } from "@/lib/social/automation-guards";
+
+interface TaskResponse {
+  success: boolean;
+  task?: Awaited<ReturnType<typeof getAutomationTask>>;
+  error?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readOptionalDate(value: unknown): Date | null | undefined {
+  if (value === null) return null;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  }
+  return undefined;
+}
+
+function readOptionalInt(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isInteger(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function readTaskState(value: unknown): AutomationTaskState | undefined {
+  if (
+    value === "pending" ||
+    value === "claimed" ||
+    value === "succeeded" ||
+    value === "failed" ||
+    value === "cancelled"
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> },
+): Promise<NextResponse<TaskResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const auth = await withApiPermission(request, {
+      route: "/api/social/automation/tasks",
+      permission: "social:view",
+    });
+    if (!auth.authorized) {
+      return auth.response;
+    }
+
+    const { taskId } = await params;
+    const task = await getAutomationTask(auth.session.workspace.id, taskId);
+    return NextResponse.json({ success: true, task });
+  } catch (error) {
+    if (error instanceof AutomationTaskNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to load automation task",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> },
+): Promise<NextResponse<TaskResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const auth = await withApiPermission(request, {
+      route: "/api/social/automation/tasks",
+      permission: "social:publish",
+    });
+    if (!auth.authorized) {
+      return auth.response;
+    }
+
+    const body = (await request.json()) as unknown;
+    if (!isRecord(body)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid JSON body." },
+        { status: 400 },
+      );
+    }
+
+    const { taskId } = await params;
+    const existing = await getAutomationTask(auth.session.workspace.id, taskId);
+
+    if (body.state !== undefined && !readTaskState(body.state)) {
+      return NextResponse.json(
+        { success: false, error: "state is invalid." },
+        { status: 400 },
+      );
+    }
+    if (
+      body.input !== undefined &&
+      body.input !== null &&
+      !isRecord(body.input)
+    ) {
+      return NextResponse.json(
+        { success: false, error: "input must be an object." },
+        { status: 400 },
+      );
+    }
+    if (
+      body.result !== undefined &&
+      body.result !== null &&
+      !isRecord(body.result)
+    ) {
+      return NextResponse.json(
+        { success: false, error: "result must be an object." },
+        { status: 400 },
+      );
+    }
+    if (
+      body.attemptCount !== undefined &&
+      readOptionalInt(body.attemptCount) === undefined
+    ) {
+      return NextResponse.json(
+        { success: false, error: "attemptCount must be an integer." },
+        { status: 400 },
+      );
+    }
+
+    const nextRunIndex = readOptionalInt(body.runIndex) ?? existing.runIndex;
+    const guardError = validateAutomationTaskPayload({
+      runIndex: nextRunIndex,
+      payload:
+        body.input === undefined
+          ? (existing.input as Record<string, unknown> | null | undefined)
+          : body.input === null
+            ? null
+            : (body.input as Record<string, unknown>),
+    });
+    if (guardError) {
+      return NextResponse.json(
+        { success: false, error: guardError },
+        { status: 400 },
+      );
+    }
+
+    if (body.sourcePostId !== undefined && body.sourcePostId !== null) {
+      if (typeof body.sourcePostId !== "string" || !body.sourcePostId.trim()) {
+        return NextResponse.json(
+          { success: false, error: "sourcePostId must be a non-empty string." },
+          { status: 400 },
+        );
+      }
+      const owned = await socialPostBelongsToWorkspace(
+        auth.session.workspace.id,
+        body.sourcePostId.trim(),
+      );
+      if (!owned) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: "sourcePostId does not belong to this workspace.",
+          },
+          { status: 404 },
+        );
+      }
+    }
+
+    if (body.sourceEventId !== undefined && body.sourceEventId !== null) {
+      if (typeof body.sourceEventId !== "string" || !body.sourceEventId.trim()) {
+        return NextResponse.json(
+          { success: false, error: "sourceEventId must be a non-empty string." },
+          { status: 400 },
+        );
+      }
+      const owned = await socialEventBelongsToWorkspace(
+        auth.session.workspace.id,
+        body.sourceEventId.trim(),
+      );
+      if (!owned) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: "sourceEventId does not belong to this workspace.",
+          },
+          { status: 404 },
+        );
+      }
+    }
+
+    const task = await updateAutomationTask(auth.session.workspace.id, taskId, {
+      ...(body.state !== undefined ? { state: readTaskState(body.state) } : {}),
+      ...(body.dueAt !== undefined ? { dueAt: readOptionalDate(body.dueAt) } : {}),
+      ...(body.claimToken !== undefined
+        ? { claimToken: typeof body.claimToken === "string" ? body.claimToken : null }
+        : {}),
+      ...(body.claimedAt !== undefined
+        ? { claimedAt: readOptionalDate(body.claimedAt) }
+        : {}),
+      ...(body.claimedBy !== undefined
+        ? { claimedBy: typeof body.claimedBy === "string" ? body.claimedBy : null }
+        : {}),
+      ...(body.attemptCount !== undefined
+        ? { attemptCount: readOptionalInt(body.attemptCount) }
+        : {}),
+      ...(body.input !== undefined
+        ? { input: body.input === null ? null : (body.input as Record<string, unknown>) }
+        : {}),
+      ...(body.result !== undefined
+        ? { result: body.result === null ? null : (body.result as Record<string, unknown>) }
+        : {}),
+      ...(body.errorMessage !== undefined
+        ? {
+            errorMessage:
+              typeof body.errorMessage === "string" ? body.errorMessage : null,
+          }
+        : {}),
+      ...(body.sourcePostId !== undefined
+        ? {
+            sourcePostId:
+              typeof body.sourcePostId === "string"
+                ? body.sourcePostId.trim()
+                : null,
+          }
+        : {}),
+      ...(body.sourceEventId !== undefined
+        ? {
+            sourceEventId:
+              typeof body.sourceEventId === "string"
+                ? body.sourceEventId.trim()
+                : null,
+          }
+        : {}),
+      ...(body.completedAt !== undefined
+        ? { completedAt: readOptionalDate(body.completedAt) }
+        : {}),
+    });
+
+    return NextResponse.json({ success: true, task });
+  } catch (error) {
+    if (error instanceof AutomationTaskNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to update automation task",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> },
+): Promise<NextResponse<{ success: boolean; error?: string }>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const auth = await withApiPermission(request, {
+      route: "/api/social/automation/tasks",
+      permission: "social:publish",
+    });
+    if (!auth.authorized) {
+      return auth.response;
+    }
+
+    const { taskId } = await params;
+    await deleteAutomationTask(auth.session.workspace.id, taskId);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof AutomationTaskNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to delete automation task",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/social/automation/tasks/route.ts
+++ b/src/app/api/social/automation/tasks/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/social/repository";
 import type { AutomationTaskState } from "@/lib/db/schema";
 import { validateAutomationTaskPayload } from "@/lib/social/automation-guards";
+import { isRecord } from "@/lib/social/utils";
 
 interface TasksGetResponse {
   success: boolean;
@@ -23,10 +24,6 @@ interface TasksPostResponse {
   success: boolean;
   task?: Awaited<ReturnType<typeof createAutomationTask>>;
   error?: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 function readString(value: unknown): string | undefined {

--- a/src/app/api/social/events/[eventId]/read/route.ts
+++ b/src/app/api/social/events/[eventId]/read/route.ts
@@ -2,9 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { isDatabaseConfigured } from "@/lib/db";
 import { withApiPermission } from "@/lib/studio/authz";
 import {
+  markSocialEventUnread,
   markSocialEventRead,
   markSocialEventReadForUser,
   SocialEventNotFoundError,
+  SocialEventReadNotFoundError,
+  unmarkSocialEventReadForUser,
 } from "@/lib/social/repository";
 
 interface ReadEventResponse {
@@ -51,7 +54,64 @@ export async function POST(
 
     return NextResponse.json({ success: true, event });
   } catch (error) {
-    if (error instanceof SocialEventNotFoundError) {
+    if (
+      error instanceof SocialEventNotFoundError ||
+      error instanceof SocialEventReadNotFoundError
+    ) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to update social event",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ eventId: string }> },
+): Promise<NextResponse<ReadEventResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/events",
+      permission: "social:view",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { eventId } = await params;
+    const url = new URL(request.url);
+    const perUserReads = parseBoolean(url.searchParams.get("perUserReads"));
+    const event = perUserReads
+      ? await unmarkSocialEventReadForUser({
+          workspaceId: result.session.workspace.id,
+          eventId,
+          userId: result.session.user.id,
+        })
+      : await markSocialEventUnread(result.session.workspace.id, eventId);
+
+    return NextResponse.json({ success: true, event });
+  } catch (error) {
+    if (
+      error instanceof SocialEventNotFoundError ||
+      error instanceof SocialEventReadNotFoundError
+    ) {
       return NextResponse.json(
         { success: false, error: error.message },
         { status: 404 },

--- a/src/app/api/social/events/__tests__/route.test.ts
+++ b/src/app/api/social/events/__tests__/route.test.ts
@@ -4,6 +4,10 @@ import { NextRequest, NextResponse } from "next/server";
 const mockWithApiPermission = vi.fn();
 const mockListSocialEvents = vi.fn();
 const mockMarkSocialEventRead = vi.fn();
+const mockListSocialEventReadsForUser = vi.fn();
+const mockMarkSocialEventReadForUser = vi.fn();
+const mockMarkSocialEventUnread = vi.fn();
+const mockUnmarkSocialEventReadForUser = vi.fn();
 
 vi.mock("@/lib/db", () => ({
   isDatabaseConfigured: vi.fn(() => true),
@@ -17,11 +21,24 @@ vi.mock("@/lib/studio/authz", () => ({
 
 vi.mock("@/lib/social/repository", () => ({
   listSocialEvents: (...args: unknown[]) => mockListSocialEvents(...args),
+  listSocialEventReadsForUser: (...args: unknown[]) =>
+    mockListSocialEventReadsForUser(...args),
   markSocialEventRead: (...args: unknown[]) => mockMarkSocialEventRead(...args),
+  markSocialEventReadForUser: (...args: unknown[]) =>
+    mockMarkSocialEventReadForUser(...args),
+  markSocialEventUnread: (...args: unknown[]) => mockMarkSocialEventUnread(...args),
+  unmarkSocialEventReadForUser: (...args: unknown[]) =>
+    mockUnmarkSocialEventReadForUser(...args),
   SocialEventNotFoundError: class extends Error {
     constructor(id?: string) {
       super(`Social event "${id}" not found.`);
       this.name = "SocialEventNotFoundError";
+    }
+  },
+  SocialEventReadNotFoundError: class extends Error {
+    constructor(id?: string) {
+      super(`Social event read "${id}" not found.`);
+      this.name = "SocialEventReadNotFoundError";
     }
   },
 }));
@@ -55,6 +72,7 @@ function request(url: string, init?: RequestInit): NextRequest {
 describe("/api/social/events", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockListSocialEventReadsForUser.mockResolvedValue([]);
   });
 
   it("returns 401 for unauthenticated requests", async () => {
@@ -109,6 +127,25 @@ describe("/api/social/events/[eventId]/read", () => {
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
     expect(mockMarkSocialEventRead).toHaveBeenCalledWith("ws_1", "sevt_1");
+  });
+
+  it("marks an event as unread", async () => {
+    authorized();
+    mockMarkSocialEventUnread.mockResolvedValue({
+      id: "sevt_1",
+      readAt: null,
+    });
+
+    const { DELETE } = await import("../[eventId]/read/route");
+    const response = await DELETE(
+      request("http://localhost:3000/api/social/events/sevt_1/read", { method: "DELETE" }),
+      { params: Promise.resolve({ eventId: "sevt_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockMarkSocialEventUnread).toHaveBeenCalledWith("ws_1", "sevt_1");
   });
 
   it("returns 404 when event does not exist", async () => {

--- a/src/app/api/social/internal/automation-dispatch/route.ts
+++ b/src/app/api/social/internal/automation-dispatch/route.ts
@@ -16,6 +16,7 @@ import {
   validateAutomationRulePayload,
   validateAutomationTaskPayload,
 } from "@/lib/social/automation-guards";
+import { isRecord } from "@/lib/social/utils";
 import { logger } from "@/utils/logger";
 
 interface AutomationDispatchResponse {
@@ -46,10 +47,6 @@ function getBatchSize(request: NextRequest): number {
     process.env.SOCIAL_AUTOMATION_DISPATCH_BATCH_SIZE ?? null,
   );
   return Math.min(MAX_BATCH_SIZE, queryBatch ?? envBatch ?? DEFAULT_BATCH_SIZE);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 function readString(value: unknown): string | undefined {

--- a/src/app/api/social/notifications/preferences/route.ts
+++ b/src/app/api/social/notifications/preferences/route.ts
@@ -6,6 +6,7 @@ import {
   SocialNotificationPreferencesNotFoundError,
   upsertSocialNotificationPreferences,
 } from "@/lib/social/repository";
+import { isRecord } from "@/lib/social/utils";
 
 interface NotificationPreferencesResponse {
   success: boolean;
@@ -27,10 +28,6 @@ interface NotificationPreferencesBody {
   webhookEnabled?: boolean;
   muteAll?: boolean;
   preferences?: Record<string, unknown> | null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 function isBooleanOrUndefined(value: unknown): value is boolean | undefined {

--- a/src/app/api/social/posts/[postId]/publish/route.ts
+++ b/src/app/api/social/posts/[postId]/publish/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/social/repository";
 import { resolveWorkflowRunRef } from "@/lib/social/workflow-utils";
 import { emitSocialEvent } from "@/lib/social/events";
+import { isRecord } from "@/lib/social/utils";
 import { start } from "workflow/api";
 import {
   publishPostChainWorkflow,
@@ -28,10 +29,6 @@ interface PublishResponse {
 
 const PUBLISHABLE_STATES = new Set(["draft", "failed"]);
 const DISPATCH_RETRY_DELAY_MS = 5 * 60 * 1000;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;

--- a/src/app/api/social/posts/route.ts
+++ b/src/app/api/social/posts/route.ts
@@ -8,6 +8,7 @@ import {
   listSocialPosts,
 } from "@/lib/social/repository";
 import type { SocialPostStatus } from "@/lib/db/schema";
+import { isRecord } from "@/lib/social/utils";
 import { logger } from "@/utils/logger";
 
 interface PostsGetResponse {
@@ -45,10 +46,6 @@ interface PostsPostResponse {
   error?: string;
   code?: string;
   billingUrl?: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 function readString(value: unknown): string | undefined {

--- a/src/app/api/social/webhooks/[webhookId]/__tests__/route.test.ts
+++ b/src/app/api/social/webhooks/[webhookId]/__tests__/route.test.ts
@@ -5,6 +5,9 @@ const mockWithApiPermission = vi.fn();
 const mockGetSocialWebhook = vi.fn();
 const mockDeleteSocialWebhook = vi.fn();
 const mockListWebhookDeliveriesForWorkspace = vi.fn();
+const mockUpdateSocialWebhook = vi.fn();
+const mockListSocialWebhookSubscriptions = vi.fn();
+const mockUpdateSocialWebhookSubscription = vi.fn();
 
 vi.mock("@/lib/db", () => ({
   isDatabaseConfigured: vi.fn(() => true),
@@ -19,12 +22,23 @@ vi.mock("@/lib/studio/authz", () => ({
 vi.mock("@/lib/social/repository", () => ({
   getSocialWebhook: (...args: unknown[]) => mockGetSocialWebhook(...args),
   deleteSocialWebhook: (...args: unknown[]) => mockDeleteSocialWebhook(...args),
+  updateSocialWebhook: (...args: unknown[]) => mockUpdateSocialWebhook(...args),
+  listSocialWebhookSubscriptions: (...args: unknown[]) =>
+    mockListSocialWebhookSubscriptions(...args),
+  updateSocialWebhookSubscription: (...args: unknown[]) =>
+    mockUpdateSocialWebhookSubscription(...args),
   listWebhookDeliveriesForWorkspace: (...args: unknown[]) =>
     mockListWebhookDeliveriesForWorkspace(...args),
   SocialWebhookNotFoundError: class extends Error {
     constructor(id?: string) {
       super(`Social webhook "${id}" not found.`);
       this.name = "SocialWebhookNotFoundError";
+    }
+  },
+  SocialWebhookSubscriptionNotFoundError: class extends Error {
+    constructor(id?: string) {
+      super(`Social webhook subscription "${id}" not found.`);
+      this.name = "SocialWebhookSubscriptionNotFoundError";
     }
   },
 }));
@@ -95,5 +109,35 @@ describe("/api/social/webhooks/[webhookId]", () => {
 
     expect(response.status).toBe(200);
     expect(mockDeleteSocialWebhook).toHaveBeenCalledWith("ws_1", "swh_1");
+  });
+
+  it("updates webhook enabled flag", async () => {
+    authorized();
+    mockUpdateSocialWebhook.mockResolvedValue({
+      id: "swh_1",
+      workspaceId: "ws_1",
+      targetUrl: "https://example.com/hook",
+      signingSecretEncrypted: "enc_secret",
+      enabled: false,
+      createdByUserId: "user_1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const { PATCH } = await import("../route");
+    const response = await PATCH(
+      req("http://localhost:3000/api/social/webhooks/swh_1", {
+        method: "PATCH",
+        body: JSON.stringify({ enabled: false }),
+      }),
+      { params: Promise.resolve({ webhookId: "swh_1" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockUpdateSocialWebhook).toHaveBeenCalledWith("ws_1", "swh_1", {
+      enabled: false,
+    });
   });
 });

--- a/src/app/api/social/webhooks/[webhookId]/route.ts
+++ b/src/app/api/social/webhooks/[webhookId]/route.ts
@@ -12,6 +12,7 @@ import {
   SocialWebhookSubscriptionNotFoundError,
 } from "@/lib/social/repository";
 import { validateMediaUrl } from "@/utils/urlValidation";
+import { isRecord } from "@/lib/social/utils";
 
 interface WebhookGetResponse {
   success: boolean;
@@ -69,10 +70,6 @@ function parsePositiveInteger(value: string | null): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function isValidWebhookTargetUrl(input: string): boolean {

--- a/src/app/api/social/webhooks/[webhookId]/route.ts
+++ b/src/app/api/social/webhooks/[webhookId]/route.ts
@@ -4,9 +4,14 @@ import { withApiPermission } from "@/lib/studio/authz";
 import {
   deleteSocialWebhook,
   getSocialWebhook,
+  listSocialWebhookSubscriptions,
   listWebhookDeliveriesForWorkspace,
   SocialWebhookNotFoundError,
+  updateSocialWebhook,
+  updateSocialWebhookSubscription,
+  SocialWebhookSubscriptionNotFoundError,
 } from "@/lib/social/repository";
+import { validateMediaUrl } from "@/utils/urlValidation";
 
 interface WebhookGetResponse {
   success: boolean;
@@ -28,6 +33,31 @@ interface WebhookDeleteResponse {
   error?: string;
 }
 
+interface WebhookPatchRequest {
+  targetUrl?: string;
+  enabled?: boolean;
+  subscription?: {
+    name?: string | null;
+    enabled?: boolean;
+    filters?: Record<string, unknown> | null;
+  };
+}
+
+interface WebhookPatchResponse {
+  success: boolean;
+  webhook?: {
+    id: string;
+    workspaceId: string;
+    targetUrl: string;
+    enabled: boolean;
+    createdByUserId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  subscription?: Record<string, unknown> | null;
+  error?: string;
+}
+
 function parseBooleanFilter(value: string | null): boolean | undefined {
   if (value === null) return undefined;
   if (value === "true") return true;
@@ -39,6 +69,25 @@ function parsePositiveInteger(value: string | null): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isValidWebhookTargetUrl(input: string): boolean {
+  try {
+    const parsed = new URL(input);
+    if (parsed.protocol !== "https:") {
+      return false;
+    }
+    if (parsed.username || parsed.password) {
+      return false;
+    }
+    return validateMediaUrl(input).valid;
+  } catch {
+    return false;
+  }
 }
 
 export async function GET(
@@ -152,6 +201,151 @@ export async function DELETE(
       {
         success: false,
         error: error instanceof Error ? error.message : "Failed to delete social webhook",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ webhookId: string }> },
+): Promise<NextResponse<WebhookPatchResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await withApiPermission(request, {
+      route: "/api/social/webhooks",
+      permission: "social:manage",
+    });
+
+    if (!result.authorized) {
+      return result.response;
+    }
+
+    const { webhookId } = await params;
+    const body = (await request.json()) as WebhookPatchRequest;
+
+    if (body.targetUrl !== undefined) {
+      if (!body.targetUrl.trim()) {
+        return NextResponse.json(
+          { success: false, error: "targetUrl must be a non-empty string." },
+          { status: 400 },
+        );
+      }
+      if (!isValidWebhookTargetUrl(body.targetUrl.trim())) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: "targetUrl must be a valid https URL.",
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (body.enabled !== undefined && typeof body.enabled !== "boolean") {
+      return NextResponse.json(
+        { success: false, error: "enabled must be a boolean." },
+        { status: 400 },
+      );
+    }
+
+    if (body.subscription !== undefined && !isRecord(body.subscription)) {
+      return NextResponse.json(
+        { success: false, error: "subscription must be an object." },
+        { status: 400 },
+      );
+    }
+    if (
+      body.subscription &&
+      body.subscription.enabled !== undefined &&
+      typeof body.subscription.enabled !== "boolean"
+    ) {
+      return NextResponse.json(
+        { success: false, error: "subscription.enabled must be a boolean." },
+        { status: 400 },
+      );
+    }
+    if (
+      body.subscription &&
+      body.subscription.filters !== undefined &&
+      body.subscription.filters !== null &&
+      !isRecord(body.subscription.filters)
+    ) {
+      return NextResponse.json(
+        { success: false, error: "subscription.filters must be an object." },
+        { status: 400 },
+      );
+    }
+
+    const updatedWebhook = await updateSocialWebhook(
+      result.session.workspace.id,
+      webhookId,
+      {
+        ...(body.targetUrl !== undefined
+          ? { targetUrl: body.targetUrl.trim() }
+          : {}),
+        ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
+      },
+    );
+
+    let updatedSubscription: Record<string, unknown> | null = null;
+    if (body.subscription) {
+      const subscriptions = await listSocialWebhookSubscriptions(
+        result.session.workspace.id,
+        { webhookId },
+      );
+      const primarySubscription = subscriptions[0];
+      if (!primarySubscription) {
+        throw new SocialWebhookSubscriptionNotFoundError();
+      }
+      updatedSubscription = await updateSocialWebhookSubscription(
+        result.session.workspace.id,
+        primarySubscription.id,
+        {
+          ...(body.subscription.name !== undefined
+            ? { name: body.subscription.name }
+            : {}),
+          ...(body.subscription.enabled !== undefined
+            ? { enabled: body.subscription.enabled }
+            : {}),
+          ...(body.subscription.filters !== undefined
+            ? { filters: body.subscription.filters }
+            : {}),
+        },
+      );
+    }
+
+    const { signingSecretEncrypted, ...safeWebhook } = updatedWebhook;
+    return NextResponse.json({
+      success: true,
+      webhook: safeWebhook,
+      subscription: updatedSubscription,
+    });
+  } catch (error) {
+    if (
+      error instanceof SocialWebhookNotFoundError ||
+      error instanceof SocialWebhookSubscriptionNotFoundError
+    ) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to update social webhook",
       },
       { status: 500 },
     );

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { FormEvent, useEffect, useState } from "react";
 import { authClient } from "@/lib/auth/client";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
@@ -20,7 +20,11 @@ function getErrorMessage(error: unknown, fallback: string): string {
 
 export default function SignInPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: session, isPending } = authClient.useSession();
+  const nextParam = searchParams.get("next");
+  const nextPath =
+    nextParam && nextParam.startsWith("/") ? nextParam : "/studio";
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -29,9 +33,9 @@ export default function SignInPage() {
 
   useEffect(() => {
     if (session?.user) {
-      router.replace("/studio");
+      router.replace(nextPath);
     }
-  }, [router, session]);
+  }, [router, session, nextPath]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -49,7 +53,7 @@ export default function SignInPage() {
         return;
       }
 
-      router.replace("/studio");
+      router.replace(nextPath);
     } catch (submitError) {
       setError(getErrorMessage(submitError, "Sign in failed."));
     } finally {

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, Suspense, useEffect, useState } from "react";
 import { authClient } from "@/lib/auth/client";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 
@@ -18,13 +18,25 @@ function getErrorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
+function isSafeRedirectPath(path: string): boolean {
+  return path.startsWith("/") && !path.startsWith("//") && !path.includes(":");
+}
+
 export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInForm />
+    </Suspense>
+  );
+}
+
+function SignInForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: session, isPending } = authClient.useSession();
   const nextParam = searchParams.get("next");
   const nextPath =
-    nextParam && nextParam.startsWith("/") ? nextParam : "/studio";
+    nextParam && isSafeRedirectPath(nextParam) ? nextParam : "/studio";
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/src/app/social/agents/page.tsx
+++ b/src/app/social/agents/page.tsx
@@ -189,7 +189,14 @@ export default function SocialAgentsPage() {
       </div>
 
       <div className="rounded-lg border bg-card p-4">
-        <h3 className="text-sm font-medium">Tasks</h3>
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium">Tasks</h3>
+          {tasks.length > 40 && (
+            <span className="text-xs text-muted-foreground">
+              Showing 40 of {tasks.length}
+            </span>
+          )}
+        </div>
         {tasks.length === 0 ? (
           <p className="mt-2 text-sm text-muted-foreground">No automation tasks found.</p>
         ) : (

--- a/src/app/social/agents/page.tsx
+++ b/src/app/social/agents/page.tsx
@@ -1,0 +1,233 @@
+"use client"
+
+import { useRef, useState } from "react"
+import {
+  deleteAutomationRule,
+  deleteAutomationTask,
+  getSocialNotificationPreferences,
+  listAutomationRules,
+  listAutomationTasks,
+  type AutomationRule,
+  type AutomationTask,
+  updateAutomationRule,
+  updateAutomationTask,
+  updateSocialNotificationPreferences,
+} from "@/lib/social/client"
+import { useToast } from "@/components/Toast"
+import { Loader2Icon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function SocialAgentsPage() {
+  const [rules, setRules] = useState<AutomationRule[]>([])
+  const [tasks, setTasks] = useState<AutomationTask[]>([])
+  const [prefs, setPrefs] = useState<{
+    inAppEnabled: boolean;
+    emailEnabled: boolean;
+    webhookEnabled: boolean;
+    muteAll: boolean;
+    preferences: Record<string, unknown> | null;
+  } | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const initialized = useRef(false)
+  const { show } = useToast()
+
+  async function load() {
+    const [loadedRules, loadedTasks, loadedPrefs] = await Promise.all([
+      listAutomationRules(),
+      listAutomationTasks(),
+      getSocialNotificationPreferences(),
+    ])
+    setRules(loadedRules)
+    setTasks(loadedTasks)
+    setPrefs(loadedPrefs)
+  }
+
+  if (!initialized.current) {
+    initialized.current = true
+    load().finally(() => setIsLoading(false))
+  }
+
+  async function toggleMuteAll() {
+    if (!prefs) return
+    setIsSaving(true)
+    try {
+      const updated = await updateSocialNotificationPreferences({
+        muteAll: !prefs.muteAll,
+      })
+      setPrefs(updated)
+      show(updated.muteAll ? "Notifications muted" : "Notifications enabled", "success")
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to update preferences", "error")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function toggleRule(rule: AutomationRule) {
+    setBusyId(rule.id)
+    try {
+      await updateAutomationRule(rule.id, { enabled: !rule.enabled })
+      await load()
+      show(rule.enabled ? "Rule disabled" : "Rule enabled", "success")
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to update rule", "error")
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function removeRule(ruleId: string) {
+    if (!confirm("Delete this automation rule?")) return
+    setBusyId(ruleId)
+    try {
+      await deleteAutomationRule(ruleId)
+      await load()
+      show("Rule deleted", "success")
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to delete rule", "error")
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function cancelTask(taskId: string) {
+    setBusyId(taskId)
+    try {
+      await updateAutomationTask(taskId, { state: "cancelled" })
+      await load()
+      show("Task cancelled", "success")
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to cancel task", "error")
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function removeTask(taskId: string) {
+    if (!confirm("Delete this automation task?")) return
+    setBusyId(taskId)
+    try {
+      await deleteAutomationTask(taskId)
+      await load()
+      show("Task deleted", "success")
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to delete task", "error")
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
+      <h2 className="text-lg font-semibold">Agents & Automation</h2>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-xs text-muted-foreground">Automation rules</div>
+          <div className="mt-1 text-2xl font-semibold">{rules.length}</div>
+        </div>
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-xs text-muted-foreground">Automation tasks</div>
+          <div className="mt-1 text-2xl font-semibold">{tasks.length}</div>
+        </div>
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-xs text-muted-foreground">Notifications</div>
+          <div className="mt-2">
+            <Button size="sm" variant="outline" onClick={toggleMuteAll} disabled={isSaving}>
+              {prefs?.muteAll ? "Unmute all" : "Mute all"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <h3 className="text-sm font-medium">Rules</h3>
+        {rules.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">No automation rules found.</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {rules.map((rule) => (
+              <div key={rule.id} className="flex items-center justify-between gap-2 rounded-md border p-2">
+                <div className="min-w-0">
+                  <div className="truncate text-sm">{rule.name}</div>
+                  <div className="text-[10px] text-muted-foreground">
+                    {rule.enabled ? "Enabled" : "Disabled"} · {rule.triggerSource}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => toggleRule(rule)}
+                    disabled={busyId === rule.id}
+                  >
+                    {rule.enabled ? "Disable" : "Enable"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-destructive"
+                    onClick={() => removeRule(rule.id)}
+                    disabled={busyId === rule.id}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <h3 className="text-sm font-medium">Tasks</h3>
+        {tasks.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">No automation tasks found.</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {tasks.slice(0, 40).map((task) => (
+              <div key={task.id} className="flex items-center justify-between gap-2 rounded-md border p-2">
+                <div className="min-w-0">
+                  <div className="truncate text-sm">{task.taskKey}</div>
+                  <div className="text-[10px] text-muted-foreground">
+                    {task.state} · run {task.runIndex}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {(task.state === "pending" || task.state === "claimed") && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => cancelTask(task.id)}
+                      disabled={busyId === task.id}
+                    >
+                      Cancel
+                    </Button>
+                  )}
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-destructive"
+                    onClick={() => removeTask(task.id)}
+                    disabled={busyId === task.id}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/social/analytics/page.tsx
+++ b/src/app/social/analytics/page.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useMemo, useRef, useState } from "react"
+import { listSocialEvents, listSocialPosts, type SocialPost } from "@/lib/social/client"
+import { Loader2Icon } from "lucide-react"
+
+const STATUS_ORDER = ["draft", "queued", "publishing", "published", "failed"] as const
+
+export default function SocialAnalyticsPage() {
+  const [posts, setPosts] = useState<SocialPost[]>([])
+  const [eventCount, setEventCount] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const initialized = useRef(false)
+
+  if (!initialized.current) {
+    initialized.current = true
+    Promise.all([
+      listSocialPosts({ limit: 500 }),
+      listSocialEvents({ limit: 200 }),
+    ])
+      .then(([loadedPosts, events]) => {
+        setPosts(loadedPosts)
+        setEventCount(events.length)
+      })
+      .finally(() => setIsLoading(false))
+  }
+
+  const statusCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const status of STATUS_ORDER) {
+      counts.set(status, 0)
+    }
+    for (const post of posts) {
+      counts.set(post.status, (counts.get(post.status) || 0) + 1)
+    }
+    return counts
+  }, [posts])
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
+      <h2 className="text-lg font-semibold">Social Analytics</h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-xs text-muted-foreground">Total posts</div>
+          <div className="mt-1 text-2xl font-semibold">{posts.length}</div>
+        </div>
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-xs text-muted-foreground">Published posts</div>
+          <div className="mt-1 text-2xl font-semibold">
+            {statusCounts.get("published") || 0}
+          </div>
+        </div>
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-xs text-muted-foreground">Ops events (recent)</div>
+          <div className="mt-1 text-2xl font-semibold">{eventCount}</div>
+        </div>
+      </div>
+      <div className="rounded-lg border bg-card p-4">
+        <h3 className="text-sm font-medium">Post status distribution</h3>
+        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
+          {STATUS_ORDER.map((status) => (
+            <div key={status} className="rounded-md bg-muted px-3 py-2">
+              <div className="text-[10px] uppercase text-muted-foreground">
+                {status}
+              </div>
+              <div className="text-lg font-semibold">
+                {statusCounts.get(status) || 0}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/social/calendar/page.tsx
+++ b/src/app/social/calendar/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef } from "react"
+import { useEffect, useRef } from "react"
 import { useSocialCalendarStore } from "@/store/socialCalendarStore"
 import { useSocialAccountsStore } from "@/store/socialAccountsStore"
 import { CalendarFilters } from "@/components/social/calendar/CalendarFilters"
@@ -42,9 +42,11 @@ export default function CalendarPage() {
   prevKey.current = key
 
   // Keep calendar filter aligned with sidebar channel filter
-  if (selectedChannelFilter !== channelFilter) {
-    setChannelFilter(selectedChannelFilter)
-  }
+  useEffect(() => {
+    if (selectedChannelFilter !== channelFilter) {
+      setChannelFilter(selectedChannelFilter)
+    }
+  }, [selectedChannelFilter, channelFilter, setChannelFilter])
 
   // Empty state: no channels
   if (accounts.length === 0) {

--- a/src/app/social/calendar/page.tsx
+++ b/src/app/social/calendar/page.tsx
@@ -5,15 +5,26 @@ import { useSocialCalendarStore } from "@/store/socialCalendarStore"
 import { useSocialAccountsStore } from "@/store/socialAccountsStore"
 import { CalendarFilters } from "@/components/social/calendar/CalendarFilters"
 import { CalendarWeek } from "@/components/social/calendar/CalendarWeek"
+import { CalendarDay } from "@/components/social/calendar/CalendarDay"
+import { CalendarMonth } from "@/components/social/calendar/CalendarMonth"
 import { CalendarListView } from "@/components/social/calendar/CalendarListView"
 import { Button } from "@/components/ui/button"
 import { PlusIcon, Loader2Icon } from "lucide-react"
-import Link from "next/link"
 
 export default function CalendarPage() {
-  const { viewMode, isLoading, fetchPosts, currentDate, channelFilter } =
+  const {
+    viewMode,
+    isLoading,
+    fetchPosts,
+    currentDate,
+    channelFilter,
+    setChannelFilter,
+  } =
     useSocialCalendarStore()
-  const accounts = useSocialAccountsStore((s) => s.accounts)
+  const { accounts, selectedChannelFilter } = useSocialAccountsStore((s) => ({
+    accounts: s.accounts,
+    selectedChannelFilter: s.selectedChannelFilter,
+  }))
   const initialized = useRef(false)
 
   // Fetch posts on first render
@@ -24,11 +35,16 @@ export default function CalendarPage() {
 
   // Refetch when date or filter changes — track previous values via ref
   const prevKey = useRef("")
-  const key = `${currentDate.toISOString()}-${channelFilter}`
+  const key = `${viewMode}-${currentDate.toISOString()}-${channelFilter}`
   if (prevKey.current && prevKey.current !== key) {
     fetchPosts()
   }
   prevKey.current = key
+
+  // Keep calendar filter aligned with sidebar channel filter
+  if (selectedChannelFilter !== channelFilter) {
+    setChannelFilter(selectedChannelFilter)
+  }
 
   // Empty state: no channels
   if (accounts.length === 0) {
@@ -58,8 +74,12 @@ export default function CalendarPage() {
         <div className="flex flex-1 items-center justify-center">
           <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
         </div>
+      ) : viewMode === "day" ? (
+        <CalendarDay />
       ) : viewMode === "week" ? (
         <CalendarWeek />
+      ) : viewMode === "month" ? (
+        <CalendarMonth />
       ) : (
         <CalendarListView />
       )}

--- a/src/app/social/channels/page.tsx
+++ b/src/app/social/channels/page.tsx
@@ -7,6 +7,7 @@ interface ChannelsPageProps {
     platform?: string
     oauth_token?: string
     oauth_verifier?: string
+    error?: string
   }>
 }
 
@@ -14,7 +15,7 @@ export default async function ChannelsPage({ searchParams }: ChannelsPageProps) 
   const params = await searchParams
 
   // Normalize OAuth callback params (X uses oauth_token/oauth_verifier)
-  const oauthCallback =
+  const normalizedCallback =
     (params.code && params.state) || (params.oauth_token && params.oauth_verifier)
       ? {
           platform: params.platform ?? "",
@@ -22,6 +23,16 @@ export default async function ChannelsPage({ searchParams }: ChannelsPageProps) 
           state: params.state ?? params.oauth_token ?? "",
         }
       : null
+  const hasInvalidCallback = normalizedCallback && !normalizedCallback.platform
+  const oauthCallback = hasInvalidCallback ? null : normalizedCallback
 
-  return <ChannelsPageClient oauthCallback={oauthCallback} />
+  return (
+    <ChannelsPageClient
+      oauthCallback={oauthCallback}
+      oauthError={
+        params.error ??
+        (hasInvalidCallback ? "OAuth callback is missing platform information." : null)
+      }
+    />
+  )
 }

--- a/src/app/social/channels/page.tsx
+++ b/src/app/social/channels/page.tsx
@@ -1,38 +1,39 @@
+import { cookies } from "next/headers"
 import { ChannelsPageClient } from "@/components/social/ChannelsPageClient"
+
+const OAUTH_CALLBACK_COOKIE = "social_oauth_cb"
 
 interface ChannelsPageProps {
   searchParams: Promise<{
-    code?: string
-    state?: string
-    platform?: string
-    oauth_token?: string
-    oauth_verifier?: string
+    oauth_pending?: string
     error?: string
   }>
 }
 
 export default async function ChannelsPage({ searchParams }: ChannelsPageProps) {
   const params = await searchParams
+  const cookieStore = await cookies()
 
-  // Normalize OAuth callback params (X uses oauth_token/oauth_verifier)
-  const normalizedCallback =
-    (params.code && params.state) || (params.oauth_token && params.oauth_verifier)
-      ? {
-          platform: params.platform ?? "",
-          code: params.code ?? params.oauth_verifier ?? "",
-          state: params.state ?? params.oauth_token ?? "",
-        }
-      : null
-  const hasInvalidCallback = normalizedCallback && !normalizedCallback.platform
-  const oauthCallback = hasInvalidCallback ? null : normalizedCallback
+  // Read OAuth callback data from the secure HTTP-only cookie set by the
+  // GET callback handler, then clear it immediately.
+  let oauthCallback: { platform: string; code: string; state: string } | null = null
+  const callbackCookie = cookieStore.get(OAUTH_CALLBACK_COOKIE)
+  if (callbackCookie) {
+    try {
+      const parsed = JSON.parse(callbackCookie.value)
+      if (parsed.platform && parsed.code && parsed.state) {
+        oauthCallback = parsed
+      }
+    } catch {
+      // Malformed cookie — ignore
+    }
+  }
 
   return (
     <ChannelsPageClient
       oauthCallback={oauthCallback}
-      oauthError={
-        params.error ??
-        (hasInvalidCallback ? "OAuth callback is missing platform information." : null)
-      }
+      oauthError={params.error ?? null}
+      clearCallbackCookie={!!callbackCookie}
     />
   )
 }

--- a/src/app/social/compose/page.tsx
+++ b/src/app/social/compose/page.tsx
@@ -1,10 +1,15 @@
 import { ComposePageClient } from "@/components/social/compose/ComposePageClient"
 
 interface ComposePageProps {
-  searchParams: Promise<{ date?: string }>
+  searchParams: Promise<{ date?: string; accountId?: string }>
 }
 
 export default async function ComposePage({ searchParams }: ComposePageProps) {
   const params = await searchParams
-  return <ComposePageClient initialDate={params.date ?? null} />
+  return (
+    <ComposePageClient
+      initialDate={params.date ?? null}
+      initialAccountId={params.accountId ?? null}
+    />
+  )
 }

--- a/src/app/social/events/page.tsx
+++ b/src/app/social/events/page.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useRef, useState } from "react"
+import {
+  listSocialEvents,
+  markSocialEventRead,
+  markSocialEventUnread,
+  type SocialEvent,
+} from "@/lib/social/client"
+import { Loader2Icon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useToast } from "@/components/Toast"
+
+export default function SocialEventsPage() {
+  const [events, setEvents] = useState<SocialEvent[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isUpdatingId, setIsUpdatingId] = useState<string | null>(null)
+  const initialized = useRef(false)
+  const { show } = useToast()
+
+  async function load() {
+    const rows = await listSocialEvents({
+      perUserReads: true,
+      userFacing: true,
+      limit: 200,
+    })
+    setEvents(rows)
+  }
+
+  if (!initialized.current) {
+    initialized.current = true
+    load().finally(() => setIsLoading(false))
+  }
+
+  async function toggleRead(event: SocialEvent) {
+    setIsUpdatingId(event.id)
+    try {
+      if (event.readByCurrentUser) {
+        await markSocialEventUnread(event.id, { perUserReads: true })
+      } else {
+        await markSocialEventRead(event.id, { perUserReads: true })
+      }
+      await load()
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to update event", "error")
+    } finally {
+      setIsUpdatingId(null)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
+      <h2 className="text-lg font-semibold">Events</h2>
+      {events.length === 0 ? (
+        <div className="rounded-lg border bg-card p-5 text-sm text-muted-foreground">
+          No events yet.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {events.map((event) => (
+            <div key={event.id} className="rounded-lg border bg-card p-3">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="text-xs text-muted-foreground">
+                    {event.eventType} · {event.severity.toUpperCase()}
+                  </div>
+                  <p className="mt-0.5 text-sm">{event.message}</p>
+                  <div className="mt-1 text-[10px] text-muted-foreground">
+                    {new Date(event.createdAt).toLocaleString()}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant={event.readByCurrentUser ? "outline" : "secondary"}
+                  onClick={() => toggleRead(event)}
+                  disabled={isUpdatingId === event.id}
+                >
+                  {event.readByCurrentUser ? "Mark Unread" : "Mark Read"}
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/social/integrations/page.tsx
+++ b/src/app/social/integrations/page.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { listSocialAccounts, listSocialProviders } from "@/lib/social/client"
+import type { SocialAccount } from "@/lib/social/client"
+import type { ProviderCapabilities } from "@/lib/social/provider-interface"
+import { Loader2Icon } from "lucide-react"
+
+export default function SocialIntegrationsPage() {
+  const [providers, setProviders] = useState<ProviderCapabilities[]>([])
+  const [accounts, setAccounts] = useState<SocialAccount[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const initialized = useRef(false)
+
+  if (!initialized.current) {
+    initialized.current = true
+    Promise.all([listSocialProviders(), listSocialAccounts()])
+      .then(([loadedProviders, loadedAccounts]) => {
+        setProviders(loadedProviders)
+        setAccounts(loadedAccounts)
+      })
+      .finally(() => setIsLoading(false))
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
+      <h2 className="text-lg font-semibold">Integrations</h2>
+      <div className="rounded-lg border bg-card p-4">
+        <div className="text-sm font-medium">Connected channels</div>
+        <div className="mt-2 text-sm text-muted-foreground">{accounts.length}</div>
+      </div>
+      <div className="rounded-lg border bg-card p-4">
+        <div className="text-sm font-medium">Available providers</div>
+        <div className="mt-3 grid grid-cols-2 gap-2 md:grid-cols-3">
+          {providers.map((provider) => (
+            <div key={provider.identifier} className="rounded-md bg-muted px-3 py-2 text-xs">
+              {provider.displayName}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/social/layout.tsx
+++ b/src/app/social/layout.tsx
@@ -11,7 +11,7 @@ export default async function SocialRootLayout({
   const session = await getServerAuthSession(await headers());
 
   if (!session?.user) {
-    redirect("/sign-in");
+    redirect("/sign-in?next=%2Fsocial%2Fcalendar");
   }
 
   return <SocialLayout>{children}</SocialLayout>;

--- a/src/app/social/media/page.tsx
+++ b/src/app/social/media/page.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useMemo, useRef, useState } from "react"
+import { listSocialPosts, type SocialPost } from "@/lib/social/client"
+import { Loader2Icon } from "lucide-react"
+
+type MediaItem = {
+  postId: string;
+  type: string;
+  url: string;
+  createdAt: string;
+}
+
+export default function SocialMediaPage() {
+  const [posts, setPosts] = useState<SocialPost[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const initialized = useRef(false)
+
+  if (!initialized.current) {
+    initialized.current = true
+    listSocialPosts({ limit: 400 })
+      .then(setPosts)
+      .finally(() => setIsLoading(false))
+  }
+
+  const media = useMemo<MediaItem[]>(() => {
+    return posts.flatMap((post) =>
+      (post.mediaUrls || []).map((item) => ({
+        postId: post.id,
+        type: item.type,
+        url: item.url,
+        createdAt: post.createdAt,
+      })),
+    )
+  }, [posts])
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
+      <h2 className="text-lg font-semibold">Social Media Library</h2>
+      {media.length === 0 ? (
+        <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+          No media attached to social posts yet.
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4">
+          {media.map((item, index) => (
+            <div key={`${item.postId}-${index}`} className="rounded-lg border bg-card p-2">
+              {item.type === "image" ? (
+                <img
+                  src={item.url}
+                  alt={`Media ${index + 1}`}
+                  className="h-36 w-full rounded-md object-cover"
+                />
+              ) : (
+                <video
+                  src={item.url}
+                  className="h-36 w-full rounded-md object-cover"
+                  controls
+                />
+              )}
+              <div className="mt-2 text-[10px] text-muted-foreground">
+                {item.type.toUpperCase()} · Post {item.postId.slice(0, 8)}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/app/social/plugs/page.tsx
+++ b/src/app/social/plugs/page.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { FormEvent, useRef, useState } from "react"
+import {
+  createSocialWebhook,
+  deleteSocialWebhook,
+  listSocialWebhooks,
+  updateSocialWebhook,
+  type SocialWebhook,
+} from "@/lib/social/client"
+import { useToast } from "@/components/Toast"
+import { Loader2Icon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+export default function SocialPlugsPage() {
+  const [webhooks, setWebhooks] = useState<SocialWebhook[]>([])
+  const [targetUrl, setTargetUrl] = useState("")
+  const [isLoading, setIsLoading] = useState(true)
+  const [isCreating, setIsCreating] = useState(false)
+  const [mutatingWebhookId, setMutatingWebhookId] = useState<string | null>(null)
+  const initialized = useRef(false)
+  const { show } = useToast()
+
+  function refresh() {
+    return listSocialWebhooks()
+      .then(setWebhooks)
+      .finally(() => setIsLoading(false))
+  }
+
+  if (!initialized.current) {
+    initialized.current = true
+    refresh()
+  }
+
+  async function onCreate(e: FormEvent) {
+    e.preventDefault()
+    if (!targetUrl.trim()) return
+    setIsCreating(true)
+    try {
+      const { signingSecret } = await createSocialWebhook({ targetUrl: targetUrl.trim() })
+      show(
+        signingSecret
+          ? `Webhook created. Secret: ${signingSecret.slice(0, 12)}...`
+          : "Webhook created",
+        "success",
+      )
+      setTargetUrl("")
+      await refresh()
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to create webhook", "error")
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  async function onToggleEnabled(webhook: SocialWebhook) {
+    setMutatingWebhookId(webhook.id)
+    try {
+      await updateSocialWebhook(webhook.id, { enabled: !webhook.enabled })
+      await refresh()
+      show(webhook.enabled ? "Plug disabled" : "Plug enabled", "success")
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to update plug", "error")
+    } finally {
+      setMutatingWebhookId(null)
+    }
+  }
+
+  async function onDelete(webhook: SocialWebhook) {
+    if (!confirm("Delete this plug?")) return
+    setMutatingWebhookId(webhook.id)
+    try {
+      await deleteSocialWebhook(webhook.id)
+      await refresh()
+      show("Plug deleted", "success")
+    } catch (error) {
+      show(error instanceof Error ? error.message : "Failed to delete plug", "error")
+    } finally {
+      setMutatingWebhookId(null)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
+      <h2 className="text-lg font-semibold">Plugs (Webhooks)</h2>
+      <form onSubmit={onCreate} className="flex gap-2">
+        <Input
+          type="url"
+          value={targetUrl}
+          onChange={(e) => setTargetUrl(e.target.value)}
+          placeholder="https://example.com/social-webhook"
+        />
+        <Button type="submit" disabled={isCreating}>
+          {isCreating ? "Creating..." : "Add Plug"}
+        </Button>
+      </form>
+      <div className="space-y-2">
+        {webhooks.length === 0 ? (
+          <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+            No plugs configured yet.
+          </div>
+        ) : (
+          webhooks.map((webhook) => (
+            <div key={webhook.id} className="rounded-lg border bg-card p-3">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">{webhook.targetUrl}</div>
+                  <div className="text-[10px] text-muted-foreground">
+                    {webhook.enabled ? "Enabled" : "Disabled"} · {webhook.id}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onToggleEnabled(webhook)}
+                    disabled={mutatingWebhookId === webhook.id}
+                  >
+                    {webhook.enabled ? "Disable" : "Enable"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-destructive"
+                    onClick={() => onDelete(webhook)}
+                    disabled={mutatingWebhookId === webhook.id}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/social/ChannelCard.tsx
+++ b/src/components/social/ChannelCard.tsx
@@ -5,6 +5,7 @@ import type { SocialAccount } from "@/lib/social/client"
 import {
   connectSocialAccount,
   disconnectSocialAccount,
+  updateSocialAccount,
 } from "@/lib/social/client"
 import { PlatformIcon } from "./shared/PlatformIcon"
 import { PLATFORM_LABELS } from "@/lib/social/constants"
@@ -14,6 +15,15 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import type { SocialPlatform } from "@/lib/db/schema"
 
 interface ChannelCardProps {
@@ -22,17 +32,26 @@ interface ChannelCardProps {
 
 export function ChannelCard({ account }: ChannelCardProps) {
   const [showConfirm, setShowConfirm] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
   const [isDisconnecting, setIsDisconnecting] = useState(false)
   const [isReconnecting, setIsReconnecting] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [displayName, setDisplayName] = useState(account.displayName)
+  const [postingTimes, setPostingTimes] = useState(
+    Array.isArray(account.additionalSettings?.postingTimes)
+      ? (account.additionalSettings?.postingTimes as number[]).join(",")
+      : "",
+  )
+  const [customerName, setCustomerName] = useState(
+    typeof account.additionalSettings?.customerName === "string"
+      ? account.additionalSettings.customerName
+      : "",
+  )
   const { show: showToast } = useToast()
-  const removeAccount = useSocialAccountsStore((s) => s.removeAccount)
-
-  const initials = account.displayName
-    .split(" ")
-    .map((w) => w[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase()
+  const { removeAccount, addOrUpdateAccount } = useSocialAccountsStore((s) => ({
+    removeAccount: s.removeAccount,
+    addOrUpdateAccount: s.addOrUpdateAccount,
+  }))
 
   async function handleDisconnect() {
     setIsDisconnecting(true)
@@ -41,6 +60,26 @@ export function ChannelCard({ account }: ChannelCardProps) {
       removeAccount(account.id)
       showToast(`${account.displayName} disconnected`, "success")
     } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("existing posts") &&
+        confirm("This channel has linked posts. Force disconnect and remove linked posts?")
+      ) {
+        try {
+          await disconnectSocialAccount(account.id, true)
+          removeAccount(account.id)
+          showToast(`${account.displayName} force-disconnected`, "success")
+          return
+        } catch (forceError) {
+          showToast(
+            forceError instanceof Error
+              ? forceError.message
+              : "Force disconnect failed",
+            "error",
+          )
+          return
+        }
+      }
       showToast(
         error instanceof Error ? error.message : "Failed to disconnect",
         "error",
@@ -54,7 +93,7 @@ export function ChannelCard({ account }: ChannelCardProps) {
   async function handleReconnect() {
     setIsReconnecting(true)
     try {
-      const { authUrl } = await connectSocialAccount(account.platform)
+      const { authUrl } = await connectSocialAccount(account.platform, account.id)
       window.location.href = authUrl
     } catch (error) {
       showToast(
@@ -63,6 +102,63 @@ export function ChannelCard({ account }: ChannelCardProps) {
       )
       setIsReconnecting(false)
     }
+  }
+
+  async function handleToggleDisabled() {
+    setIsSaving(true)
+    try {
+      const updated = await updateSocialAccount(account.id, {
+        disabled: !account.disabled,
+      })
+      addOrUpdateAccount(updated)
+      showToast(
+        updated.disabled ? "Channel disabled" : "Channel enabled",
+        "success",
+      )
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : "Failed to update channel",
+        "error",
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleSaveSettings() {
+    setIsSaving(true)
+    try {
+      const parsedTimes = postingTimes
+        .split(",")
+        .map((v) => Number.parseInt(v.trim(), 10))
+        .filter((v) => Number.isInteger(v) && v >= 0 && v <= 23)
+      const mergedSettings = {
+        ...(account.additionalSettings || {}),
+        postingTimes: parsedTimes,
+        customerName: customerName.trim() || null,
+      }
+      const updated = await updateSocialAccount(account.id, {
+        displayName: displayName.trim(),
+        additionalSettings: mergedSettings,
+      })
+      addOrUpdateAccount(updated)
+      showToast("Channel settings updated", "success")
+      setShowSettings(false)
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : "Failed to save settings",
+        "error",
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  function handleCopyId() {
+    navigator.clipboard
+      .writeText(account.id)
+      .then(() => showToast("Channel ID copied", "success"))
+      .catch(() => showToast("Failed to copy channel ID", "error"))
   }
 
   return (
@@ -90,6 +186,10 @@ export function ChannelCard({ account }: ChannelCardProps) {
       </CardHeader>
 
       <CardFooter className="gap-2 pt-0">
+        <Button size="sm" variant="outline" className="flex-1" render={<a href={`/social/compose?accountId=${account.id}`} />} nativeButton={false}>
+          Create Post
+        </Button>
+
         {account.requiresReauth ? (
           <Button
             size="sm"
@@ -101,8 +201,34 @@ export function ChannelCard({ account }: ChannelCardProps) {
             {isReconnecting ? "Reconnecting..." : "Reconnect"}
           </Button>
         ) : (
-          <Button size="sm" variant="outline" className="flex-1">
+          <Button
+            size="sm"
+            variant="outline"
+            className="flex-1"
+            onClick={() => setShowSettings(true)}
+          >
             Settings
+          </Button>
+        )}
+
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-xs"
+          onClick={handleCopyId}
+        >
+          Copy ID
+        </Button>
+
+        {!account.requiresReauth && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-xs"
+            onClick={handleToggleDisabled}
+            disabled={isSaving}
+          >
+            {account.disabled ? "Enable" : "Disable"}
           </Button>
         )}
 
@@ -136,6 +262,51 @@ export function ChannelCard({ account }: ChannelCardProps) {
           </Button>
         )}
       </CardFooter>
+
+      <Dialog open={showSettings} onOpenChange={setShowSettings}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Channel settings</DialogTitle>
+            <DialogDescription>
+              Update display name and channel-specific scheduling metadata.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label>Display name</Label>
+              <Input
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="Channel name"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Posting times (0-23, comma separated)</Label>
+              <Input
+                value={postingTimes}
+                onChange={(e) => setPostingTimes(e.target.value)}
+                placeholder="9,12,18"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Customer/Group name</Label>
+              <Input
+                value={customerName}
+                onChange={(e) => setCustomerName(e.target.value)}
+                placeholder="Acme Social Team"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setShowSettings(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleSaveSettings} disabled={isSaving}>
+                {isSaving ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </Card>
   )
 }

--- a/src/components/social/ChannelsPageClient.tsx
+++ b/src/components/social/ChannelsPageClient.tsx
@@ -28,11 +28,13 @@ interface ChannelsPageClientProps {
     state: string
   } | null
   oauthError?: string | null
+  clearCallbackCookie?: boolean
 }
 
 export function ChannelsPageClient({
   oauthCallback,
   oauthError,
+  clearCallbackCookie,
 }: ChannelsPageClientProps) {
   const router = useRouter()
   const { accounts, isLoading, fetchAccounts } = useSocialAccountsStore()
@@ -45,6 +47,11 @@ export function ChannelsPageClient({
   } | null>(null)
   const { show: showToast } = useToast()
   const initialized = useRef(false)
+
+  // Clear the HTTP-only callback cookie now that the server component has read it
+  if (!initialized.current && clearCallbackCookie) {
+    document.cookie = "social_oauth_cb=; path=/; max-age=0"
+  }
 
   // Process OAuth callback on first render — no useEffect
   if (!initialized.current && oauthCallback) {

--- a/src/components/social/ChannelsPageClient.tsx
+++ b/src/components/social/ChannelsPageClient.tsx
@@ -27,9 +27,13 @@ interface ChannelsPageClientProps {
     code: string
     state: string
   } | null
+  oauthError?: string | null
 }
 
-export function ChannelsPageClient({ oauthCallback }: ChannelsPageClientProps) {
+export function ChannelsPageClient({
+  oauthCallback,
+  oauthError,
+}: ChannelsPageClientProps) {
   const router = useRouter()
   const { accounts, isLoading, fetchAccounts } = useSocialAccountsStore()
   const [showPicker, setShowPicker] = useState(false)
@@ -52,6 +56,10 @@ export function ChannelsPageClient({ oauthCallback }: ChannelsPageClientProps) {
     )
   } else if (!initialized.current) {
     initialized.current = true
+    if (oauthError) {
+      showToast(oauthError, "error")
+      router.replace("/social/channels")
+    }
   }
 
   async function processOAuthCallback(

--- a/src/components/social/SocialAppSidebar.tsx
+++ b/src/components/social/SocialAppSidebar.tsx
@@ -10,6 +10,12 @@ import {
   ActivityIcon,
   PlusIcon,
   BananaIcon,
+  BarChart3Icon,
+  ImageIcon,
+  PlugIcon,
+  BotIcon,
+  PuzzleIcon,
+  BellIcon,
 } from "lucide-react"
 import { useSocialAccountsStore } from "@/store/socialAccountsStore"
 import { PlatformIcon } from "./shared/PlatformIcon"
@@ -38,6 +44,12 @@ const NAV_ITEMS = [
   { href: "/social/compose", label: "Compose", icon: PenSquareIcon },
   { href: "/social/posts", label: "Posts", icon: FileTextIcon },
   { href: "/social/channels", label: "Channels", icon: ActivityIcon },
+  { href: "/social/events", label: "Events", icon: BellIcon },
+  { href: "/social/analytics", label: "Analytics", icon: BarChart3Icon },
+  { href: "/social/media", label: "Media", icon: ImageIcon },
+  { href: "/social/integrations", label: "Integrations", icon: PuzzleIcon },
+  { href: "/social/plugs", label: "Plugs", icon: PlugIcon },
+  { href: "/social/agents", label: "Agents", icon: BotIcon },
 ]
 
 

--- a/src/components/social/SocialSiteHeader.tsx
+++ b/src/components/social/SocialSiteHeader.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { PlusIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -12,6 +11,12 @@ const PAGE_TITLES: Record<string, string> = {
   "/social/compose": "Compose",
   "/social/posts": "Posts",
   "/social/channels": "Channels",
+  "/social/events": "Events",
+  "/social/analytics": "Analytics",
+  "/social/media": "Media",
+  "/social/integrations": "Integrations",
+  "/social/plugs": "Plugs",
+  "/social/agents": "Agents",
 }
 
 export function SocialSiteHeader() {

--- a/src/components/social/calendar/CalendarColumn.tsx
+++ b/src/components/social/calendar/CalendarColumn.tsx
@@ -8,7 +8,6 @@ import { updateSocialPost } from "@/lib/social/client"
 import { useSocialCalendarStore } from "@/store/socialCalendarStore"
 import { useToast } from "@/components/Toast"
 import type { SocialPost } from "@/lib/social/client"
-import type { SocialPlatform } from "@/lib/db/schema"
 
 interface CalendarColumnProps {
   date: Date
@@ -27,11 +26,17 @@ export function CalendarColumn({ date, hour, posts }: CalendarColumnProps) {
 
   const [{ isOver, canDrop }, dropRef] = useDrop(() => ({
     accept: POST_DND_TYPE,
-    canDrop: () => !isInPast,
+    canDrop: (item: { postId: string; status: string }) =>
+      !isInPast && item.status !== "published" && item.status !== "publishing",
     drop: async (item: { postId: string; status: string }) => {
       if (isInPast) return
 
-      if (item.status === "published" || item.status === "queued") {
+      if (item.status === "published" || item.status === "publishing") {
+        showToast("Published posts cannot be rescheduled.", "warning")
+        return
+      }
+
+      if (item.status === "queued") {
         if (!confirm("Reschedule this post to the new time?")) return
       }
 
@@ -74,11 +79,7 @@ export function CalendarColumn({ date, hour, posts }: CalendarColumnProps) {
       }`}
     >
       {posts.map((post) => (
-        <CalendarPostCard
-          key={post.id}
-          post={post}
-          platform={post.socialAccountId ? undefined : undefined}
-        />
+        <CalendarPostCard key={post.id} post={post} />
       ))}
     </div>
   )

--- a/src/components/social/calendar/CalendarDay.tsx
+++ b/src/components/social/calendar/CalendarDay.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { DndProvider } from "react-dnd"
+import { HTML5Backend } from "react-dnd-html5-backend"
+import { format } from "date-fns"
+import { useSocialCalendarStore } from "@/store/socialCalendarStore"
+import { CalendarColumn } from "./CalendarColumn"
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i)
+
+export function CalendarDay() {
+  const { currentDate, posts } = useSocialCalendarStore()
+  const day = new Date(currentDate)
+
+  function getPostsForHour(hour: number) {
+    return posts.filter((post) => {
+      const dateStr = post.scheduledAt || post.publishedAt || post.createdAt
+      if (!dateStr) return false
+      const d = new Date(dateStr)
+      return (
+        d.getFullYear() === day.getFullYear() &&
+        d.getMonth() === day.getMonth() &&
+        d.getDate() === day.getDate() &&
+        d.getHours() === hour
+      )
+    })
+  }
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <div className="flex flex-1 overflow-auto">
+        <div className="w-[60px] flex-shrink-0 border-e">
+          <div className="h-8 border-b" />
+          {HOURS.map((hour) => (
+            <div
+              key={hour}
+              className="flex h-12 items-start justify-end border-b pe-2 pt-0.5 text-[10px] text-muted-foreground"
+            >
+              {format(new Date().setHours(hour, 0), "HH:mm")}
+            </div>
+          ))}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex h-8 items-center justify-center border-b text-xs font-medium text-muted-foreground">
+            {format(day, "EEEE, MMM d")}
+          </div>
+          {HOURS.map((hour) => (
+            <CalendarColumn
+              key={hour}
+              date={day}
+              hour={hour}
+              posts={getPostsForHour(hour)}
+            />
+          ))}
+        </div>
+      </div>
+    </DndProvider>
+  )
+}
+

--- a/src/components/social/calendar/CalendarFilters.tsx
+++ b/src/components/social/calendar/CalendarFilters.tsx
@@ -2,23 +2,41 @@
 
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react"
 import { useSocialCalendarStore } from "@/store/socialCalendarStore"
+import { useSocialAccountsStore } from "@/store/socialAccountsStore"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import type { SocialPlatform } from "@/lib/db/schema"
 
 export function CalendarFilters() {
   const {
     viewMode,
     setViewMode,
+    channelFilter,
+    setChannelFilter,
     navigatePrev,
     navigateNext,
     goToToday,
     getDateRangeLabel,
   } = useSocialCalendarStore()
+  const { accounts, setSidebarChannelFilter } = useSocialAccountsStore((s) => ({
+    accounts: s.accounts,
+    setSidebarChannelFilter: s.setChannelFilter,
+  }))
 
   return (
     <div className="flex items-center gap-2 border-b px-4 py-2">
       {/* View toggle */}
       <div className="flex rounded-md border">
+        <button
+          onClick={() => setViewMode("day")}
+          className={`px-3 py-1 text-xs font-medium transition-colors ${
+            viewMode === "day"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-accent"
+          }`}
+        >
+          Day
+        </button>
         <button
           onClick={() => setViewMode("week")}
           className={`px-3 py-1 text-xs font-medium transition-colors ${
@@ -28,6 +46,16 @@ export function CalendarFilters() {
           }`}
         >
           Week
+        </button>
+        <button
+          onClick={() => setViewMode("month")}
+          className={`px-3 py-1 text-xs font-medium transition-colors ${
+            viewMode === "month"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-accent"
+          }`}
+        >
+          Month
         </button>
         <button
           onClick={() => setViewMode("list")}
@@ -56,6 +84,25 @@ export function CalendarFilters() {
 
       {/* Date range */}
       <span className="text-sm font-medium">{getDateRangeLabel()}</span>
+
+      <Separator orientation="vertical" className="h-4" />
+
+      <select
+        value={channelFilter ?? ""}
+        onChange={(e) => {
+          const next = e.target.value || null
+          setChannelFilter(next)
+          setSidebarChannelFilter(next)
+        }}
+        className="h-8 min-w-[180px] rounded-md border bg-background px-2 text-xs"
+      >
+        <option value="">All channels</option>
+        {accounts.map((account) => (
+          <option key={account.id} value={account.id}>
+            {account.displayName} ({account.platform as SocialPlatform})
+          </option>
+        ))}
+      </select>
     </div>
   )
 }

--- a/src/components/social/calendar/CalendarListView.tsx
+++ b/src/components/social/calendar/CalendarListView.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react"
 import { format } from "date-fns"
 import { useRouter } from "next/navigation"
 import { useSocialCalendarStore } from "@/store/socialCalendarStore"
+import { useSocialAccountsStore } from "@/store/socialAccountsStore"
 import { PlatformIcon } from "@/components/social/shared/PlatformIcon"
 import { POST_STATUS_CONFIG } from "@/lib/social/constants"
 import { Badge } from "@/components/ui/badge"
@@ -14,6 +15,7 @@ import type { SocialPlatform, SocialPostStatus } from "@/lib/db/schema"
 
 export function CalendarListView() {
   const { posts } = useSocialCalendarStore()
+  const accounts = useSocialAccountsStore((s) => s.accounts)
   const router = useRouter()
   const { show: showToast } = useToast()
   const fetchPosts = useSocialCalendarStore((s) => s.fetchPosts)
@@ -74,8 +76,8 @@ export function CalendarListView() {
                 >
                   <PlatformIcon
                     platform={
-                      (post as any).platform ??
-                      ("linkedin" as SocialPlatform)
+                      (accounts.find((account) => account.id === post.socialAccountId)
+                        ?.platform as SocialPlatform) ?? "linkedin"
                     }
                     size={16}
                   />

--- a/src/components/social/calendar/CalendarMonth.tsx
+++ b/src/components/social/calendar/CalendarMonth.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { useMemo } from "react"
+import {
+  addDays,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns"
+import { useSocialCalendarStore } from "@/store/socialCalendarStore"
+
+const WEEK_DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+export function CalendarMonth() {
+  const { currentDate, posts, setViewMode } = useSocialCalendarStore()
+  const monthStart = startOfMonth(currentDate)
+  const monthEnd = endOfMonth(currentDate)
+  const calendarStart = startOfWeek(monthStart, { weekStartsOn: 1 })
+  const calendarEnd = endOfWeek(monthEnd, { weekStartsOn: 1 })
+
+  const days = useMemo(() => {
+    const values: Date[] = []
+    let cursor = new Date(calendarStart)
+    while (cursor <= calendarEnd) {
+      values.push(new Date(cursor))
+      cursor = addDays(cursor, 1)
+    }
+    return values
+  }, [calendarStart, calendarEnd])
+
+  function countPostsForDate(day: Date) {
+    return posts.filter((post) => {
+      const dateStr = post.scheduledAt || post.publishedAt || post.createdAt
+      if (!dateStr) return false
+      const d = new Date(dateStr)
+      return (
+        d.getFullYear() === day.getFullYear() &&
+        d.getMonth() === day.getMonth() &&
+        d.getDate() === day.getDate()
+      )
+    }).length
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-auto">
+      <div className="grid grid-cols-7 border-b">
+        {WEEK_DAYS.map((day) => (
+          <div
+            key={day}
+            className="p-2 text-center text-xs font-medium text-muted-foreground"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+      <div className="grid flex-1 grid-cols-7 auto-rows-fr">
+        {days.map((day) => {
+          const inCurrentMonth = isSameMonth(day, currentDate)
+          const postCount = countPostsForDate(day)
+          return (
+            <button
+              key={day.toISOString()}
+              onClick={() => {
+                useSocialCalendarStore.setState({ currentDate: day })
+                setViewMode("day")
+              }}
+              className={`min-h-[90px] border-e border-b p-2 text-start transition-colors hover:bg-accent/30 ${
+                inCurrentMonth ? "text-foreground" : "text-muted-foreground/50"
+              }`}
+            >
+              <div className="text-xs font-medium">{format(day, "d")}</div>
+              {postCount > 0 && (
+                <div className="mt-2 inline-flex rounded-full bg-primary/15 px-2 py-0.5 text-[10px] text-primary">
+                  {postCount} post{postCount > 1 ? "s" : ""}
+                </div>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/social/calendar/CalendarWeek.tsx
+++ b/src/components/social/calendar/CalendarWeek.tsx
@@ -7,7 +7,6 @@ import {
   startOfWeek,
   addDays,
   format,
-  isSameDay,
   isToday,
 } from "date-fns"
 import { useSocialCalendarStore } from "@/store/socialCalendarStore"

--- a/src/components/social/compose/ComposePageClient.tsx
+++ b/src/components/social/compose/ComposePageClient.tsx
@@ -6,11 +6,15 @@ import { ComposeView } from "./ComposeView"
 
 interface ComposePageClientProps {
   initialDate: string | null
+  initialAccountId: string | null
 }
 
-export function ComposePageClient({ initialDate }: ComposePageClientProps) {
+export function ComposePageClient({
+  initialDate,
+  initialAccountId,
+}: ComposePageClientProps) {
   const initialized = useRef(false)
-  const { reset, setScheduledAt } = useSocialComposerStore()
+  const { reset, setScheduledAt, setSelectedAccounts } = useSocialComposerStore()
 
   // Initialize once on first render — no useEffect needed
   if (!initialized.current) {
@@ -21,6 +25,9 @@ export function ComposePageClient({ initialDate }: ComposePageClientProps) {
       if (!isNaN(date.getTime())) {
         setScheduledAt(date)
       }
+    }
+    if (initialAccountId) {
+      setSelectedAccounts([initialAccountId])
     }
   }
 

--- a/src/components/social/compose/ComposeView.tsx
+++ b/src/components/social/compose/ComposeView.tsx
@@ -87,6 +87,21 @@ export function ComposeView() {
     }
   }
 
+  async function publishAll(postIds: string[]) {
+    const results = await Promise.allSettled(
+      postIds.map((id) => publishSocialPost(id)),
+    )
+    const failed = results.filter(
+      (r): r is PromiseRejectedResult => r.status === "rejected",
+    )
+    if (failed.length === results.length) {
+      throw failed[0].reason instanceof Error
+        ? failed[0].reason
+        : new Error("All publish attempts failed")
+    }
+    return { total: results.length, failed: failed.length }
+  }
+
   async function handleSchedule() {
     if (!canSchedule) return
     setIsSubmitting("schedule")
@@ -116,10 +131,15 @@ export function ComposeView() {
         publishQueue.push(created.id)
       }
 
-      for (const publishPostId of publishQueue) {
-        await publishSocialPost(publishPostId)
+      const { total, failed } = await publishAll(publishQueue)
+      if (failed > 0) {
+        showToast(
+          `Scheduled ${total - failed} of ${total} posts. ${failed} failed.`,
+          "error",
+        )
+      } else {
+        showToast("Post scheduled", "success")
       }
-      showToast("Post scheduled", "success")
       reset()
       router.push("/social/calendar")
     } catch (error) {
@@ -160,10 +180,15 @@ export function ComposeView() {
         publishQueue.push(created.id)
       }
 
-      for (const publishPostId of publishQueue) {
-        await publishSocialPost(publishPostId)
+      const { total, failed } = await publishAll(publishQueue)
+      if (failed > 0) {
+        showToast(
+          `Published ${total - failed} of ${total} posts. ${failed} failed.`,
+          "error",
+        )
+      } else {
+        showToast("Publishing...", "success")
       }
-      showToast("Publishing...", "success")
       reset()
       router.push("/social/calendar")
     } catch (error) {

--- a/src/components/social/compose/ComposeView.tsx
+++ b/src/components/social/compose/ComposeView.tsx
@@ -24,7 +24,6 @@ import {
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { useToast } from "@/components/Toast"
-import type { SocialPlatform } from "@/lib/db/schema"
 
 export function ComposeView() {
   const router = useRouter()
@@ -40,6 +39,7 @@ export function ComposeView() {
     mediaUrls,
     scheduledAt,
     postId,
+    editSourceAccountId,
     isDirty,
     reset,
   } = useSocialComposerStore()
@@ -48,27 +48,31 @@ export function ComposeView() {
   const hasChannels = selectedAccountIds.length > 0
   const canPublish = hasContent && hasChannels
   const canSchedule = canPublish && scheduledAt && scheduledAt > new Date()
+  const sourceAccountId = editSourceAccountId ?? selectedAccountIds[0] ?? null
 
   async function handleSaveDraft() {
     if (!hasContent || !hasChannels) return
     setIsSubmitting("draft")
     try {
-      // Create one draft per selected account
-      for (const accountId of selectedAccountIds) {
-        if (postId) {
-          await updateSocialPost(postId, {
-            content,
-            mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
-            scheduledAt: scheduledAt?.toISOString(),
-          })
-        } else {
-          await createSocialPost({
-            socialAccountId: accountId,
-            content,
-            mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
-            scheduledAt: scheduledAt?.toISOString(),
-          })
-        }
+      if (postId) {
+        await updateSocialPost(postId, {
+          content,
+          mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+          scheduledAt: scheduledAt ? scheduledAt.toISOString() : null,
+        })
+      }
+
+      const extraAccountIds = postId
+        ? selectedAccountIds.filter((accountId) => accountId !== sourceAccountId)
+        : selectedAccountIds
+
+      for (const accountId of extraAccountIds) {
+        await createSocialPost({
+          socialAccountId: accountId,
+          content,
+          mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+          scheduledAt: scheduledAt?.toISOString(),
+        })
       }
       showToast("Draft saved", "success")
       reset()
@@ -87,14 +91,33 @@ export function ComposeView() {
     if (!canSchedule) return
     setIsSubmitting("schedule")
     try {
-      for (const accountId of selectedAccountIds) {
-        const post = await createSocialPost({
+      const publishQueue: string[] = []
+
+      if (postId) {
+        const updated = await updateSocialPost(postId, {
+          content,
+          mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+          scheduledAt: scheduledAt!.toISOString(),
+        })
+        publishQueue.push(updated.id)
+      }
+
+      const extraAccountIds = postId
+        ? selectedAccountIds.filter((accountId) => accountId !== sourceAccountId)
+        : selectedAccountIds
+
+      for (const accountId of extraAccountIds) {
+        const created = await createSocialPost({
           socialAccountId: accountId,
           content,
           mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
           scheduledAt: scheduledAt!.toISOString(),
         })
-        await publishSocialPost(post.id)
+        publishQueue.push(created.id)
+      }
+
+      for (const publishPostId of publishQueue) {
+        await publishSocialPost(publishPostId)
       }
       showToast("Post scheduled", "success")
       reset()
@@ -113,13 +136,32 @@ export function ComposeView() {
     if (!canPublish) return
     setIsSubmitting("publish")
     try {
-      for (const accountId of selectedAccountIds) {
-        const post = await createSocialPost({
+      const publishQueue: string[] = []
+
+      if (postId) {
+        const updated = await updateSocialPost(postId, {
+          content,
+          mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+          scheduledAt: null,
+        })
+        publishQueue.push(updated.id)
+      }
+
+      const extraAccountIds = postId
+        ? selectedAccountIds.filter((accountId) => accountId !== sourceAccountId)
+        : selectedAccountIds
+
+      for (const accountId of extraAccountIds) {
+        const created = await createSocialPost({
           socialAccountId: accountId,
           content,
           mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
         })
-        await publishSocialPost(post.id)
+        publishQueue.push(created.id)
+      }
+
+      for (const publishPostId of publishQueue) {
+        await publishSocialPost(publishPostId)
       }
       showToast("Publishing...", "success")
       reset()

--- a/src/components/social/posts/PostRow.tsx
+++ b/src/components/social/posts/PostRow.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import {
   ChevronDownIcon,
+  CopyIcon,
   ExternalLinkIcon,
   PencilIcon,
   RefreshCwIcon,
@@ -13,6 +14,7 @@ import { format } from "date-fns"
 import { PostStatusBadge } from "./PostStatusBadge"
 import { Button } from "@/components/ui/button"
 import {
+  createSocialPost,
   deleteSocialPost,
   retrySocialPost,
 } from "@/lib/social/client"
@@ -59,6 +61,26 @@ export function PostRow({ post, onMutate }: PostRowProps) {
     } catch (error) {
       showToast(
         error instanceof Error ? error.message : "Delete failed",
+        "error",
+      )
+    } finally {
+      setIsActing(false)
+    }
+  }
+
+  async function handleDuplicate() {
+    setIsActing(true)
+    try {
+      const duplicated = await createSocialPost({
+        socialAccountId: post.socialAccountId,
+        content: post.content ?? undefined,
+        mediaUrls: (post.mediaUrls as Array<{ type: string; url: string; alt?: string }>) ?? undefined,
+      })
+      showToast("Post duplicated as draft", "success")
+      router.push(`/social/compose/${duplicated.id}`)
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : "Duplicate failed",
         "error",
       )
     } finally {
@@ -136,6 +158,15 @@ export function PostRow({ post, onMutate }: PostRowProps) {
               <Trash2Icon className="size-3.5" />
             </Button>
           )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={handleDuplicate}
+            disabled={isActing}
+          >
+            <CopyIcon className="size-3.5" />
+          </Button>
         </div>
       </div>
 

--- a/src/components/social/posts/PostRow.tsx
+++ b/src/components/social/posts/PostRow.tsx
@@ -77,7 +77,7 @@ export function PostRow({ post, onMutate }: PostRowProps) {
         mediaUrls: (post.mediaUrls as Array<{ type: string; url: string; alt?: string }>) ?? undefined,
       })
       showToast("Post duplicated as draft", "success")
-      router.push(`/social/compose/${duplicated.id}`)
+      router.push(`/social/compose?postId=${duplicated.id}`)
     } catch (error) {
       showToast(
         error instanceof Error ? error.message : "Duplicate failed",
@@ -120,7 +120,7 @@ export function PostRow({ post, onMutate }: PostRowProps) {
               variant="ghost"
               size="icon"
               className="size-7"
-              onClick={() => router.push(`/social/compose/${post.id}`)}
+              onClick={() => router.push(`/social/compose?postId=${post.id}`)}
             >
               <PencilIcon className="size-3.5" />
             </Button>

--- a/src/lib/social/automation-guards.ts
+++ b/src/lib/social/automation-guards.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@/lib/social/utils";
+
 const ALLOWED_TRIGGER_SOURCES = new Set(["schedule", "manual", "event"]);
 const LOOP_BLOCKED_TRIGGER_SOURCE = "automation";
 const SUPPORTED_ACTION_TYPE = "create_social_post";
@@ -7,10 +9,6 @@ export const MAX_REPEAT_INTERVAL_SECONDS = 60 * 60 * 24 * 30;
 export const MAX_ALLOWED_RUNS = 1000;
 export const MAX_AUTOMATION_CHAIN_LENGTH = 25;
 export const MAX_AUTOMATION_CHAIN_DELAY_SECONDS = 60 * 60 * 24 * 7;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;

--- a/src/lib/social/client.ts
+++ b/src/lib/social/client.ts
@@ -75,6 +75,7 @@ export interface SocialAccount {
   tokenExpiresAt?: string | null;
   requiresReauth: boolean;
   disabled: boolean;
+  additionalSettings?: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -124,11 +125,15 @@ export async function listSocialAccounts(): Promise<SocialAccount[]> {
 
 export async function connectSocialAccount(
   platform: string,
+  accountId?: string,
 ): Promise<{ authUrl: string }> {
   const data = await socialFetch("/api/social/accounts/connect", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ platform }),
+    body: JSON.stringify({
+      platform,
+      ...(accountId ? { accountId } : {}),
+    }),
   });
   return { authUrl: data.authUrl as string };
 }
@@ -179,10 +184,28 @@ export async function getSocialAccount(
 
 export async function disconnectSocialAccount(
   accountId: string,
+  force = false,
 ): Promise<void> {
-  await socialFetch(`/api/social/accounts/${accountId}`, {
+  const qs = force ? "?force=true" : "";
+  await socialFetch(`/api/social/accounts/${accountId}${qs}`, {
     method: "DELETE",
   });
+}
+
+export async function updateSocialAccount(
+  accountId: string,
+  input: {
+    displayName?: string;
+    disabled?: boolean;
+    additionalSettings?: Record<string, unknown> | null;
+  },
+): Promise<SocialAccount> {
+  const data = await socialFetch(`/api/social/accounts/${accountId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return data.account as SocialAccount;
 }
 
 // ---------------------------------------------------------------------------
@@ -262,4 +285,264 @@ export async function publishSocialPost(postId: string): Promise<SocialPost> {
 export async function retrySocialPost(postId: string): Promise<SocialPost> {
   // Retry uses the same publish endpoint — it accepts "failed" posts too
   return publishSocialPost(postId);
+}
+
+// ---------------------------------------------------------------------------
+// Events / Ops
+// ---------------------------------------------------------------------------
+
+export interface SocialEvent {
+  id: string;
+  workspaceId: string;
+  eventType: string;
+  severity: string;
+  message: string;
+  createdAt: string;
+  readAt?: string | null;
+  readByCurrentUser?: boolean;
+}
+
+export async function listSocialEvents(filters?: {
+  userFacing?: boolean;
+  unreadOnly?: boolean;
+  perUserReads?: boolean;
+  limit?: number;
+  offset?: number;
+}): Promise<SocialEvent[]> {
+  const params = new URLSearchParams();
+  if (filters?.userFacing !== undefined) {
+    params.set("userFacing", String(filters.userFacing));
+  }
+  if (filters?.unreadOnly !== undefined) {
+    params.set("unreadOnly", String(filters.unreadOnly));
+  }
+  if (filters?.perUserReads !== undefined) {
+    params.set("perUserReads", String(filters.perUserReads));
+  }
+  if (filters?.limit) params.set("limit", String(filters.limit));
+  if (filters?.offset) params.set("offset", String(filters.offset));
+
+  const qs = params.toString();
+  const data = await socialFetch(`/api/social/events${qs ? `?${qs}` : ""}`);
+  return (data.events as SocialEvent[]) || [];
+}
+
+export async function markSocialEventRead(
+  eventId: string,
+  options?: { perUserReads?: boolean },
+): Promise<SocialEvent> {
+  const params = new URLSearchParams();
+  if (options?.perUserReads !== undefined) {
+    params.set("perUserReads", String(options.perUserReads));
+  }
+  const qs = params.toString();
+  const data = await socialFetch(
+    `/api/social/events/${eventId}/read${qs ? `?${qs}` : ""}`,
+    { method: "POST" },
+  );
+  return data.event as SocialEvent;
+}
+
+export async function markSocialEventUnread(
+  eventId: string,
+  options?: { perUserReads?: boolean },
+): Promise<SocialEvent> {
+  const params = new URLSearchParams();
+  if (options?.perUserReads !== undefined) {
+    params.set("perUserReads", String(options.perUserReads));
+  }
+  const qs = params.toString();
+  const data = await socialFetch(
+    `/api/social/events/${eventId}/read${qs ? `?${qs}` : ""}`,
+    { method: "DELETE" },
+  );
+  return data.event as SocialEvent;
+}
+
+export interface SocialWebhook {
+  id: string;
+  workspaceId: string;
+  targetUrl: string;
+  enabled: boolean;
+  createdByUserId?: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export async function listSocialWebhooks(): Promise<SocialWebhook[]> {
+  const data = await socialFetch("/api/social/webhooks");
+  return (data.webhooks as SocialWebhook[]) || [];
+}
+
+export async function createSocialWebhook(input: {
+  targetUrl: string;
+  name?: string;
+  enabled?: boolean;
+  filters?: Record<string, unknown>;
+}): Promise<{ webhook: SocialWebhook; signingSecret?: string }> {
+  const data = await socialFetch("/api/social/webhooks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return {
+    webhook: data.webhook as SocialWebhook,
+    signingSecret: data.signingSecret as string | undefined,
+  };
+}
+
+export async function updateSocialWebhook(
+  webhookId: string,
+  input: {
+    targetUrl?: string;
+    enabled?: boolean;
+    subscription?: {
+      name?: string | null;
+      enabled?: boolean;
+      filters?: Record<string, unknown> | null;
+    };
+  },
+): Promise<{
+  webhook: SocialWebhook;
+  subscription?: Record<string, unknown> | null;
+}> {
+  const data = await socialFetch(`/api/social/webhooks/${webhookId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return {
+    webhook: data.webhook as SocialWebhook,
+    subscription: data.subscription as Record<string, unknown> | null | undefined,
+  };
+}
+
+export async function deleteSocialWebhook(webhookId: string): Promise<void> {
+  await socialFetch(`/api/social/webhooks/${webhookId}`, {
+    method: "DELETE",
+  });
+}
+
+export interface AutomationRule {
+  id: string;
+  workspaceId: string;
+  name: string;
+  triggerSource: string;
+  enabled: boolean;
+  repeatIntervalSeconds?: number | null;
+  maxRuns?: number | null;
+  totalRuns?: number;
+  actionType?: string | null;
+  actionConfig?: Record<string, unknown> | null;
+  triggerFilters?: Record<string, unknown> | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface AutomationTask {
+  id: string;
+  workspaceId: string;
+  ruleId: string;
+  taskKey: string;
+  runIndex: number;
+  state: "pending" | "claimed" | "succeeded" | "failed" | "cancelled";
+  dueAt?: string | null;
+  claimedBy?: string | null;
+  errorMessage?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export async function listAutomationRules(): Promise<AutomationRule[]> {
+  const data = await socialFetch("/api/social/automation/rules");
+  return (data.rules as AutomationRule[]) || [];
+}
+
+export async function getAutomationRule(ruleId: string): Promise<AutomationRule> {
+  const data = await socialFetch(`/api/social/automation/rules/${ruleId}`);
+  return data.rule as AutomationRule;
+}
+
+export async function updateAutomationRule(
+  ruleId: string,
+  input: Record<string, unknown>,
+): Promise<AutomationRule> {
+  const data = await socialFetch(`/api/social/automation/rules/${ruleId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return data.rule as AutomationRule;
+}
+
+export async function deleteAutomationRule(ruleId: string): Promise<void> {
+  await socialFetch(`/api/social/automation/rules/${ruleId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function listAutomationTasks(): Promise<AutomationTask[]> {
+  const data = await socialFetch("/api/social/automation/tasks");
+  return (data.tasks as AutomationTask[]) || [];
+}
+
+export async function getAutomationTask(taskId: string): Promise<AutomationTask> {
+  const data = await socialFetch(`/api/social/automation/tasks/${taskId}`);
+  return data.task as AutomationTask;
+}
+
+export async function updateAutomationTask(
+  taskId: string,
+  input: Record<string, unknown>,
+): Promise<AutomationTask> {
+  const data = await socialFetch(`/api/social/automation/tasks/${taskId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return data.task as AutomationTask;
+}
+
+export async function deleteAutomationTask(taskId: string): Promise<void> {
+  await socialFetch(`/api/social/automation/tasks/${taskId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getSocialNotificationPreferences(): Promise<{
+  inAppEnabled: boolean;
+  emailEnabled: boolean;
+  webhookEnabled: boolean;
+  muteAll: boolean;
+  preferences: Record<string, unknown> | null;
+}> {
+  const data = await socialFetch("/api/social/notifications/preferences");
+  return data.preferences as {
+    inAppEnabled: boolean;
+    emailEnabled: boolean;
+    webhookEnabled: boolean;
+    muteAll: boolean;
+    preferences: Record<string, unknown> | null;
+  };
+}
+
+export async function updateSocialNotificationPreferences(input: {
+  inAppEnabled?: boolean;
+  emailEnabled?: boolean;
+  webhookEnabled?: boolean;
+  muteAll?: boolean;
+  preferences?: Record<string, unknown> | null;
+}) {
+  const data = await socialFetch("/api/social/notifications/preferences", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return data.preferences as {
+    inAppEnabled: boolean;
+    emailEnabled: boolean;
+    webhookEnabled: boolean;
+    muteAll: boolean;
+    preferences: Record<string, unknown> | null;
+  };
 }

--- a/src/lib/social/repository.ts
+++ b/src/lib/social/repository.ts
@@ -357,6 +357,16 @@ export async function consumeOAuthState(state: string) {
   return row;
 }
 
+export async function getOAuthStateByState(state: string) {
+  const db = getDb();
+  const [row] = await db
+    .select()
+    .from(socialOAuthStates)
+    .where(eq(socialOAuthStates.state, state));
+
+  return row ?? null;
+}
+
 export async function cleanupExpiredOAuthStates() {
   const db = getDb();
   const rows = await db
@@ -412,6 +422,34 @@ export async function consumeOAuthSelectionSession(input: {
       ),
     )
     .returning();
+
+  if (!row) {
+    throw new OAuthSelectionSessionNotFoundError();
+  }
+
+  if (row.expiresAt < new Date()) {
+    throw new OAuthSelectionSessionExpiredError();
+  }
+
+  return row;
+}
+
+export async function getOAuthSelectionSession(input: {
+  selectionSessionId: string;
+  workspaceId: string;
+  platform: SocialPlatform;
+}) {
+  const db = getDb();
+  const [row] = await db
+    .select()
+    .from(socialOAuthSelectionSessions)
+    .where(
+      and(
+        eq(socialOAuthSelectionSessions.id, input.selectionSessionId),
+        eq(socialOAuthSelectionSessions.workspaceId, input.workspaceId),
+        eq(socialOAuthSelectionSessions.platform, input.platform),
+      ),
+    );
 
   if (!row) {
     throw new OAuthSelectionSessionNotFoundError();
@@ -640,6 +678,61 @@ export async function disconnectSocialAccount(
 
   // Hard delete — cascades to associated posts
   await db.delete(socialAccounts).where(eq(socialAccounts.id, accountId));
+}
+
+export async function updateSocialAccount(
+  workspaceId: string,
+  accountId: string,
+  data: {
+    displayName?: string;
+    disabled?: boolean;
+    additionalSettings?: Record<string, unknown> | null;
+  },
+) {
+  const db = getDb();
+  const [row] = await db
+    .update(socialAccounts)
+    .set({
+      ...(data.displayName !== undefined && { displayName: data.displayName }),
+      ...(data.disabled !== undefined && { disabled: data.disabled }),
+      ...(data.additionalSettings !== undefined && {
+        additionalSettings: data.additionalSettings,
+      }),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(socialAccounts.workspaceId, workspaceId),
+        eq(socialAccounts.id, accountId),
+      ),
+    )
+    .returning();
+
+  if (!row) {
+    throw new SocialAccountNotFoundError(accountId);
+  }
+
+  return row;
+}
+
+export async function countSocialPostsForAccount(
+  workspaceId: string,
+  accountId: string,
+) {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      count: sql<number>`cast(count(*) as int)`,
+    })
+    .from(socialPosts)
+    .where(
+      and(
+        eq(socialPosts.workspaceId, workspaceId),
+        eq(socialPosts.socialAccountId, accountId),
+      ),
+    );
+
+  return row?.count ?? 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -1111,9 +1204,27 @@ export async function updateSocialPost(
 ) {
   const db = getDb();
 
-  // Verify post exists and is a draft
+  // Verify post exists
   const existing = await getSocialPost(workspaceId, postId);
-  if (existing.status !== "draft") {
+  const onlyScheduledAtUpdate =
+    data.scheduledAt !== undefined &&
+    data.content === undefined &&
+    data.mediaUrls === undefined &&
+    data.platformSettings === undefined &&
+    data.rootPostId === undefined &&
+    data.kind === undefined &&
+    data.delaySeconds === undefined &&
+    data.position === undefined &&
+    data.sourceTemplatePostId === undefined &&
+    data.triggerSource === undefined &&
+    data.parentPostId === undefined;
+
+  const canEditAsDraft = existing.status === "draft";
+  const canRescheduleQueued =
+    onlyScheduledAtUpdate &&
+    (existing.status === "queued" || existing.status === "failed");
+
+  if (!canEditAsDraft && !canRescheduleQueued) {
     throw new SocialPostStateTransitionError(existing.status, "draft");
   }
 
@@ -1703,6 +1814,37 @@ export async function listSocialWebhooks(workspaceId: string) {
     .orderBy(desc(socialWebhooks.createdAt));
 }
 
+export async function updateSocialWebhook(
+  workspaceId: string,
+  webhookId: string,
+  data: {
+    targetUrl?: string;
+    enabled?: boolean;
+  },
+) {
+  const db = getDb();
+  const [row] = await db
+    .update(socialWebhooks)
+    .set({
+      ...(data.targetUrl !== undefined && { targetUrl: data.targetUrl }),
+      ...(data.enabled !== undefined && { enabled: data.enabled }),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(socialWebhooks.workspaceId, workspaceId),
+        eq(socialWebhooks.id, webhookId),
+      ),
+    )
+    .returning();
+
+  if (!row) {
+    throw new SocialWebhookNotFoundError(webhookId);
+  }
+
+  return row;
+}
+
 export async function createSocialWebhookSubscription(input: {
   workspaceId: string;
   webhookId: string;
@@ -2251,6 +2393,31 @@ export async function markSocialEventRead(workspaceId: string, eventId: string) 
     .update(socialEvents)
     .set({
       readAt: new Date(),
+    })
+    .where(
+      and(
+        eq(socialEvents.workspaceId, workspaceId),
+        eq(socialEvents.id, eventId),
+      ),
+    )
+    .returning();
+
+  if (!row) {
+    throw new SocialEventNotFoundError(eventId);
+  }
+
+  return row;
+}
+
+export async function markSocialEventUnread(
+  workspaceId: string,
+  eventId: string,
+) {
+  const db = getDb();
+  const [row] = await db
+    .update(socialEvents)
+    .set({
+      readAt: null,
     })
     .where(
       and(

--- a/src/lib/social/repository.ts
+++ b/src/lib/social/repository.ts
@@ -13,6 +13,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { getDb } from "@/lib/db";
+import { isRecord } from "@/lib/social/utils";
 import {
   socialAutomationRules,
   socialAutomationTasks,
@@ -222,10 +223,6 @@ type SocialWebhookMatchInput = {
   metadata?: Record<string, unknown> | null;
   webhookId?: string;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 function includesFilter<T extends string>(
   filterValue: unknown,

--- a/src/lib/social/utils.ts
+++ b/src/lib/social/utils.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/store/socialCalendarStore.ts
+++ b/src/store/socialCalendarStore.ts
@@ -2,15 +2,23 @@
 
 import { create } from "zustand"
 import {
+  startOfDay,
+  endOfDay,
   startOfWeek,
   endOfWeek,
+  startOfMonth,
+  endOfMonth,
+  addDays,
   addWeeks,
+  addMonths,
+  subDays,
   subWeeks,
+  subMonths,
   format,
 } from "date-fns"
 import { listSocialPosts, type SocialPost } from "@/lib/social/client"
 
-type ViewMode = "week" | "list"
+type ViewMode = "day" | "week" | "month" | "list"
 
 interface SocialCalendarState {
   viewMode: ViewMode
@@ -32,7 +40,11 @@ interface SocialCalendarState {
 
 function loadViewMode(): ViewMode {
   if (typeof window === "undefined") return "week"
-  return (localStorage.getItem("social-calendar-view") as ViewMode) ?? "week"
+  const stored = localStorage.getItem("social-calendar-view") as ViewMode | null
+  if (stored === "day" || stored === "week" || stored === "month" || stored === "list") {
+    return stored
+  }
+  return "week"
 }
 
 export const useSocialCalendarStore = create<SocialCalendarState>(
@@ -51,11 +63,25 @@ export const useSocialCalendarStore = create<SocialCalendarState>(
     },
 
     navigateNext: () => {
-      set((s) => ({ currentDate: addWeeks(s.currentDate, 1) }))
+      set((s) => ({
+        currentDate:
+          s.viewMode === "day"
+            ? addDays(s.currentDate, 1)
+            : s.viewMode === "month" || s.viewMode === "list"
+              ? addMonths(s.currentDate, 1)
+              : addWeeks(s.currentDate, 1),
+      }))
     },
 
     navigatePrev: () => {
-      set((s) => ({ currentDate: subWeeks(s.currentDate, 1) }))
+      set((s) => ({
+        currentDate:
+          s.viewMode === "day"
+            ? subDays(s.currentDate, 1)
+            : s.viewMode === "month" || s.viewMode === "list"
+              ? subMonths(s.currentDate, 1)
+              : subWeeks(s.currentDate, 1),
+      }))
     },
 
     goToToday: () => {
@@ -71,11 +97,24 @@ export const useSocialCalendarStore = create<SocialCalendarState>(
       if (get().isLoading) return
       set({ isLoading: true })
       try {
-        const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 })
-        const weekEnd = endOfWeek(currentDate, { weekStartsOn: 1 })
+        const range =
+          get().viewMode === "day"
+            ? {
+                start: startOfDay(currentDate),
+                end: endOfDay(currentDate),
+              }
+            : get().viewMode === "month" || get().viewMode === "list"
+              ? {
+                  start: startOfMonth(currentDate),
+                  end: endOfMonth(currentDate),
+                }
+              : {
+                  start: startOfWeek(currentDate, { weekStartsOn: 1 }),
+                  end: endOfWeek(currentDate, { weekStartsOn: 1 }),
+                }
         const posts = await listSocialPosts({
-          startDate: weekStart.toISOString(),
-          endDate: weekEnd.toISOString(),
+          startDate: range.start.toISOString(),
+          endDate: range.end.toISOString(),
           socialAccountId: channelFilter ?? undefined,
         })
         set({ posts, isLoading: false })
@@ -88,6 +127,13 @@ export const useSocialCalendarStore = create<SocialCalendarState>(
     getWeekEnd: () => endOfWeek(get().currentDate, { weekStartsOn: 1 }),
 
     getDateRangeLabel: () => {
+      const viewMode = get().viewMode
+      if (viewMode === "day") {
+        return format(get().currentDate, "EEEE, MMM d, yyyy")
+      }
+      if (viewMode === "month" || viewMode === "list") {
+        return format(get().currentDate, "MMMM yyyy")
+      }
       const start = startOfWeek(get().currentDate, { weekStartsOn: 1 })
       const end = endOfWeek(get().currentDate, { weekStartsOn: 1 })
       return `${format(start, "MMM d")} – ${format(end, "MMM d, yyyy")}`

--- a/src/store/socialComposerStore.ts
+++ b/src/store/socialComposerStore.ts
@@ -19,6 +19,7 @@ interface SocialComposerState {
 
   // Edit mode
   postId: string | null
+  editSourceAccountId: string | null
   isDirty: boolean
   autoSaveTimer: ReturnType<typeof setTimeout> | null
 
@@ -52,6 +53,7 @@ const INITIAL_STATE = {
   scheduledAt: null,
   platformSettings: {},
   postId: null,
+  editSourceAccountId: null,
   isDirty: false,
   autoSaveTimer: null,
 }
@@ -128,6 +130,7 @@ export const useSocialComposerStore = create<SocialComposerState>(
     loadDraft: (draft) => {
       set({
         postId: draft.postId,
+        editSourceAccountId: draft.socialAccountId,
         content: draft.content ?? "",
         mediaUrls: (draft.mediaUrls as ComposerMediaItem[]) ?? [],
         scheduledAt: draft.scheduledAt ? new Date(draft.scheduledAt) : null,


### PR DESCRIPTION
## Summary
- implement Postiz -> Node Banana social migration parity across auth, channel connect/manage, calendar/workspace, compose lifecycle, and operations surfaces
- harden OAuth callback/connect/reconnect flows and retry-safe two-step provider selection session handling
- add missing ops lifecycle APIs and client contracts for events read/unread, webhooks management, and automation rule/task management
- add secondary Social surfaces (Events, Analytics, Media, Integrations, Plugs, Agents) and navigation linkage
- add/adjust social API tests for newly introduced route behaviors

## Notes
- left unrelated local change in `public/.well-known/workflow/v1/manifest.json` out of this PR
- environment currently lacks `next` and `vitest` binaries (`pnpm exec next --version` / `pnpm exec vitest --version` fail), so full runtime test execution could not be completed here
- ran TypeScript scan filtered to non-test social implementation files with no social implementation errors
