### PR TITLE
fix: project limit bypass and template images on Vercel

### DIFF
--- a/src/app/api/quickstart/route.ts
+++ b/src/app/api/quickstart/route.ts
@@ -9,45 +9,59 @@ import {
   parseJSONFromResponse,
 } from "@/lib/quickstart/validation";
 import { ImageInputNodeData } from "@/types";
-import fs from "fs/promises";
-import path from "path";
+import { headers } from "next/headers";
 
 export const maxDuration = 60; // 1 minute timeout
 
 /**
- * Convert local image paths (e.g., /sample-images/model.jpg) to base64 data URLs
+ * Build the base URL for fetching public assets.
+ * Works both locally (localhost) and on Vercel (where fs.readFile can't access public/).
  */
-async function convertLocalImagesToBase64(workflow: WorkflowFile): Promise<WorkflowFile> {
+function getBaseUrl(requestHeaders: Headers): string {
+  const forwardedProto = requestHeaders.get("x-forwarded-proto") || "http";
+  const host = requestHeaders.get("host") || "localhost:3000";
+  return `${forwardedProto}://${host}`;
+}
+
+/**
+ * Convert local image paths (e.g., /sample-images/model.jpg) to base64 data URLs.
+ * Uses HTTP fetch instead of fs.readFile so it works on serverless platforms (Vercel)
+ * where the public/ folder is served via CDN, not available on the filesystem.
+ */
+async function convertLocalImagesToBase64(
+  workflow: WorkflowFile,
+  baseUrl: string,
+): Promise<WorkflowFile> {
   const updatedNodes = await Promise.all(
     workflow.nodes.map(async (node) => {
       if (node.type === "imageInput") {
         const data = node.data as ImageInputNodeData;
-        // Check if image is a local path (starts with /sample-images/)
         if (data.image && data.image.startsWith("/sample-images/")) {
           try {
-            // Read file from public folder
-            const publicPath = path.join(process.cwd(), "public", data.image);
-            const fileBuffer = await fs.readFile(publicPath);
-            const base64 = fileBuffer.toString("base64");
+            const imageUrl = `${baseUrl}${data.image}`;
+            const response = await fetch(imageUrl);
+            if (!response.ok) {
+              console.error(`Failed to fetch sample image: ${imageUrl} (${response.status})`);
+              return node;
+            }
 
-            // Determine MIME type from extension
-            const ext = path.extname(data.image).toLowerCase();
-            const mimeType = ext === ".png" ? "image/png"
-              : ext === ".webp" ? "image/webp"
+            const buffer = await response.arrayBuffer();
+            const base64 = Buffer.from(buffer).toString("base64");
+
+            const ext = data.image.split(".").pop()?.toLowerCase() || "jpg";
+            const mimeType = ext === "png" ? "image/png"
+              : ext === "webp" ? "image/webp"
               : "image/jpeg";
-
-            const dataUrl = `data:${mimeType};base64,${base64}`;
 
             return {
               ...node,
               data: {
                 ...data,
-                image: dataUrl,
+                image: `data:${mimeType};base64,${base64}`,
               },
             };
           } catch (error) {
             console.error(`Failed to convert image to base64: ${data.image}`, error);
-            // Return node unchanged if conversion fails
             return node;
           }
         }
@@ -94,8 +108,10 @@ export async function POST(request: NextRequest) {
       console.log(`[Quickstart:${requestId}] Using preset template: ${templateId}`);
       try {
         const workflow = getPresetTemplate(templateId, contentLevel);
-        // Convert any local image paths to base64 for the Gemini API
-        const workflowWithBase64 = await convertLocalImagesToBase64(workflow);
+        // Convert any local image paths to base64 via HTTP fetch (works on Vercel)
+        const requestHeaders = await headers();
+        const baseUrl = getBaseUrl(requestHeaders);
+        const workflowWithBase64 = await convertLocalImagesToBase64(workflow, baseUrl);
         console.log(`[Quickstart:${requestId}] Preset template loaded successfully`);
         return NextResponse.json<QuickstartResponse>({
           success: true,

--- a/src/app/api/studio/projects/route.ts
+++ b/src/app/api/studio/projects/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isDatabaseConfigured } from "@/lib/db";
 import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
-import { countProjects, listProjects, upsertProject } from "@/lib/studio/repository";
+import { countProjects, getProject, listProjects, upsertProject } from "@/lib/studio/repository";
 import { MAX_PROJECTS_PER_WORKSPACE } from "@/lib/studio/constants";
 
 interface ProjectsGetResponse {
@@ -101,8 +101,12 @@ export async function POST(
       return authzErrorResponse(authz);
     }
 
-    // Enforce project limit on new project creation (skip for updates to existing projects)
-    if (!body.projectId) {
+    // Enforce project limit: skip only for updates to projects that already exist in the DB
+    const isExistingProject = body.projectId
+      ? Boolean(await getProject(authz.workspaceId, body.projectId))
+      : false;
+
+    if (!isExistingProject) {
       const currentCount = await countProjects(authz.workspaceId);
       if (currentCount >= MAX_PROJECTS_PER_WORKSPACE) {
         return NextResponse.json(

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -1958,8 +1958,10 @@ export function WorkflowCanvas() {
                   );
                   return;
                 }
-              } catch {
-                // If count check fails, proceed anyway — the API will enforce the limit on save
+              } catch (err) {
+                console.error("Failed to check project limit:", err);
+                showToast("Could not verify project limit. Please try again.", "error");
+                return;
               }
             }
 


### PR DESCRIPTION
## Summary
- **Project limit bypass**: Templates passed a `projectId` to the API, which skipped the limit check assuming it was an update. Now checks if the project actually exists in the DB before skipping the limit. Also stops silently swallowing client-side limit check errors.
- **Template images on Vercel**: `fs.readFile("public/...")` doesn't work on Vercel serverless (public/ is served via CDN, not on the filesystem). Raw file paths were sent to Gemini as `inline_data.data`, causing base64 decode errors. Switched to `fetch()` using the request host header.

## Test plan
- [ ] Load a template when at max project limit (3) — should show error toast, not create project
- [ ] Load a template on Vercel — images should render correctly in nodes
- [ ] Run the loaded template — Gemini should receive valid base64 image data
- [ ] Load a template on localhost — still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)