### PR TITLE
chore: add vercel.json for deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "regions": ["iad1"],
+  "functions": {
+    "src/app/api/generate/route.ts": {
+      "maxDuration": 300
+    },
+    "src/app/api/workflow/route.ts": {
+      "maxDuration": 300
+    },
+    "src/app/api/workflow-images/route.ts": {
+      "maxDuration": 300
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` with region config (`iad1`) and extended function timeouts (300s) for long-running API routes (`generate`, `workflow`, `workflow-images`)
- Required for Vercel deployment (Pro plan for 5-min timeouts)

## Test plan
- [ ] Verify `vercel build` succeeds locally
- [ ] Deploy preview and confirm API routes respect timeout config

🤖 Generated with [Claude Code](https://claude.com/claude-code)