### PR TITLE
feat: Simple Studio Mode — form-based batch generation UI

### DIFF
--- a/drizzle/0013_messy_stellaris.sql
+++ b/drizzle/0013_messy_stellaris.sql
@@ -1,0 +1,221 @@
+CREATE TYPE "public"."automation_task_state" AS ENUM('pending', 'claimed', 'succeeded', 'failed', 'cancelled');--> statement-breakpoint
+CREATE TYPE "public"."saved_prompt_mode" AS ENUM('photo', 'video', 'copy');--> statement-breakpoint
+CREATE TYPE "public"."social_dispatch_run_state" AS ENUM('pending', 'claimed', 'succeeded', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."social_token_refresh_lease_state" AS ENUM('active', 'released', 'expired');--> statement-breakpoint
+CREATE TYPE "public"."social_webhook_dead_letter_replay_state" AS ENUM('dead_lettered', 'replay_requested', 'replayed', 'failed');--> statement-breakpoint
+CREATE TABLE "saved_prompts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"mode" "saved_prompt_mode" NOT NULL,
+	"name" text NOT NULL,
+	"prompt_text" text NOT NULL,
+	"form_config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"is_public" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "social_automation_rules" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"name" text NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"trigger_source" text NOT NULL,
+	"trigger_filters" jsonb,
+	"repeat_interval_seconds" integer,
+	"max_runs" integer,
+	"total_runs" integer DEFAULT 0 NOT NULL,
+	"action_type" text DEFAULT 'create_social_post' NOT NULL,
+	"action_config" jsonb,
+	"created_by_user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "social_automation_tasks" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"rule_id" text NOT NULL,
+	"task_key" text NOT NULL,
+	"run_index" integer DEFAULT 1 NOT NULL,
+	"state" "automation_task_state" DEFAULT 'pending' NOT NULL,
+	"due_at" timestamp with time zone,
+	"claim_token" text,
+	"claimed_at" timestamp with time zone,
+	"claimed_by" text,
+	"attempt_count" integer DEFAULT 0 NOT NULL,
+	"input" jsonb,
+	"result" jsonb,
+	"error_message" text,
+	"source_post_id" text,
+	"source_event_id" text,
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "social_dispatch_runs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"dispatch_key" text NOT NULL,
+	"state" "social_dispatch_run_state" DEFAULT 'pending' NOT NULL,
+	"kind" text DEFAULT 'post' NOT NULL,
+	"post_id" text,
+	"event_id" text,
+	"account_id" text,
+	"provider" "social_platform",
+	"claim_token" text,
+	"claimed_at" timestamp with time zone,
+	"finalized_at" timestamp with time zone,
+	"error_message" text,
+	"result" jsonb,
+	"payload" jsonb,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "social_event_reads" (
+	"event_id" text NOT NULL,
+	"workspace_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"read_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "social_event_reads_pk" PRIMARY KEY("event_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "social_notification_preferences" (
+	"workspace_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"in_app_enabled" boolean DEFAULT true NOT NULL,
+	"email_enabled" boolean DEFAULT false NOT NULL,
+	"webhook_enabled" boolean DEFAULT false NOT NULL,
+	"mute_all" boolean DEFAULT false NOT NULL,
+	"preferences" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "social_notification_preferences_pk" PRIMARY KEY("workspace_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "social_token_refresh_leases" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"social_account_id" text NOT NULL,
+	"lease_token" text NOT NULL,
+	"state" "social_token_refresh_lease_state" DEFAULT 'active' NOT NULL,
+	"leased_at" timestamp with time zone NOT NULL,
+	"lease_expires_at" timestamp with time zone NOT NULL,
+	"released_at" timestamp with time zone,
+	"claimed_by" text,
+	"last_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "social_webhook_delivery_dead_letters" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"delivery_id" text NOT NULL,
+	"webhook_id" text NOT NULL,
+	"event_id" text NOT NULL,
+	"dead_letter_reason" text NOT NULL,
+	"response_status" integer,
+	"response_body" text,
+	"replay_state" "social_webhook_dead_letter_replay_state" DEFAULT 'dead_lettered' NOT NULL,
+	"dead_lettered_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"replay_requested_at" timestamp with time zone,
+	"replay_requested_by_user_id" text,
+	"replay_metadata" jsonb,
+	"replay_delivery_id" text,
+	"replayed_at" timestamp with time zone,
+	"replay_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "social_webhook_subscriptions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"webhook_id" text NOT NULL,
+	"name" text,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"filters" jsonb,
+	"created_by_user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "social_posts" ADD COLUMN "root_post_id" text;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD COLUMN "kind" text DEFAULT 'post' NOT NULL;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD COLUMN "delay_seconds" integer;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD COLUMN "position" integer;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD COLUMN "source_template_post_id" text;--> statement-breakpoint
+ALTER TABLE "social_posts" ADD COLUMN "trigger_source" text;--> statement-breakpoint
+ALTER TABLE "saved_prompts" ADD CONSTRAINT "saved_prompts_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_automation_rules" ADD CONSTRAINT "social_automation_rules_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_automation_rules" ADD CONSTRAINT "social_automation_rules_created_by_user_id_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."user"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_automation_tasks" ADD CONSTRAINT "social_automation_tasks_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_automation_tasks" ADD CONSTRAINT "social_automation_tasks_rule_id_social_automation_rules_id_fk" FOREIGN KEY ("rule_id") REFERENCES "public"."social_automation_rules"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_automation_tasks" ADD CONSTRAINT "social_automation_tasks_source_post_id_social_posts_id_fk" FOREIGN KEY ("source_post_id") REFERENCES "public"."social_posts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_automation_tasks" ADD CONSTRAINT "social_automation_tasks_source_event_id_social_events_id_fk" FOREIGN KEY ("source_event_id") REFERENCES "public"."social_events"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_dispatch_runs" ADD CONSTRAINT "social_dispatch_runs_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_dispatch_runs" ADD CONSTRAINT "social_dispatch_runs_post_id_social_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."social_posts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_dispatch_runs" ADD CONSTRAINT "social_dispatch_runs_event_id_social_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."social_events"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_dispatch_runs" ADD CONSTRAINT "social_dispatch_runs_account_id_social_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."social_accounts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_event_reads" ADD CONSTRAINT "social_event_reads_event_id_social_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."social_events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_event_reads" ADD CONSTRAINT "social_event_reads_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_event_reads" ADD CONSTRAINT "social_event_reads_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_notification_preferences" ADD CONSTRAINT "social_notification_preferences_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_notification_preferences" ADD CONSTRAINT "social_notification_preferences_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_token_refresh_leases" ADD CONSTRAINT "social_token_refresh_leases_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_token_refresh_leases" ADD CONSTRAINT "social_token_refresh_leases_social_account_id_social_accounts_id_fk" FOREIGN KEY ("social_account_id") REFERENCES "public"."social_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_delivery_dead_letters" ADD CONSTRAINT "social_webhook_delivery_dead_letters_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_delivery_dead_letters" ADD CONSTRAINT "social_webhook_delivery_dead_letters_delivery_id_social_webhook_deliveries_id_fk" FOREIGN KEY ("delivery_id") REFERENCES "public"."social_webhook_deliveries"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_delivery_dead_letters" ADD CONSTRAINT "social_webhook_delivery_dead_letters_webhook_id_social_webhooks_id_fk" FOREIGN KEY ("webhook_id") REFERENCES "public"."social_webhooks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_delivery_dead_letters" ADD CONSTRAINT "social_webhook_delivery_dead_letters_event_id_social_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."social_events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_delivery_dead_letters" ADD CONSTRAINT "social_webhook_delivery_dead_letters_replay_requested_by_user_id_user_id_fk" FOREIGN KEY ("replay_requested_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_delivery_dead_letters" ADD CONSTRAINT "social_webhook_delivery_dead_letters_replay_delivery_id_social_webhook_deliveries_id_fk" FOREIGN KEY ("replay_delivery_id") REFERENCES "public"."social_webhook_deliveries"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_subscriptions" ADD CONSTRAINT "social_webhook_subscriptions_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_subscriptions" ADD CONSTRAINT "social_webhook_subscriptions_webhook_id_social_webhooks_id_fk" FOREIGN KEY ("webhook_id") REFERENCES "public"."social_webhooks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "social_webhook_subscriptions" ADD CONSTRAINT "social_webhook_subscriptions_created_by_user_id_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."user"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "saved_prompts_workspace_deleted_idx" ON "saved_prompts" USING btree ("workspace_id","deleted_at");--> statement-breakpoint
+CREATE INDEX "saved_prompts_public_mode_deleted_idx" ON "saved_prompts" USING btree ("is_public","mode","deleted_at");--> statement-breakpoint
+CREATE INDEX "saved_prompts_created_at_idx" ON "saved_prompts" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "social_automation_rules_workspace_idx" ON "social_automation_rules" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "social_automation_rules_enabled_idx" ON "social_automation_rules" USING btree ("enabled");--> statement-breakpoint
+CREATE INDEX "social_automation_rules_trigger_source_idx" ON "social_automation_rules" USING btree ("trigger_source");--> statement-breakpoint
+CREATE INDEX "social_automation_rules_created_at_idx" ON "social_automation_rules" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "social_automation_tasks_workspace_idx" ON "social_automation_tasks" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "social_automation_tasks_rule_idx" ON "social_automation_tasks" USING btree ("rule_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "social_automation_tasks_task_key_unique" ON "social_automation_tasks" USING btree ("task_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "social_automation_tasks_rule_run_index_unique" ON "social_automation_tasks" USING btree ("rule_id","run_index");--> statement-breakpoint
+CREATE INDEX "social_automation_tasks_state_idx" ON "social_automation_tasks" USING btree ("state");--> statement-breakpoint
+CREATE INDEX "social_automation_tasks_due_at_idx" ON "social_automation_tasks" USING btree ("due_at");--> statement-breakpoint
+CREATE INDEX "social_automation_tasks_run_index_idx" ON "social_automation_tasks" USING btree ("run_index");--> statement-breakpoint
+CREATE INDEX "social_automation_tasks_claimed_at_idx" ON "social_automation_tasks" USING btree ("claimed_at");--> statement-breakpoint
+CREATE INDEX "social_automation_tasks_created_at_idx" ON "social_automation_tasks" USING btree ("created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "social_dispatch_runs_dispatch_key_unique" ON "social_dispatch_runs" USING btree ("dispatch_key");--> statement-breakpoint
+CREATE INDEX "social_dispatch_runs_workspace_idx" ON "social_dispatch_runs" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "social_dispatch_runs_state_idx" ON "social_dispatch_runs" USING btree ("state");--> statement-breakpoint
+CREATE INDEX "social_dispatch_runs_created_at_idx" ON "social_dispatch_runs" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "social_event_reads_workspace_idx" ON "social_event_reads" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "social_event_reads_user_idx" ON "social_event_reads" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "social_event_reads_read_at_idx" ON "social_event_reads" USING btree ("read_at");--> statement-breakpoint
+CREATE INDEX "social_notification_preferences_user_idx" ON "social_notification_preferences" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "social_token_refresh_leases_social_account_unique" ON "social_token_refresh_leases" USING btree ("social_account_id");--> statement-breakpoint
+CREATE INDEX "social_token_refresh_leases_workspace_idx" ON "social_token_refresh_leases" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "social_token_refresh_leases_state_idx" ON "social_token_refresh_leases" USING btree ("state");--> statement-breakpoint
+CREATE INDEX "social_token_refresh_leases_expires_at_idx" ON "social_token_refresh_leases" USING btree ("lease_expires_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "social_webhook_delivery_dead_letters_delivery_unique" ON "social_webhook_delivery_dead_letters" USING btree ("delivery_id");--> statement-breakpoint
+CREATE INDEX "social_webhook_delivery_dead_letters_workspace_idx" ON "social_webhook_delivery_dead_letters" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "social_webhook_delivery_dead_letters_replay_state_idx" ON "social_webhook_delivery_dead_letters" USING btree ("replay_state");--> statement-breakpoint
+CREATE INDEX "social_webhook_delivery_dead_letters_created_at_idx" ON "social_webhook_delivery_dead_letters" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "social_webhook_subscriptions_workspace_idx" ON "social_webhook_subscriptions" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "social_webhook_subscriptions_webhook_idx" ON "social_webhook_subscriptions" USING btree ("webhook_id");--> statement-breakpoint
+CREATE INDEX "social_webhook_subscriptions_enabled_idx" ON "social_webhook_subscriptions" USING btree ("enabled");--> statement-breakpoint
+CREATE INDEX "social_webhook_subscriptions_created_at_idx" ON "social_webhook_subscriptions" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "social_posts_root_post_idx" ON "social_posts" USING btree ("root_post_id");--> statement-breakpoint
+CREATE INDEX "social_posts_source_template_post_idx" ON "social_posts" USING btree ("source_template_post_id");--> statement-breakpoint
+CREATE INDEX "social_posts_kind_idx" ON "social_posts" USING btree ("kind");--> statement-breakpoint
+CREATE INDEX "social_posts_trigger_source_idx" ON "social_posts" USING btree ("trigger_source");

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,5247 @@
+{
+  "id": "b599c9fe-7256-45c6-84b9-dc9d6e516b73",
+  "prevId": "145536ba-a903-4cd0-9012-c6d935bbf585",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "storage_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "assets_workspace_idx": {
+          "name": "assets_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_idx": {
+          "name": "assets_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_storage_provider_key_unique": {
+          "name": "assets_storage_provider_key_unique",
+          "columns": [
+            {
+              "expression": "storage_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_created_at_idx": {
+          "name": "assets_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_workspace_id_workspaces_id_fk": {
+          "name": "assets_workspace_id_workspaces_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assets_created_by_user_id_user_id_fk": {
+          "name": "assets_created_by_user_id_user_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_jobs": {
+      "name": "generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "generation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_asset_id": {
+          "name": "result_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "generation_jobs_workspace_idx": {
+          "name": "generation_jobs_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_project_idx": {
+          "name": "generation_jobs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_status_idx": {
+          "name": "generation_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_created_at_idx": {
+          "name": "generation_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_jobs_workspace_id_workspaces_id_fk": {
+          "name": "generation_jobs_workspace_id_workspaces_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_project_id_projects_id_fk": {
+          "name": "generation_jobs_project_id_projects_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_result_asset_id_assets_id_fk": {
+          "name": "generation_jobs_result_asset_id_assets_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "result_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_created_by_user_id_user_id_fk": {
+          "name": "generation_jobs_created_by_user_id_user_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_idx": {
+          "name": "invitation_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_user_unique": {
+          "name": "member_organization_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_idx": {
+          "name": "member_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_idx": {
+          "name": "member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_directory_path": {
+          "name": "source_directory_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_json": {
+          "name": "workflow_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_workspace_slug_unique": {
+          "name": "projects_workspace_slug_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_workspace_idx": {
+          "name": "projects_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_workspaces_id_fk": {
+          "name": "projects_workspace_id_workspaces_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_user_id_fk": {
+          "name": "projects_created_by_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_prompts": {
+      "name": "saved_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "saved_prompt_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_config": {
+          "name": "form_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "saved_prompts_workspace_deleted_idx": {
+          "name": "saved_prompts_workspace_deleted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_prompts_public_mode_deleted_idx": {
+          "name": "saved_prompts_public_mode_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_prompts_created_at_idx": {
+          "name": "saved_prompts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_prompts_workspace_id_workspaces_id_fk": {
+          "name": "saved_prompts_workspace_id_workspaces_id_fk",
+          "tableFrom": "saved_prompts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_accounts": {
+      "name": "social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_secret": {
+          "name": "access_token_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_settings": {
+          "name": "additional_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_reauth": {
+          "name": "requires_reauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_accounts_workspace_platform_user_unique": {
+          "name": "social_accounts_workspace_platform_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_workspace_idx": {
+          "name": "social_accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_created_at_idx": {
+          "name": "social_accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_accounts_workspace_id_workspaces_id_fk": {
+          "name": "social_accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_accounts_created_by_user_id_user_id_fk": {
+          "name": "social_accounts_created_by_user_id_user_id_fk",
+          "tableFrom": "social_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_automation_rules": {
+      "name": "social_automation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_filters": {
+          "name": "trigger_filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repeat_interval_seconds": {
+          "name": "repeat_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_runs": {
+          "name": "max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'create_social_post'"
+        },
+        "action_config": {
+          "name": "action_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_automation_rules_workspace_idx": {
+          "name": "social_automation_rules_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_enabled_idx": {
+          "name": "social_automation_rules_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_trigger_source_idx": {
+          "name": "social_automation_rules_trigger_source_idx",
+          "columns": [
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_created_at_idx": {
+          "name": "social_automation_rules_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_automation_rules_workspace_id_workspaces_id_fk": {
+          "name": "social_automation_rules_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_automation_rules",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_rules_created_by_user_id_user_id_fk": {
+          "name": "social_automation_rules_created_by_user_id_user_id_fk",
+          "tableFrom": "social_automation_rules",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_automation_tasks": {
+      "name": "social_automation_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_index": {
+          "name": "run_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "state": {
+          "name": "state",
+          "type": "automation_task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_post_id": {
+          "name": "source_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_automation_tasks_workspace_idx": {
+          "name": "social_automation_tasks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_rule_idx": {
+          "name": "social_automation_tasks_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_task_key_unique": {
+          "name": "social_automation_tasks_task_key_unique",
+          "columns": [
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_rule_run_index_unique": {
+          "name": "social_automation_tasks_rule_run_index_unique",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_state_idx": {
+          "name": "social_automation_tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_due_at_idx": {
+          "name": "social_automation_tasks_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_run_index_idx": {
+          "name": "social_automation_tasks_run_index_idx",
+          "columns": [
+            {
+              "expression": "run_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_claimed_at_idx": {
+          "name": "social_automation_tasks_claimed_at_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_created_at_idx": {
+          "name": "social_automation_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_automation_tasks_workspace_id_workspaces_id_fk": {
+          "name": "social_automation_tasks_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_rule_id_social_automation_rules_id_fk": {
+          "name": "social_automation_tasks_rule_id_social_automation_rules_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_automation_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_source_post_id_social_posts_id_fk": {
+          "name": "social_automation_tasks_source_post_id_social_posts_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "source_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_source_event_id_social_events_id_fk": {
+          "name": "social_automation_tasks_source_event_id_social_events_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_dispatch_runs": {
+      "name": "social_dispatch_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "social_dispatch_run_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_dispatch_runs_dispatch_key_unique": {
+          "name": "social_dispatch_runs_dispatch_key_unique",
+          "columns": [
+            {
+              "expression": "dispatch_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_workspace_idx": {
+          "name": "social_dispatch_runs_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_state_idx": {
+          "name": "social_dispatch_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_created_at_idx": {
+          "name": "social_dispatch_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_dispatch_runs_workspace_id_workspaces_id_fk": {
+          "name": "social_dispatch_runs_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_post_id_social_posts_id_fk": {
+          "name": "social_dispatch_runs_post_id_social_posts_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_event_id_social_events_id_fk": {
+          "name": "social_dispatch_runs_event_id_social_events_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_account_id_social_accounts_id_fk": {
+          "name": "social_dispatch_runs_account_id_social_accounts_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_event_reads": {
+      "name": "social_event_reads",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_event_reads_workspace_idx": {
+          "name": "social_event_reads_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_event_reads_user_idx": {
+          "name": "social_event_reads_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_event_reads_read_at_idx": {
+          "name": "social_event_reads_read_at_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_event_reads_event_id_social_events_id_fk": {
+          "name": "social_event_reads_event_id_social_events_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_event_reads_workspace_id_workspaces_id_fk": {
+          "name": "social_event_reads_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_event_reads_user_id_user_id_fk": {
+          "name": "social_event_reads_user_id_user_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "social_event_reads_pk": {
+          "name": "social_event_reads_pk",
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_events": {
+      "name": "social_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "social_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "social_event_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_facing": {
+          "name": "user_facing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_ref": {
+          "name": "workflow_run_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_events_workspace_idx": {
+          "name": "social_events_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_event_type_idx": {
+          "name": "social_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_user_facing_idx": {
+          "name": "social_events_user_facing_idx",
+          "columns": [
+            {
+              "expression": "user_facing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_read_at_idx": {
+          "name": "social_events_read_at_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_post_idx": {
+          "name": "social_events_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_account_idx": {
+          "name": "social_events_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_created_at_idx": {
+          "name": "social_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_events_workspace_id_workspaces_id_fk": {
+          "name": "social_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_events_post_id_social_posts_id_fk": {
+          "name": "social_events_post_id_social_posts_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_events_account_id_social_accounts_id_fk": {
+          "name": "social_events_account_id_social_accounts_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_events_created_by_user_id_user_id_fk": {
+          "name": "social_events_created_by_user_id_user_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_notification_preferences": {
+      "name": "social_notification_preferences",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_app_enabled": {
+          "name": "in_app_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mute_all": {
+          "name": "mute_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_notification_preferences_user_idx": {
+          "name": "social_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_notification_preferences_workspace_id_workspaces_id_fk": {
+          "name": "social_notification_preferences_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_notification_preferences",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_notification_preferences_user_id_user_id_fk": {
+          "name": "social_notification_preferences_user_id_user_id_fk",
+          "tableFrom": "social_notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "social_notification_preferences_pk": {
+          "name": "social_notification_preferences_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_oauth_selection_sessions": {
+      "name": "social_oauth_selection_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_secret": {
+          "name": "access_token_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_oauth_selection_sessions_workspace_idx": {
+          "name": "social_oauth_selection_sessions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_oauth_selection_sessions_expires_at_idx": {
+          "name": "social_oauth_selection_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_oauth_selection_sessions_workspace_id_workspaces_id_fk": {
+          "name": "social_oauth_selection_sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_oauth_selection_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_oauth_selection_sessions_created_by_user_id_user_id_fk": {
+          "name": "social_oauth_selection_sessions_created_by_user_id_user_id_fk",
+          "tableFrom": "social_oauth_selection_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_oauth_states": {
+      "name": "social_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_oauth_states_state_unique": {
+          "name": "social_oauth_states_state_unique",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_oauth_states_expires_at_idx": {
+          "name": "social_oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_account_id": {
+          "name": "social_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "root_post_id": {
+          "name": "root_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_status": {
+          "name": "dispatch_status",
+          "type": "social_dispatch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workflow_run_ref": {
+          "name": "workflow_run_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "delay_seconds": {
+          "name": "delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_template_post_id": {
+          "name": "source_template_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_settings": {
+          "name": "platform_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_url": {
+          "name": "platform_post_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parent_post_id": {
+          "name": "parent_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "studio_asset_id": {
+          "name": "studio_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_posts_workspace_idx": {
+          "name": "social_posts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_account_idx": {
+          "name": "social_posts_account_idx",
+          "columns": [
+            {
+              "expression": "social_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_root_post_idx": {
+          "name": "social_posts_root_post_idx",
+          "columns": [
+            {
+              "expression": "root_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_source_template_post_idx": {
+          "name": "social_posts_source_template_post_idx",
+          "columns": [
+            {
+              "expression": "source_template_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_kind_idx": {
+          "name": "social_posts_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_trigger_source_idx": {
+          "name": "social_posts_trigger_source_idx",
+          "columns": [
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_dispatch_status_idx": {
+          "name": "social_posts_dispatch_status_idx",
+          "columns": [
+            {
+              "expression": "dispatch_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_next_dispatch_at_idx": {
+          "name": "social_posts_next_dispatch_at_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_scheduled_at_idx": {
+          "name": "social_posts_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_posts_workspace_id_workspaces_id_fk": {
+          "name": "social_posts_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_posts_social_account_id_social_accounts_id_fk": {
+          "name": "social_posts_social_account_id_social_accounts_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "social_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_posts_studio_asset_id_assets_id_fk": {
+          "name": "social_posts_studio_asset_id_assets_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "studio_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_posts_created_by_user_id_user_id_fk": {
+          "name": "social_posts_created_by_user_id_user_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_token_refresh_leases": {
+      "name": "social_token_refresh_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_account_id": {
+          "name": "social_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "social_token_refresh_lease_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "leased_at": {
+          "name": "leased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_token_refresh_leases_social_account_unique": {
+          "name": "social_token_refresh_leases_social_account_unique",
+          "columns": [
+            {
+              "expression": "social_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_workspace_idx": {
+          "name": "social_token_refresh_leases_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_state_idx": {
+          "name": "social_token_refresh_leases_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_expires_at_idx": {
+          "name": "social_token_refresh_leases_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_token_refresh_leases_workspace_id_workspaces_id_fk": {
+          "name": "social_token_refresh_leases_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_token_refresh_leases",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_token_refresh_leases_social_account_id_social_accounts_id_fk": {
+          "name": "social_token_refresh_leases_social_account_id_social_accounts_id_fk",
+          "tableFrom": "social_token_refresh_leases",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "social_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_deliveries": {
+      "name": "social_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_webhook_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_deliveries_workspace_idx": {
+          "name": "social_webhook_deliveries_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_webhook_idx": {
+          "name": "social_webhook_deliveries_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_event_idx": {
+          "name": "social_webhook_deliveries_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_status_idx": {
+          "name": "social_webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_next_attempt_at_idx": {
+          "name": "social_webhook_deliveries_next_attempt_at_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_locked_at_idx": {
+          "name": "social_webhook_deliveries_locked_at_idx",
+          "columns": [
+            {
+              "expression": "locked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_created_at_idx": {
+          "name": "social_webhook_deliveries_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_deliveries_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_deliveries_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_deliveries_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_deliveries_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_deliveries_event_id_social_events_id_fk": {
+          "name": "social_webhook_deliveries_event_id_social_events_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_delivery_dead_letters": {
+      "name": "social_webhook_delivery_dead_letters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dead_letter_reason": {
+          "name": "dead_letter_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_state": {
+          "name": "replay_state",
+          "type": "social_webhook_dead_letter_replay_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dead_lettered'"
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "replay_requested_at": {
+          "name": "replay_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_requested_by_user_id": {
+          "name": "replay_requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_metadata": {
+          "name": "replay_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_delivery_id": {
+          "name": "replay_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replayed_at": {
+          "name": "replayed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_error": {
+          "name": "replay_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_delivery_dead_letters_delivery_unique": {
+          "name": "social_webhook_delivery_dead_letters_delivery_unique",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_workspace_idx": {
+          "name": "social_webhook_delivery_dead_letters_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_replay_state_idx": {
+          "name": "social_webhook_delivery_dead_letters_replay_state_idx",
+          "columns": [
+            {
+              "expression": "replay_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_created_at_idx": {
+          "name": "social_webhook_delivery_dead_letters_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_delivery_dead_letters_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_delivery_id_social_webhook_deliveries_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_delivery_id_social_webhook_deliveries_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhook_deliveries",
+          "columnsFrom": [
+            "delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_event_id_social_events_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_event_id_social_events_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_replay_requested_by_user_id_user_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_replay_requested_by_user_id_user_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "user",
+          "columnsFrom": [
+            "replay_requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_replay_delivery_id_social_webhook_deliveries_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_replay_delivery_id_social_webhook_deliveries_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhook_deliveries",
+          "columnsFrom": [
+            "replay_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_subscriptions": {
+      "name": "social_webhook_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_subscriptions_workspace_idx": {
+          "name": "social_webhook_subscriptions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_webhook_idx": {
+          "name": "social_webhook_subscriptions_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_enabled_idx": {
+          "name": "social_webhook_subscriptions_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_created_at_idx": {
+          "name": "social_webhook_subscriptions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_subscriptions_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_subscriptions_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_subscriptions_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_subscriptions_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_subscriptions_created_by_user_id_user_id_fk": {
+          "name": "social_webhook_subscriptions_created_by_user_id_user_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhooks": {
+      "name": "social_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret_encrypted": {
+          "name": "signing_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhooks_workspace_idx": {
+          "name": "social_webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhooks_enabled_idx": {
+          "name": "social_webhooks_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhooks_created_at_idx": {
+          "name": "social_webhooks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhooks_workspace_id_workspaces_id_fk": {
+          "name": "social_webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhooks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhooks_created_by_user_id_user_id_fk": {
+          "name": "social_webhooks_created_by_user_id_user_id_fk",
+          "tableFrom": "social_webhooks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_value_unique": {
+          "name": "verification_identifier_value_unique",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_members_user_idx": {
+          "name": "workspace_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_user_id_fk": {
+          "name": "workspace_members_user_id_user_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_pk": {
+          "name": "workspace_members_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_settings": {
+      "name": "workspace_settings",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "brand_kit": {
+          "name": "brand_kit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_customer_id": {
+          "name": "billing_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_subscription_id": {
+          "name": "billing_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_metadata": {
+          "name": "billing_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_settings_organization_unique": {
+          "name": "workspace_settings_organization_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_settings_plan_tier_idx": {
+          "name": "workspace_settings_plan_tier_idx",
+          "columns": [
+            {
+              "expression": "plan_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_settings_workspace_id_workspaces_id_fk": {
+          "name": "workspace_settings_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_settings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_settings_organization_id_organization_id_fk": {
+          "name": "workspace_settings_organization_id_organization_id_fk",
+          "tableFrom": "workspace_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_storage_limits": {
+      "name": "workspace_storage_limits",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quota_bytes": {
+          "name": "quota_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_storage_limits_workspace_id_workspaces_id_fk": {
+          "name": "workspace_storage_limits_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_storage_limits",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_kit": {
+          "name": "brand_kit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspaces_slug_unique": {
+          "name": "workspaces_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_owner_idx": {
+          "name": "workspaces_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_user_id_user_id_fk": {
+          "name": "workspaces_owner_user_id_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "video",
+        "audio",
+        "model3d",
+        "workflow"
+      ]
+    },
+    "public.automation_task_state": {
+      "name": "automation_task_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.generation_status": {
+      "name": "generation_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "enterprise"
+      ]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.saved_prompt_mode": {
+      "name": "saved_prompt_mode",
+      "schema": "public",
+      "values": [
+        "photo",
+        "video",
+        "copy"
+      ]
+    },
+    "public.social_dispatch_run_state": {
+      "name": "social_dispatch_run_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.social_dispatch_status": {
+      "name": "social_dispatch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "dispatched",
+        "retry_scheduled",
+        "failed"
+      ]
+    },
+    "public.social_event_severity": {
+      "name": "social_event_severity",
+      "schema": "public",
+      "values": [
+        "info",
+        "warn",
+        "error"
+      ]
+    },
+    "public.social_event_type": {
+      "name": "social_event_type",
+      "schema": "public",
+      "values": [
+        "post.queued",
+        "post.publishing",
+        "post.published",
+        "post.failed",
+        "account.reauth_required",
+        "token.refreshed",
+        "dispatch.failed"
+      ]
+    },
+    "public.social_platform": {
+      "name": "social_platform",
+      "schema": "public",
+      "values": [
+        "x",
+        "linkedin",
+        "instagram",
+        "tiktok",
+        "threads",
+        "pinterest",
+        "facebook",
+        "youtube",
+        "reddit"
+      ]
+    },
+    "public.social_post_status": {
+      "name": "social_post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "queued",
+        "publishing",
+        "published",
+        "failed"
+      ]
+    },
+    "public.social_token_refresh_lease_state": {
+      "name": "social_token_refresh_lease_state",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired"
+      ]
+    },
+    "public.social_webhook_dead_letter_replay_state": {
+      "name": "social_webhook_dead_letter_replay_state",
+      "schema": "public",
+      "values": [
+        "dead_lettered",
+        "replay_requested",
+        "replayed",
+        "failed"
+      ]
+    },
+    "public.social_webhook_delivery_status": {
+      "name": "social_webhook_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed"
+      ]
+    },
+    "public.storage_provider": {
+      "name": "storage_provider",
+      "schema": "public",
+      "values": [
+        "local",
+        "s3",
+        "r2"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1774641300000,
       "tag": "0012_social_backfill_safety",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1775058174503,
+      "tag": "0013_messy_stellaris",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.64",
     "@ai-sdk/google": "^3.0.13",
+    "@ai-sdk/openai": "^3.0.49",
     "@ai-sdk/react": "^3.0.51",
     "@aws-sdk/client-s3": "^3.1014.0",
     "@aws-sdk/lib-storage": "^3.1019.0",
@@ -78,6 +80,7 @@
     "shadcn": "^4.1.0",
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
+    "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.1.17",
     "three": "^0.182.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.64
+        version: 3.0.64(zod@4.3.6)
       '@ai-sdk/google':
         specifier: ^3.0.13
         version: 3.0.18(zod@4.3.6)
+      '@ai-sdk/openai':
+        specifier: ^3.0.49
+        version: 3.0.49(zod@4.3.6)
       '@ai-sdk/react':
         specifier: ^3.0.51
         version: 3.0.66(react@19.2.4)(zod@4.3.6)
@@ -143,6 +149,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      streamdown:
+        specifier: ^2.5.0
+        version: 2.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -231,6 +240,12 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/anthropic@3.0.64':
+    resolution: {integrity: sha512-rwLi/Rsuj2pYniQXIrvClHvXDzgM4UQHHnvHTWEF14efnlKclG/1ghpNC+adsRujAbCTr6gRsSbDE2vEqriV7g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.29':
     resolution: {integrity: sha512-zf6yXT+7DcVGWG7ntxVCYC48X/opsWlO5ePvgH8W9DaEVUtkemqKUEzBqowQ778PkZo8sqMnRfD0+fi9HamRRQ==}
     engines: {node: '>=18'}
@@ -243,14 +258,30 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@3.0.49':
+    resolution: {integrity: sha512-U2f0pCyNn/jQH3wjgxr8o9VvCkuDFTtXbIhbFFtgXqCzMbed6rBnvzQcAMEK0/Pa44byL9zfcvCOFOflvkRA8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.11':
     resolution: {integrity: sha512-y/WOPpcZaBjvNaogy83mBsCRPvbtaK0y1sY9ckRrrbTGMvG2HC/9Y/huqNXKnLAxUIME2PGa2uvF2CDwIsxoXQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.21':
+    resolution: {integrity: sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.6':
     resolution: {integrity: sha512-hSfoJtLtpMd7YxKM+iTqlJ0ZB+kJ83WESMiWuWrNVey3X8gg97x0OdAAaeAeclZByCX3UdPOTqhvJdK8qYA3ww==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@3.0.66':
@@ -262,6 +293,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@asamuzakjp/css-color@4.1.1':
     resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
@@ -729,6 +763,9 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
     resolution: {integrity: sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==}
     cpu: [arm64]
@@ -758,6 +795,21 @@ packages:
     resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
     cpu: [x64]
     os: [win32]
+
+  '@chevrotain/cst-dts-gen@11.1.2':
+    resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
+
+  '@chevrotain/gast@11.1.2':
+    resolution: {integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==}
+
+  '@chevrotain/regexp-to-ast@11.1.2':
+    resolution: {integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@chevrotain/utils@11.1.2':
+    resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1485,6 +1537,12 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.0':
+    resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
+
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
@@ -1683,6 +1741,9 @@ packages:
 
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
+  '@mermaid-js/parser@1.1.0':
+    resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
 
   '@modelcontextprotocol/sdk@1.28.0':
     resolution: {integrity: sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==}
@@ -2807,20 +2868,68 @@ packages:
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
 
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
   '@types/d3-path@3.1.1':
     resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
 
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
@@ -2830,6 +2939,9 @@ packages:
 
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
 
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
@@ -2842,6 +2954,9 @@ packages:
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -2863,6 +2978,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -2921,6 +3039,9 @@ packages:
   '@types/three@0.182.0':
     resolution: {integrity: sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2944,6 +3065,9 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@use-gesture/core@10.3.1':
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
@@ -3596,6 +3720,14 @@ packages:
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
 
+  chevrotain-allstar@0.3.1:
+    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
+    peerDependencies:
+      chevrotain: ^11.0.0
+
+  chevrotain@11.1.2:
+    resolution: {integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -3680,6 +3812,10 @@ packages:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -3735,6 +3871,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig@9.0.1:
     resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
@@ -3775,12 +3917,49 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.1:
+    resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
 
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
     engines: {node: '>=12'}
 
   d3-dispatch@3.0.1:
@@ -3791,20 +3970,63 @@ packages:
     resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
     engines: {node: '>=12'}
 
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
     engines: {node: '>=12'}
 
   d3-format@3.1.2:
     resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
     engines: {node: '>=12'}
 
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
     engines: {node: '>=12'}
 
   d3-scale@4.0.2:
@@ -3814,6 +4036,9 @@ packages:
   d3-selection@3.0.0:
     resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
     engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
 
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
@@ -3841,6 +4066,13 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -3851,6 +4083,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3924,6 +4159,9 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -3967,6 +4205,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -4186,6 +4427,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -4513,6 +4758,9 @@ packages:
     resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
     engines: {node: '>=18'}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -4529,11 +4777,29 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
@@ -4557,6 +4823,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -4591,6 +4860,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
@@ -4633,6 +4906,9 @@ packages:
 
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
@@ -4867,8 +5143,15 @@ packages:
   jws@4.0.0:
     resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
+  katex@0.16.44:
+    resolution: {integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -4895,6 +5178,16 @@ packages:
   kysely@0.28.14:
     resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
     engines: {node: '>=20.0.0'}
+
+  langium@4.2.1:
+    resolution: {integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -4984,6 +5277,9 @@ packages:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
@@ -5030,6 +5326,19 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@17.0.5:
+    resolution: {integrity: sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -5037,8 +5346,29 @@ packages:
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -5092,6 +5422,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  mermaid@11.14.0:
+    resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
+
   meshline@3.3.1:
     resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
     peerDependencies:
@@ -5106,6 +5439,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -5453,6 +5807,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -5471,6 +5828,9 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -5480,6 +5840,9 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
@@ -5576,6 +5939,12 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -5836,11 +6205,29 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
+  rehype-harden@1.1.8:
+    resolution: {integrity: sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remend@1.3.0:
+    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -5885,6 +6272,9 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.55.1:
     resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -5892,6 +6282,9 @@ packages:
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -5903,6 +6296,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -6094,6 +6490,12 @@ packages:
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
+  streamdown@2.5.0:
+    resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -6174,6 +6576,9 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  stylis@4.3.6:
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -6321,6 +6726,10 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -6499,6 +6908,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -6512,6 +6925,9 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -6604,6 +7020,26 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -6614,6 +7050,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -6828,6 +7267,12 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/anthropic@3.0.64(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/gateway@3.0.29(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.6
@@ -6841,6 +7286,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.11(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/openai@3.0.49(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.11(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.6
@@ -6848,7 +7299,18 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.21(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider@3.0.6':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
@@ -6863,6 +7325,11 @@ snapshots:
       - zod
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.0.2
 
   '@asamuzakjp/css-color@4.1.1':
     dependencies:
@@ -7703,6 +8170,8 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
     optional: true
 
@@ -7720,6 +8189,23 @@ snapshots:
 
   '@cbor-extract/cbor-extract-win32-x64@2.2.2':
     optional: true
+
+  '@chevrotain/cst-dts-gen@11.1.2':
+    dependencies:
+      '@chevrotain/gast': 11.1.2
+      '@chevrotain/types': 11.1.2
+      lodash-es: 4.17.23
+
+  '@chevrotain/gast@11.1.2':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+      lodash-es: 4.17.23
+
+  '@chevrotain/regexp-to-ast@11.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
+
+  '@chevrotain/utils@11.1.2': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -8144,6 +8630,14 @@ snapshots:
     dependencies:
       hono: 4.12.9
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.0':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      mlly: 1.8.2
+
   '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -8299,6 +8793,10 @@ snapshots:
   '@lukeed/csprng@1.1.0': {}
 
   '@mediapipe/tasks-vision@0.10.17': {}
+
+  '@mermaid-js/parser@1.1.0':
+    dependencies:
+      langium: 4.2.1
 
   '@modelcontextprotocol/sdk@1.28.0(zod@3.25.76)':
     dependencies:
@@ -9463,19 +9961,62 @@ snapshots:
 
   '@types/d3-array@3.2.2': {}
 
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
   '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
 
   '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.11
 
+  '@types/d3-dsv@3.0.7': {}
+
   '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
 
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
 
   '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
 
   '@types/d3-scale@4.0.9':
     dependencies:
@@ -9486,6 +10027,8 @@ snapshots:
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
 
   '@types/d3-time@3.0.4': {}
 
@@ -9499,6 +10042,39 @@ snapshots:
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
 
   '@types/debug@4.1.12':
     dependencies:
@@ -9519,6 +10095,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -9582,6 +10160,9 @@ snapshots:
       fflate: 0.8.2
       meshoptimizer: 0.22.0
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -9599,6 +10180,11 @@ snapshots:
       '@types/webidl-conversions': 7.0.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@use-gesture/core@10.3.1': {}
 
@@ -10475,6 +11061,20 @@ snapshots:
 
   charenc@0.0.2: {}
 
+  chevrotain-allstar@0.3.1(chevrotain@11.1.2):
+    dependencies:
+      chevrotain: 11.1.2
+      lodash-es: 4.17.23
+
+  chevrotain@11.1.2:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 11.1.2
+      '@chevrotain/gast': 11.1.2
+      '@chevrotain/regexp-to-ast': 11.1.2
+      '@chevrotain/types': 11.1.2
+      '@chevrotain/utils': 11.1.2
+      lodash-es: 4.17.23
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -10540,6 +11140,8 @@ snapshots:
 
   commander@6.2.1: {}
 
+  commander@7.2.0: {}
+
   commander@8.3.0: {}
 
   confbox@0.1.8: {}
@@ -10574,6 +11176,14 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
@@ -10614,11 +11224,49 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.1
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.1):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.1
+
+  cytoscape@3.33.1: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
 
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
 
   d3-dispatch@3.0.1: {}
 
@@ -10627,15 +11275,55 @@ snapshots:
       d3-dispatch: 3.0.1
       d3-selection: 3.0.0
 
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
   d3-ease@3.0.1: {}
 
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
 
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
 
+  d3-path@1.0.9: {}
+
   d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
 
   d3-scale@4.0.2:
     dependencies:
@@ -10646,6 +11334,10 @@ snapshots:
       d3-time-format: 4.1.0
 
   d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
 
   d3-shape@3.2.0:
     dependencies:
@@ -10678,6 +11370,44 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.17.23
+
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@6.0.0:
@@ -10686,6 +11416,8 @@ snapshots:
       whatwg-url: 15.1.0
 
   date-fns@4.1.0: {}
+
+  dayjs@1.11.20: {}
 
   debug@2.6.9:
     dependencies:
@@ -10735,6 +11467,10 @@ snapshots:
 
   defu@6.1.4: {}
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -10768,6 +11504,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.3.1: {}
 
@@ -10979,6 +11719,8 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   esprima@4.0.1: {}
 
@@ -11416,6 +12158,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hachure-fill@0.5.2: {}
+
   has-flag@4.0.0: {}
 
   has-flag@5.0.1: {}
@@ -11425,6 +12169,43 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
@@ -11446,9 +12227,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   headers-polyfill@4.0.3: {}
 
@@ -11469,6 +12268,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -11515,6 +12316,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -11545,6 +12350,8 @@ snapshots:
   inspect-with-kind@1.0.5:
     dependencies:
       kind-of: 6.0.3
+
+  internmap@1.0.1: {}
 
   internmap@2.0.3: {}
 
@@ -11753,9 +12560,15 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.44:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
 
@@ -11770,6 +12583,18 @@ snapshots:
   konva@10.0.12: {}
 
   kysely@0.28.14: {}
+
+  langium@4.2.1:
+    dependencies:
+      chevrotain: 11.1.2
+      chevrotain-allstar: 0.3.1(chevrotain@11.1.2)
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lie@3.3.0:
     dependencies:
@@ -11834,6 +12659,8 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
+  lodash-es@4.17.23: {}
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
@@ -11876,6 +12703,12 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
+  markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
+
+  marked@17.0.5: {}
+
   math-intrinsics@1.1.0: {}
 
   md5@2.3.0:
@@ -11883,6 +12716,13 @@ snapshots:
       charenc: 0.0.2
       crypt: 0.0.2
       is-buffer: 1.1.6
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -11898,6 +12738,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -11994,6 +12891,30 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  mermaid@11.14.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.0
+      '@mermaid-js/parser': 1.1.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.3.3
+      katex: 0.16.44
+      khroma: 2.1.0
+      lodash-es: 4.17.23
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.3.6
+      ts-dedent: 2.2.0
+      uuid: 11.1.0
+
   meshline@3.3.1(three@0.182.0):
     dependencies:
       three: 0.182.0
@@ -12019,6 +12940,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -12385,6 +13364,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.6.0: {}
+
   pako@1.0.11: {}
 
   parent-module@1.0.1:
@@ -12410,6 +13391,10 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -12417,6 +13402,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@5.0.0: {}
 
@@ -12501,6 +13488,13 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -12780,6 +13774,32 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
+  rehype-harden@1.1.8:
+    dependencies:
+      unist-util-visit: 5.1.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -12796,6 +13816,14 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remend@1.3.0: {}
 
   require-directory@2.1.1: {}
 
@@ -12827,6 +13855,8 @@ snapshots:
   rimraf@5.0.10:
     dependencies:
       glob: 10.5.0
+
+  robust-predicates@3.0.3: {}
 
   rollup@4.55.1:
     dependencies:
@@ -12861,6 +13891,13 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -12876,6 +13913,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -13141,6 +14180,29 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  streamdown@2.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      clsx: 2.1.1
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      marked: 17.0.5
+      mermaid: 11.14.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      rehype-harden: 1.1.8
+      rehype-raw: 7.0.0
+      rehype-sanitize: 6.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remend: 1.3.0
+      tailwind-merge: 3.5.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -13228,6 +14290,8 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.28.5
+
+  stylis@4.3.6: {}
 
   supports-color@10.2.2: {}
 
@@ -13375,6 +14439,8 @@ snapshots:
   troika-worker-utils@0.52.0: {}
 
   trough@2.2.0: {}
+
+  ts-dedent@2.2.0: {}
 
   ts-morph@26.0.0:
     dependencies:
@@ -13550,6 +14616,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@11.1.0: {}
+
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
@@ -13562,6 +14630,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
 
   vfile-message@4.0.3:
     dependencies:
@@ -13655,6 +14728,23 @@ snapshots:
       - tsx
       - yaml
 
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-uri@3.1.0: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -13668,6 +14758,8 @@ snapshots:
     dependencies:
       defaults: 1.0.4
     optional: true
+
+  web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/src/app/api/generate/providers/gemini.ts
+++ b/src/app/api/generate/providers/gemini.ts
@@ -51,9 +51,18 @@ export async function generateWithGemini(
   // Initialize Gemini client
   const ai = new GoogleGenAI({ apiKey });
 
+  // Hint aspect ratio in the prompt text as a workaround for gemini-2.5-flash-image
+  // sometimes ignoring imageConfig.aspectRatio (known server-side issue)
+  const AR_LABELS: Record<string, string> = {
+    "9:16": "9:16 portrait", "16:9": "16:9 landscape",
+    "4:5": "4:5 portrait", "1:1": "1:1 square",
+  };
+  const arLabel = aspectRatio ? AR_LABELS[aspectRatio] : null;
+  const augmentedPrompt = arLabel && prompt ? `${prompt} [aspect ratio: ${arLabel}]` : prompt;
+
   // Build request parts array with prompt and all images
   const requestParts: Array<{ text: string } | { inlineData: { mimeType: string; data: string } }> = [
-    { text: prompt },
+    { text: augmentedPrompt },
     ...imageData.map(({ data, mimeType }) => ({
       inlineData: {
         mimeType,
@@ -226,11 +235,14 @@ export async function generateWithGeminiVideo(
     numberOfVideos: 1,
   };
 
-  if (parameters.aspectRatio) {
-    config.aspectRatio = parameters.aspectRatio;
-  }
-  if (parameters.durationSeconds) {
-    config.durationSeconds = Number(parameters.durationSeconds);
+  // Veo only supports "16:9" and "9:16"; map anything else to "16:9"
+  const VALID_VEO_RATIOS = new Set(["16:9", "9:16"]);
+  const requestedRatio = parameters.aspectRatio as string | undefined;
+  config.aspectRatio = requestedRatio && VALID_VEO_RATIOS.has(requestedRatio) ? requestedRatio : "16:9";
+  const durationVal = parameters.durationSeconds ?? parameters.duration;
+  if (durationVal !== undefined && durationVal !== null && durationVal !== "") {
+    // Veo API accepts durationSeconds between 4 and 8 inclusive
+    config.durationSeconds = Math.min(8, Math.max(4, Number(durationVal)));
   }
   if (parameters.resolution) {
     config.resolution = parameters.resolution;

--- a/src/app/api/generate/providers/kie.ts
+++ b/src/app/api/generate/providers/kie.ts
@@ -414,6 +414,18 @@ export async function generateWithKie(
     Object.assign(inputParams, input.parameters);
   }
 
+  // Normalize parameter names for Kie API (expects snake_case)
+  // User's camelCase aspectRatio (from simple studio) overrides default aspect_ratio
+  if (inputParams.aspectRatio !== undefined) {
+    inputParams.aspect_ratio = inputParams.aspectRatio;
+    delete inputParams.aspectRatio;
+  }
+
+  // Coerce duration to string (Kie API requires string for duration)
+  if (inputParams.duration !== undefined && typeof inputParams.duration !== 'string') {
+    inputParams.duration = String(inputParams.duration);
+  }
+
   // GPT Image 1.5 does NOT support 'size' parameter - only 'aspect_ratio'
   // Remove any stale 'size' values from old workflow data
   if (modelId.startsWith("gpt-image/1.5")) {

--- a/src/app/api/studio/copy/route.ts
+++ b/src/app/api/studio/copy/route.ts
@@ -1,0 +1,81 @@
+import { streamText, UIMessage, convertToModelMessages } from "ai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+
+export const maxDuration = 60;
+
+/**
+ * LLM model registry for Simple Studio copy mode.
+ * Maps our model IDs to AI SDK provider constructors.
+ */
+const MODEL_REGISTRY: Record<
+  string,
+  { provider: "google" | "openai" | "anthropic"; modelId: string; envKey: string }
+> = {
+  // Google
+  "gemini-2.5-flash": { provider: "google", modelId: "gemini-2.5-flash", envKey: "GEMINI_API_KEY" },
+  "gemini-3-flash-preview": { provider: "google", modelId: "gemini-3-flash-preview", envKey: "GEMINI_API_KEY" },
+  "gemini-3-pro-preview": { provider: "google", modelId: "gemini-3-pro-preview", envKey: "GEMINI_API_KEY" },
+  // OpenAI
+  "gpt-4.1-mini": { provider: "openai", modelId: "gpt-4.1-mini", envKey: "OPENAI_API_KEY" },
+  "gpt-4.1-nano": { provider: "openai", modelId: "gpt-4.1-nano", envKey: "OPENAI_API_KEY" },
+  // Anthropic
+  "claude-sonnet-4.5": { provider: "anthropic", modelId: "claude-sonnet-4-5-20250929", envKey: "ANTHROPIC_API_KEY" },
+  "claude-haiku-4.5": { provider: "anthropic", modelId: "claude-haiku-4-5-20251001", envKey: "ANTHROPIC_API_KEY" },
+};
+
+function createModel(modelKey: string) {
+  const entry = MODEL_REGISTRY[modelKey];
+  if (!entry) throw new Error(`Unknown model: ${modelKey}`);
+
+  const apiKey = process.env[entry.envKey];
+  if (!apiKey) throw new Error(`${entry.envKey} not configured`);
+
+  switch (entry.provider) {
+    case "google": {
+      const google = createGoogleGenerativeAI({ apiKey });
+      return google(entry.modelId);
+    }
+    case "openai": {
+      const openai = createOpenAI({ apiKey });
+      return openai(entry.modelId);
+    }
+    case "anthropic": {
+      const anthropic = createAnthropic({ apiKey });
+      return anthropic(entry.modelId);
+    }
+  }
+}
+
+interface CopyRequest {
+  messages: UIMessage[];
+  model?: string;
+  system?: string;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { messages, model: modelKey, system } = (await request.json()) as CopyRequest;
+
+    const resolvedModel = modelKey || "gemini-2.5-flash";
+    const aiModel = createModel(resolvedModel);
+    const modelMessages = await convertToModelMessages(messages);
+
+    const result = streamText({
+      model: aiModel,
+      system,
+      messages: modelMessages,
+      temperature: 0.9,
+      maxOutputTokens: 2048,
+    });
+
+    return result.toUIMessageStreamResponse();
+  } catch (error) {
+    console.error("[Copy API Error]", error);
+    return new Response(
+      error instanceof Error ? error.message : "Copy generation failed",
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/studio/prompts/[promptId]/route.ts
+++ b/src/app/api/studio/prompts/[promptId]/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
+import { getPrompt, updatePrompt, softDeletePrompt } from "@/lib/studio/repository";
+
+interface PromptResponse {
+  success: boolean;
+  prompt?: Awaited<ReturnType<typeof getPrompt>>;
+  error?: string;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ promptId: string }> },
+): Promise<NextResponse<PromptResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const { promptId } = await params;
+    const body = await request.json();
+
+    const authz = await authorizeStudioRequest(request, {
+      route: "/api/studio/prompts",
+      action: "write",
+    });
+    if (!authz.authorized) {
+      return authzErrorResponse(authz);
+    }
+
+    // Verify prompt exists and belongs to workspace
+    const existing = await getPrompt(authz.workspaceId, promptId);
+    if (!existing) {
+      return NextResponse.json(
+        { success: false, error: "Prompt not found." },
+        { status: 404 },
+      );
+    }
+
+    const prompt = await updatePrompt(authz.workspaceId, promptId, {
+      name: body.name,
+      promptText: body.promptText,
+      formConfig: body.formConfig,
+      isPublic: body.isPublic,
+    });
+
+    return NextResponse.json({ success: true, prompt });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to update prompt",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ promptId: string }> },
+): Promise<NextResponse<PromptResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const { promptId } = await params;
+
+    const authz = await authorizeStudioRequest(request, {
+      route: "/api/studio/prompts",
+      action: "write",
+    });
+    if (!authz.authorized) {
+      return authzErrorResponse(authz);
+    }
+
+    const prompt = await softDeletePrompt(authz.workspaceId, promptId);
+    if (!prompt) {
+      return NextResponse.json(
+        { success: false, error: "Prompt not found." },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ success: true, prompt });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to delete prompt",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/studio/prompts/__tests__/route.test.ts
+++ b/src/app/api/studio/prompts/__tests__/route.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockAuthorizeStudioRequest = vi.fn();
+const mockListPrompts = vi.fn();
+const mockCreatePrompt = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/studio/authz", () => {
+  return {
+    authorizeStudioRequest: (...args: unknown[]) => mockAuthorizeStudioRequest(...args),
+    authzErrorResponse: (result: { status: number; error: string }) =>
+      NextResponse.json(
+        { success: false, error: result.error },
+        { status: result.status },
+      ),
+  };
+});
+
+vi.mock("@/lib/studio/repository", () => ({
+  listPrompts: (...args: unknown[]) => mockListPrompts(...args),
+  createPrompt: (...args: unknown[]) => mockCreatePrompt(...args),
+}));
+
+import { GET, POST } from "../route";
+
+function createGetRequest(mode?: string): NextRequest {
+  const url = mode
+    ? `http://localhost:3000/api/studio/prompts?mode=${mode}`
+    : "http://localhost:3000/api/studio/prompts";
+  return {
+    headers: new Headers(),
+    nextUrl: new URL(url),
+    json: vi.fn(),
+  } as unknown as NextRequest;
+}
+
+function createPostRequest(body: Record<string, unknown>): NextRequest {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL("http://localhost:3000/api/studio/prompts"),
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as NextRequest;
+}
+
+const authorizedResult = {
+  authorized: true,
+  workspaceId: "ws_test",
+  userId: "user_test",
+};
+
+describe("/api/studio/prompts GET", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: false,
+      status: 401,
+      error: "Please sign in to access AI Studio.",
+      reason: "unauthenticated",
+    });
+
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+  });
+
+  it("returns 403 for non-members", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: false,
+      status: 403,
+      error: "No access to this workspace.",
+      reason: "forbidden",
+    });
+
+    const response = await GET(createGetRequest());
+    expect(response.status).toBe(403);
+  });
+
+  it("returns prompts for authorized user", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+    mockListPrompts.mockResolvedValue([
+      { id: "sp_1", name: "Test Prompt", mode: "photo" },
+    ]);
+
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.prompts).toHaveLength(1);
+    expect(mockListPrompts).toHaveBeenCalledWith("ws_test", undefined);
+  });
+
+  it("filters by mode when provided", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+    mockListPrompts.mockResolvedValue([]);
+
+    await GET(createGetRequest("video"));
+
+    expect(mockListPrompts).toHaveBeenCalledWith("ws_test", "video");
+  });
+
+  it("returns 400 for invalid mode", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+
+    const response = await GET(createGetRequest("invalid"));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+  });
+});
+
+describe("/api/studio/prompts POST", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when name is missing", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+
+    const response = await POST(
+      createPostRequest({ mode: "photo", promptText: "test" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("name");
+  });
+
+  it("returns 400 when promptText is missing", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+
+    const response = await POST(
+      createPostRequest({ mode: "photo", name: "Test" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("text");
+  });
+
+  it("returns 400 for invalid mode", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+
+    const response = await POST(
+      createPostRequest({ mode: "invalid", name: "Test", promptText: "test" }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("creates prompt for valid input", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+    mockCreatePrompt.mockResolvedValue({
+      id: "sp_123",
+      name: "My Prompt",
+      mode: "photo",
+      promptText: "Generate a product photo",
+      formConfig: { aspectRatio: "1:1" },
+    });
+
+    const response = await POST(
+      createPostRequest({
+        mode: "photo",
+        name: "My Prompt",
+        promptText: "Generate a product photo",
+        formConfig: { aspectRatio: "1:1" },
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.prompt.name).toBe("My Prompt");
+    expect(mockCreatePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws_test",
+        mode: "photo",
+        name: "My Prompt",
+        promptText: "Generate a product photo",
+      }),
+    );
+  });
+});

--- a/src/app/api/studio/prompts/public/route.ts
+++ b/src/app/api/studio/prompts/public/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
+import { listPublicPrompts } from "@/lib/studio/repository";
+
+interface PublicPromptsGetResponse {
+  success: boolean;
+  prompts?: Awaited<ReturnType<typeof listPublicPrompts>>;
+  error?: string;
+}
+
+const VALID_MODES = new Set(["photo", "video", "copy"]);
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<PublicPromptsGetResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    // Public prompts require authentication but not workspace write access
+    const authz = await authorizeStudioRequest(request, {
+      route: "/api/studio/prompts/public",
+      action: "read",
+    });
+    if (!authz.authorized) {
+      return authzErrorResponse(authz);
+    }
+
+    const mode = request.nextUrl.searchParams.get("mode") || undefined;
+    if (mode && !VALID_MODES.has(mode)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid mode. Must be photo, video, or copy." },
+        { status: 400 },
+      );
+    }
+
+    const prompts = await listPublicPrompts(mode);
+    return NextResponse.json({ success: true, prompts });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to list public prompts",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/studio/prompts/route.ts
+++ b/src/app/api/studio/prompts/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
+import { createPrompt, listPrompts } from "@/lib/studio/repository";
+
+interface PromptsGetResponse {
+  success: boolean;
+  prompts?: Awaited<ReturnType<typeof listPrompts>>;
+  error?: string;
+}
+
+interface PromptsPostRequest {
+  mode: "photo" | "video" | "copy";
+  name: string;
+  promptText: string;
+  formConfig?: Record<string, unknown>;
+  isPublic?: boolean;
+}
+
+interface PromptsPostResponse {
+  success: boolean;
+  prompt?: Awaited<ReturnType<typeof createPrompt>>;
+  error?: string;
+}
+
+const VALID_MODES = new Set(["photo", "video", "copy"]);
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<PromptsGetResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const authz = await authorizeStudioRequest(request, {
+      route: "/api/studio/prompts",
+      action: "read",
+    });
+    if (!authz.authorized) {
+      return authzErrorResponse(authz);
+    }
+
+    const mode = request.nextUrl.searchParams.get("mode") || undefined;
+    if (mode && !VALID_MODES.has(mode)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid mode. Must be photo, video, or copy." },
+        { status: 400 },
+      );
+    }
+
+    const prompts = await listPrompts(authz.workspaceId, mode);
+    return NextResponse.json({ success: true, prompts });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to list prompts",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<PromptsPostResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const body = (await request.json()) as PromptsPostRequest;
+
+    if (!body.name?.trim()) {
+      return NextResponse.json(
+        { success: false, error: "Prompt name is required." },
+        { status: 400 },
+      );
+    }
+    if (!body.promptText?.trim()) {
+      return NextResponse.json(
+        { success: false, error: "Prompt text is required." },
+        { status: 400 },
+      );
+    }
+    if (!body.mode || !VALID_MODES.has(body.mode)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid mode. Must be photo, video, or copy." },
+        { status: 400 },
+      );
+    }
+
+    const authz = await authorizeStudioRequest(request, {
+      route: "/api/studio/prompts",
+      action: "write",
+    });
+    if (!authz.authorized) {
+      return authzErrorResponse(authz);
+    }
+
+    const prompt = await createPrompt({
+      workspaceId: authz.workspaceId,
+      mode: body.mode,
+      name: body.name.trim(),
+      promptText: body.promptText.trim(),
+      formConfig: body.formConfig || {},
+      isPublic: body.isPublic ?? false,
+    });
+
+    return NextResponse.json({ success: true, prompt });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to create prompt",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/studio/simple/SimpleStudioClient.tsx
+++ b/src/app/studio/simple/SimpleStudioClient.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Header } from "@/components/Header";
+
+/**
+ * Simple Studio — form-based batch generation UI.
+ *
+ * Two-panel layout: left sidebar (form) + right panel (results gallery).
+ * Actual sidebar form and gallery components will be added in subsequent issues.
+ */
+export function SimpleStudioClient() {
+  return (
+    <div className="h-screen flex flex-col">
+      <Header />
+      <div className="flex-1 flex overflow-hidden">
+        {/* Left sidebar — form */}
+        <aside className="w-[380px] shrink-0 border-e border-neutral-800 bg-neutral-900/50 overflow-y-auto">
+          <div className="p-6 text-neutral-500 text-sm">
+            Sidebar form will go here
+          </div>
+        </aside>
+
+        {/* Right panel — results gallery */}
+        <main className="flex-1 overflow-y-auto bg-neutral-950">
+          <div className="p-6 text-neutral-500 text-sm">
+            Results gallery will go here
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/studio/simple/SimpleStudioClient.tsx
+++ b/src/app/studio/simple/SimpleStudioClient.tsx
@@ -11,11 +11,11 @@ import { ResultsGallery } from "@/components/simple-studio/ResultsGallery";
  */
 export function SimpleStudioClient() {
   return (
-    <div className="h-screen flex flex-col">
+    <div className="h-screen flex flex-col bg-neutral-950">
       <Header />
       <div className="flex-1 flex overflow-hidden">
         {/* Left sidebar — form */}
-        <aside className="w-[380px] shrink-0 border-e border-neutral-800 bg-neutral-900/50 overflow-y-auto">
+        <aside className="w-[380px] shrink-0 border-e border-neutral-800 bg-neutral-900 overflow-y-auto">
           <Sidebar />
         </aside>
 

--- a/src/app/studio/simple/SimpleStudioClient.tsx
+++ b/src/app/studio/simple/SimpleStudioClient.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { Header } from "@/components/Header";
+import { Sidebar } from "@/components/simple-studio/Sidebar";
+import { ResultsGallery } from "@/components/simple-studio/ResultsGallery";
 
 /**
  * Simple Studio — form-based batch generation UI.
  *
  * Two-panel layout: left sidebar (form) + right panel (results gallery).
- * Actual sidebar form and gallery components will be added in subsequent issues.
  */
 export function SimpleStudioClient() {
   return (
@@ -15,16 +16,12 @@ export function SimpleStudioClient() {
       <div className="flex-1 flex overflow-hidden">
         {/* Left sidebar — form */}
         <aside className="w-[380px] shrink-0 border-e border-neutral-800 bg-neutral-900/50 overflow-y-auto">
-          <div className="p-6 text-neutral-500 text-sm">
-            Sidebar form will go here
-          </div>
+          <Sidebar />
         </aside>
 
         {/* Right panel — results gallery */}
         <main className="flex-1 overflow-y-auto bg-neutral-950">
-          <div className="p-6 text-neutral-500 text-sm">
-            Results gallery will go here
-          </div>
+          <ResultsGallery />
         </main>
       </div>
     </div>

--- a/src/app/studio/simple/page.tsx
+++ b/src/app/studio/simple/page.tsx
@@ -1,0 +1,5 @@
+import { SimpleStudioClient } from "./SimpleStudioClient";
+
+export default function SimpleStudioPage() {
+  return <SimpleStudioClient />;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useState, useMemo, useCallback } from "react";
 import { useWorkflowStore, WorkflowFile } from "@/store/workflowStore";
 import { useShallow } from "zustand/shallow";
@@ -67,6 +67,8 @@ function CommentsNavigationIcon() {
 
 export function Header() {
   const router = useRouter();
+  const pathname = usePathname();
+  const isSimpleMode = pathname?.startsWith("/studio/simple");
   const { data: session } = authClient.useSession();
   const {
     workflowName,
@@ -279,7 +281,33 @@ export function Header() {
             </h1>
           </button>
 
-          <div className="flex items-center gap-2 ms-4 ps-4 border-s border-neutral-700">
+          {/* Mode switcher pill */}
+          <div className="flex items-center ms-4 ps-4 border-s border-neutral-700">
+            <div className="flex items-center bg-neutral-800 rounded-md p-0.5">
+              <button
+                onClick={() => router.push("/studio/simple")}
+                className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
+                  isSimpleMode
+                    ? "bg-neutral-700 text-neutral-100"
+                    : "text-neutral-400 hover:text-neutral-200"
+                }`}
+              >
+                Simple
+              </button>
+              <button
+                onClick={() => router.push("/studio")}
+                className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
+                  !isSimpleMode
+                    ? "bg-neutral-700 text-neutral-100"
+                    : "text-neutral-400 hover:text-neutral-200"
+                }`}
+              >
+                Workflow
+              </button>
+            </div>
+          </div>
+
+          {!isSimpleMode && <div className="flex items-center gap-2 ms-4 ps-4 border-s border-neutral-700">
             {isProjectConfigured ? (
               <>
                 <span className="text-sm text-neutral-300">{workflowName}</span>
@@ -428,11 +456,11 @@ export function Header() {
                 {settingsButtons}
               </>
             )}
-          </div>
+          </div>}
         </div>
 
         <div className="flex items-center gap-3 text-xs">
-          {previousWorkflowSnapshot && (
+          {!isSimpleMode && previousWorkflowSnapshot && (
             <button
               onClick={handleRevertAIChanges}
               className="px-2.5 py-1.5 text-xs text-neutral-300 hover:text-neutral-100 bg-neutral-700/50 hover:bg-neutral-700 border border-neutral-600 rounded transition-colors"
@@ -442,7 +470,7 @@ export function Header() {
             </button>
           )}
           <LanguageSwitcher className="text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800" />
-          <CommentsNavigationIcon />
+          {!isSimpleMode && <CommentsNavigationIcon />}
           {session?.user ? (
             <>
               <span className="text-neutral-300 truncate max-w-[220px]" title={sessionLabel}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -501,41 +501,45 @@ export function Header() {
               </Link>
             </>
           )}
-          <span className="text-neutral-500">·</span>
-          <span className="text-neutral-400">
-            {isProjectConfigured ? (
-              isSaving ? (
-                "Saving..."
-              ) : lastSavedAt ? (
-                `Saved ${formatTime(lastSavedAt)}`
-              ) : (
-                "Not saved"
-              )
-            ) : (
-              "Not saved"
-            )}
-          </span>
-          <span className="text-neutral-500">·</span>
-          <a
-            href="https://x.com/abodiatrash"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-neutral-400 hover:text-neutral-200 transition-colors"
-          >
-            Made by abodi
-          </a>
-          <span className="text-neutral-500">·</span>
-          <button
-            onClick={() => setShortcutsDialogOpen(true)}
-            className="text-neutral-400 hover:text-neutral-200 transition-colors"
-            title="Keyboard shortcuts (?)"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75A2.25 2.25 0 014.5 4.5h15a2.25 2.25 0 012.25 2.25v10.5A2.25 2.25 0 0119.5 19.5h-15a2.25 2.25 0 01-2.25-2.25V6.75z" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M8 16h8" />
-            </svg>
-          </button>
-          <span className="text-neutral-500">·</span>
+          {!isSimpleMode && (
+            <>
+              <span className="text-neutral-500">·</span>
+              <span className="text-neutral-400">
+                {isProjectConfigured ? (
+                  isSaving ? (
+                    "Saving..."
+                  ) : lastSavedAt ? (
+                    `Saved ${formatTime(lastSavedAt)}`
+                  ) : (
+                    "Not saved"
+                  )
+                ) : (
+                  "Not saved"
+                )}
+              </span>
+              <span className="text-neutral-500">·</span>
+              <a
+                href="https://x.com/abodiatrash"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-neutral-400 hover:text-neutral-200 transition-colors"
+              >
+                Made by abodi
+              </a>
+              <span className="text-neutral-500">·</span>
+              <button
+                onClick={() => setShortcutsDialogOpen(true)}
+                className="text-neutral-400 hover:text-neutral-200 transition-colors"
+                title="Keyboard shortcuts (?)"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75A2.25 2.25 0 014.5 4.5h15a2.25 2.25 0 012.25 2.25v10.5A2.25 2.25 0 0119.5 19.5h-15a2.25 2.25 0 01-2.25-2.25V6.75z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M8 16h8" />
+                </svg>
+              </button>
+            </>
+          )}
+          {!isSimpleMode && <span className="text-neutral-500">·</span>}
           {/* <a
             href="https://discord.com/invite/89Nr6EKkTf"
             target="_blank"

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -21,7 +21,9 @@ vi.mock("@/lib/studio/client", () => ({
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     replace: (...args: unknown[]) => mockRouterReplace(...args),
+    push: vi.fn(),
   }),
+  usePathname: () => "/studio",
 }));
 
 // Mock the workflow store

--- a/src/components/simple-studio/GenerationCard.tsx
+++ b/src/components/simple-studio/GenerationCard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { type Generation } from "@/store/simpleStudioStore";
+
+interface GenerationCardProps {
+  generation: Generation;
+  onRetry?: () => void;
+}
+
+export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
+  const { status, result, error, mode } = generation;
+
+  // Loading state
+  if (status === "pending" || status === "generating") {
+    return (
+      <div className="aspect-square bg-neutral-800/50 border border-neutral-700/50 rounded-lg flex items-center justify-center">
+        <div className="flex flex-col items-center gap-2">
+          <div className="w-6 h-6 border-2 border-neutral-600 border-t-neutral-300 rounded-full animate-spin" />
+          <span className="text-[10px] text-neutral-500">
+            {status === "pending" ? "Queued" : "Generating..."}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (status === "failed") {
+    return (
+      <div className="aspect-square bg-neutral-800/50 border border-red-900/30 rounded-lg flex items-center justify-center p-3">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+          </svg>
+          <span className="text-[10px] text-red-400 line-clamp-2">{error || "Failed"}</span>
+          {onRetry && (
+            <button
+              onClick={onRetry}
+              className="text-[10px] text-blue-400 hover:text-blue-300 underline"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Copy mode — text card
+  if (mode === "copy" && result) {
+    return (
+      <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-lg p-4 min-h-[120px]">
+        <p className="text-sm text-neutral-200 leading-relaxed whitespace-pre-wrap" dir="auto">
+          {result}
+        </p>
+        <div className="mt-3 flex justify-end">
+          <button
+            onClick={() => navigator.clipboard.writeText(result)}
+            className="text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Video result
+  if (mode === "video" && result) {
+    return (
+      <div className="relative aspect-video bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group">
+        <video
+          src={result}
+          className="w-full h-full object-cover"
+          controls
+          preload="metadata"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
+        <a
+          href={result}
+          download
+          className="absolute bottom-2 end-2 p-1.5 bg-neutral-900/80 rounded text-neutral-300 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
+          title="Download"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+          </svg>
+        </a>
+      </div>
+    );
+  }
+
+  // Image result (default)
+  if (result) {
+    return (
+      <div className="relative aspect-square bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group cursor-pointer">
+        <img
+          src={result}
+          alt=""
+          className="w-full h-full object-cover"
+          loading="lazy"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
+        <a
+          href={result}
+          download
+          className="absolute bottom-2 end-2 p-1.5 bg-neutral-900/80 rounded text-neutral-300 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
+          title="Download"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+          </svg>
+        </a>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/simple-studio/GenerationCard.tsx
+++ b/src/components/simple-studio/GenerationCard.tsx
@@ -1,6 +1,105 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { type Generation } from "@/store/simpleStudioStore";
+
+// ---------------------------------------------------------------------------
+// Aspect ratio → CSS class mapping
+// ---------------------------------------------------------------------------
+
+const ASPECT_CLASS: Record<string, string> = {
+  "1:1": "aspect-square",
+  "16:9": "aspect-video",
+  "9:16": "aspect-[9/16]",
+  "4:5": "aspect-[4/5]",
+};
+
+function aspectClass(ratio: string): string {
+  return ASPECT_CLASS[ratio] || "aspect-square";
+}
+
+// ---------------------------------------------------------------------------
+// Lightbox / preview overlay
+// ---------------------------------------------------------------------------
+
+function Lightbox({
+  generation,
+  onClose,
+}: {
+  generation: Generation;
+  onClose: () => void;
+}) {
+  const { result, mode, aspectRatio } = generation;
+
+  // Close on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  if (!result) return null;
+
+  const isVideo = mode === "video";
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      {/* Content container — stop propagation so clicking media doesn't close */}
+      <div
+        className="relative max-w-[90vw] max-h-[90vh] flex flex-col items-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          className="absolute -top-10 end-0 p-1.5 text-neutral-400 hover:text-white transition-colors z-10"
+          title="Close (Esc)"
+        >
+          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        {isVideo ? (
+          <video
+            src={result}
+            className="max-w-[90vw] max-h-[85vh] rounded-lg"
+            style={{ aspectRatio: aspectRatio.replace(":", "/") }}
+            controls
+            autoPlay
+          />
+        ) : (
+          <img
+            src={result}
+            alt=""
+            className="max-w-[90vw] max-h-[85vh] rounded-lg object-contain"
+          />
+        )}
+
+        {/* Download button */}
+        <a
+          href={result}
+          download={`generation.${isVideo ? "mp4" : "png"}`}
+          className="mt-3 px-4 py-1.5 text-xs font-medium bg-neutral-800 text-neutral-200 rounded-md hover:bg-neutral-700 transition-colors flex items-center gap-1.5"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+          </svg>
+          Download
+        </a>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GenerationCard
+// ---------------------------------------------------------------------------
 
 interface GenerationCardProps {
   generation: Generation;
@@ -8,12 +107,18 @@ interface GenerationCardProps {
 }
 
 export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
-  const { status, result, error, mode } = generation;
+  const { status, result, error, mode, aspectRatio } = generation;
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const openPreview = useCallback(() => setPreviewOpen(true), []);
+  const closePreview = useCallback(() => setPreviewOpen(false), []);
+
+  const aspect = aspectClass(aspectRatio);
 
   // Loading state
   if (status === "pending" || status === "generating") {
     return (
-      <div className="aspect-square bg-neutral-800/50 border border-neutral-700/50 rounded-lg flex items-center justify-center">
+      <div className={`${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg flex items-center justify-center`}>
         <div className="flex flex-col items-center gap-2">
           <div className="w-6 h-6 border-2 border-neutral-600 border-t-neutral-300 rounded-full animate-spin" />
           <span className="text-[10px] text-neutral-500">
@@ -27,7 +132,7 @@ export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
   // Error state
   if (status === "failed") {
     return (
-      <div className="aspect-square bg-neutral-800/50 border border-red-900/30 rounded-lg flex items-center justify-center p-3">
+      <div className={`${aspect} bg-neutral-800/50 border border-red-900/30 rounded-lg flex items-center justify-center p-3`}>
         <div className="flex flex-col items-center gap-2 text-center">
           <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
@@ -68,50 +173,53 @@ export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
   // Video result
   if (mode === "video" && result) {
     return (
-      <div className="relative aspect-video bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group">
-        <video
-          src={result}
-          className="w-full h-full object-cover"
-          controls
-          preload="metadata"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
-        <a
-          href={result}
-          download
-          className="absolute bottom-2 end-2 p-1.5 bg-neutral-900/80 rounded text-neutral-300 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
-          title="Download"
+      <>
+        <div
+          className={`relative ${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group cursor-pointer`}
+          onClick={openPreview}
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
-          </svg>
-        </a>
-      </div>
+          <video
+            src={result}
+            className="w-full h-full object-cover"
+            preload="metadata"
+            muted
+            playsInline
+            onMouseEnter={(e) => e.currentTarget.play().catch(() => {})}
+            onMouseLeave={(e) => { e.currentTarget.pause(); e.currentTarget.currentTime = 0; }}
+          />
+          {/* Play icon overlay */}
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <div className="w-10 h-10 rounded-full bg-black/50 flex items-center justify-center opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-all">
+              <svg className="w-5 h-5 text-white ms-0.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </div>
+          </div>
+          <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
+        </div>
+        {previewOpen && <Lightbox generation={generation} onClose={closePreview} />}
+      </>
     );
   }
 
   // Image result (default)
   if (result) {
     return (
-      <div className="relative aspect-square bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group cursor-pointer">
-        <img
-          src={result}
-          alt=""
-          className="w-full h-full object-cover"
-          loading="lazy"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
-        <a
-          href={result}
-          download
-          className="absolute bottom-2 end-2 p-1.5 bg-neutral-900/80 rounded text-neutral-300 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
-          title="Download"
+      <>
+        <div
+          className={`relative ${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group cursor-pointer`}
+          onClick={openPreview}
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
-          </svg>
-        </a>
-      </div>
+          <img
+            src={result}
+            alt=""
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
+        </div>
+        {previewOpen && <Lightbox generation={generation} onClose={closePreview} />}
+      </>
     );
   }
 

--- a/src/components/simple-studio/PromptLibrary.tsx
+++ b/src/components/simple-studio/PromptLibrary.tsx
@@ -18,10 +18,11 @@ export function PromptLibrary() {
   const saveCurrentPrompt = useSimpleStudioStore((s) => s.saveCurrentPrompt);
   const loadSavedPrompts = useSimpleStudioStore((s) => s.loadSavedPrompts);
 
-  // Load saved prompts on mount and mode change
+  // Load saved prompts once on mount (silently fails if DB not migrated)
   useEffect(() => {
     loadSavedPrompts();
-  }, [loadSavedPrompts, mode]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Filter templates by current mode
   const filteredTemplates = PROMPT_TEMPLATES.filter((t) => t.mode === mode);

--- a/src/components/simple-studio/PromptLibrary.tsx
+++ b/src/components/simple-studio/PromptLibrary.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSimpleStudioStore, type SavedPrompt } from "@/store/simpleStudioStore";
+import { PROMPT_TEMPLATES } from "@/lib/simple-studio/promptTemplates";
+
+type Tab = "templates" | "my-prompts";
+
+export function PromptLibrary() {
+  const [activeTab, setActiveTab] = useState<Tab>("templates");
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [saveName, setSaveName] = useState("");
+
+  const mode = useSimpleStudioStore((s) => s.mode);
+  const prompt = useSimpleStudioStore((s) => s.prompt);
+  const savedPrompts = useSimpleStudioStore((s) => s.savedPrompts);
+  const applyPrompt = useSimpleStudioStore((s) => s.applyPrompt);
+  const saveCurrentPrompt = useSimpleStudioStore((s) => s.saveCurrentPrompt);
+  const loadSavedPrompts = useSimpleStudioStore((s) => s.loadSavedPrompts);
+
+  // Load saved prompts on mount and mode change
+  useEffect(() => {
+    loadSavedPrompts();
+  }, [loadSavedPrompts, mode]);
+
+  // Filter templates by current mode
+  const filteredTemplates = PROMPT_TEMPLATES.filter((t) => t.mode === mode);
+
+  const handleSave = async () => {
+    if (!saveName.trim()) return;
+    await saveCurrentPrompt(saveName.trim());
+    setSaveName("");
+    setSaveDialogOpen(false);
+  };
+
+  return (
+    <div className="border-t border-neutral-800">
+      {/* Tabs + save button */}
+      <div className="flex items-center justify-between px-4 pt-3">
+        <div className="flex gap-3">
+          <button
+            onClick={() => setActiveTab("templates")}
+            className={`text-xs font-medium pb-1 transition-colors ${
+              activeTab === "templates"
+                ? "text-neutral-200 border-b border-blue-500"
+                : "text-neutral-500 hover:text-neutral-300"
+            }`}
+          >
+            Templates
+          </button>
+          <button
+            onClick={() => setActiveTab("my-prompts")}
+            className={`text-xs font-medium pb-1 transition-colors ${
+              activeTab === "my-prompts"
+                ? "text-neutral-200 border-b border-blue-500"
+                : "text-neutral-500 hover:text-neutral-300"
+            }`}
+          >
+            My Prompts
+          </button>
+        </div>
+        {prompt.trim() && (
+          <button
+            onClick={() => setSaveDialogOpen(true)}
+            className="text-[10px] text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            Save Prompt
+          </button>
+        )}
+      </div>
+
+      {/* Save dialog */}
+      {saveDialogOpen && (
+        <div className="px-4 py-2">
+          <div className="flex gap-2">
+            <input
+              value={saveName}
+              onChange={(e) => setSaveName(e.target.value)}
+              placeholder="Prompt name..."
+              className="flex-1 bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-xs text-neutral-200 placeholder-neutral-500 focus:outline-none focus:border-neutral-600"
+              autoFocus
+              onKeyDown={(e) => e.key === "Enter" && handleSave()}
+            />
+            <button
+              onClick={handleSave}
+              disabled={!saveName.trim()}
+              className="px-2 py-1 text-xs bg-blue-600 text-white rounded disabled:opacity-40 hover:bg-blue-500 transition-colors"
+            >
+              Save
+            </button>
+            <button
+              onClick={() => setSaveDialogOpen(false)}
+              className="px-2 py-1 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Prompt list */}
+      <div className="px-4 py-2 space-y-1.5 max-h-[200px] overflow-y-auto">
+        {activeTab === "templates" && (
+          <>
+            {filteredTemplates.length === 0 ? (
+              <p className="text-xs text-neutral-600 py-2">No templates for this mode</p>
+            ) : (
+              filteredTemplates.map((tpl) => (
+                <PromptItem key={tpl.id} prompt={tpl} onApply={applyPrompt} />
+              ))
+            )}
+          </>
+        )}
+
+        {activeTab === "my-prompts" && (
+          <>
+            {savedPrompts.length === 0 ? (
+              <p className="text-xs text-neutral-600 py-2">No saved prompts yet</p>
+            ) : (
+              savedPrompts.map((p) => (
+                <PromptItem key={p.id} prompt={p} onApply={applyPrompt} />
+              ))
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PromptItem({
+  prompt,
+  onApply,
+}: {
+  prompt: SavedPrompt;
+  onApply: (p: SavedPrompt) => void;
+}) {
+  return (
+    <button
+      onClick={() => onApply(prompt)}
+      className="w-full text-start p-2 rounded hover:bg-neutral-800/50 transition-colors group"
+    >
+      <div className="text-xs font-medium text-neutral-300 group-hover:text-neutral-100 truncate" dir="auto">
+        {prompt.name}
+      </div>
+      <div className="text-[10px] text-neutral-500 mt-0.5 line-clamp-2" dir="auto">
+        {prompt.promptText}
+      </div>
+    </button>
+  );
+}

--- a/src/components/simple-studio/ResultsGallery.tsx
+++ b/src/components/simple-studio/ResultsGallery.tsx
@@ -47,13 +47,22 @@ export function ResultsGallery() {
     }
   }
 
-  // Grid columns based on mode
-  const gridCols =
-    mode === "copy"
-      ? "grid-cols-1 md:grid-cols-2"
-      : mode === "video"
-        ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-        : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4";
+  // Detect aspect ratio from the first item in the batch (all share the same)
+  const firstAspect = generations[0]?.aspectRatio || "1:1";
+  const isPortrait = firstAspect === "9:16";
+
+  // Grid columns based on mode and aspect ratio
+  let gridCols: string;
+  if (mode === "copy") {
+    gridCols = "grid-cols-1 md:grid-cols-2";
+  } else if (isPortrait) {
+    // Portrait (9:16) — narrower cards, more columns
+    gridCols = "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+  } else if (mode === "video") {
+    gridCols = "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3";
+  } else {
+    gridCols = "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4";
+  }
 
   return (
     <div className="p-4 space-y-6">

--- a/src/components/simple-studio/ResultsGallery.tsx
+++ b/src/components/simple-studio/ResultsGallery.tsx
@@ -1,18 +1,11 @@
 "use client";
 
-import { useEffect } from "react";
 import { useSimpleStudioStore } from "@/store/simpleStudioStore";
 import { GenerationCard } from "./GenerationCard";
 
 export function ResultsGallery() {
   const generations = useSimpleStudioStore((s) => s.generations);
   const mode = useSimpleStudioStore((s) => s.mode);
-  const loadRecentResults = useSimpleStudioStore((s) => s.loadRecentResults);
-
-  // Load persisted results on mount
-  useEffect(() => {
-    loadRecentResults();
-  }, [loadRecentResults]);
 
   if (generations.length === 0) {
     return (

--- a/src/components/simple-studio/ResultsGallery.tsx
+++ b/src/components/simple-studio/ResultsGallery.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { GenerationCard } from "./GenerationCard";
+
+export function ResultsGallery() {
+  const generations = useSimpleStudioStore((s) => s.generations);
+  const mode = useSimpleStudioStore((s) => s.mode);
+  const loadRecentResults = useSimpleStudioStore((s) => s.loadRecentResults);
+
+  // Load persisted results on mount
+  useEffect(() => {
+    loadRecentResults();
+  }, [loadRecentResults]);
+
+  if (generations.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center text-neutral-500">
+        <div className="text-center">
+          <svg
+            className="w-12 h-12 mx-auto mb-3 text-neutral-700"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5a1.5 1.5 0 001.5-1.5V4.5a1.5 1.5 0 00-1.5-1.5H3.75a1.5 1.5 0 00-1.5 1.5v15a1.5 1.5 0 001.5 1.5z"
+            />
+          </svg>
+          <p className="text-sm">Your generated content will appear here</p>
+          <p className="text-xs mt-1 text-neutral-600">
+            Fill in the form and click Generate
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Group generations by batchId
+  const batches: { batchId: string; items: typeof generations }[] = [];
+  const seen = new Set<string>();
+
+  for (const gen of generations) {
+    if (!seen.has(gen.batchId)) {
+      seen.add(gen.batchId);
+      batches.push({
+        batchId: gen.batchId,
+        items: generations.filter((g) => g.batchId === gen.batchId),
+      });
+    }
+  }
+
+  // Grid columns based on mode
+  const gridCols =
+    mode === "copy"
+      ? "grid-cols-1 md:grid-cols-2"
+      : mode === "video"
+        ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+        : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4";
+
+  return (
+    <div className="p-4 space-y-6">
+      {batches.map((batch) => (
+        <div key={batch.batchId}>
+          <div className={`grid ${gridCols} gap-3`}>
+            {batch.items.map((gen) => (
+              <GenerationCard key={gen.id} generation={gen} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -59,7 +59,14 @@ export function Sidebar() {
       .then((r) => r.json())
       .then((data) => {
         if (!cancelled && data.success) {
-          setModels(data.models || []);
+          // Deduplicate models by ID
+          const seen = new Set<string>();
+          const unique = (data.models || []).filter((m: ProviderModel) => {
+            if (seen.has(m.id)) return false;
+            seen.add(m.id);
+            return true;
+          });
+          setModels(unique);
         }
       })
       .catch(() => {})
@@ -121,14 +128,16 @@ export function Sidebar() {
               AI Prompt Enhance
             </label>
             <button
+              role="switch"
+              aria-checked={store.rewriteEnabled}
               onClick={() => store.setRewriteEnabled(!store.rewriteEnabled)}
               className={`relative w-9 h-5 rounded-full transition-colors ${
                 store.rewriteEnabled ? "bg-blue-600" : "bg-neutral-700"
               }`}
             >
               <span
-                className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-                  store.rewriteEnabled ? "translate-x-4" : "translate-x-0.5"
+                className={`absolute top-0.5 start-0.5 w-4 h-4 rounded-full bg-white transition-all ${
+                  store.rewriteEnabled ? "translate-x-4 rtl:-translate-x-4" : ""
                 }`}
               />
             </button>

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -48,6 +48,16 @@ const BATCH_PRESETS = [1, 4, 8, 12, 20];
 const VIDEO_BATCH_PRESETS = [1, 2, 4, 8];
 const TONES = ["professional", "casual", "creative", "persuasive"];
 const PLATFORMS = ["general", "instagram", "x", "linkedin"];
+
+const LLM_MODELS: { id: string; name: string; provider: string }[] = [
+  { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", provider: "Google" },
+  { id: "gemini-3-flash-preview", name: "Gemini 3 Flash", provider: "Google" },
+  { id: "gemini-3-pro-preview", name: "Gemini 3 Pro", provider: "Google" },
+  { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "OpenAI" },
+  { id: "gpt-4.1-nano", name: "GPT-4.1 Nano", provider: "OpenAI" },
+  { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5", provider: "Anthropic" },
+  { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", provider: "Anthropic" },
+];
 const OUTPUT_LANGUAGES: { value: "ar" | "en" | "both"; label: string }[] = [
   { value: "en", label: "English" },
   { value: "ar", label: "عربي" },
@@ -512,6 +522,26 @@ export function Sidebar() {
               </>
             )}
           </>
+        )}
+
+        {/* LLM Model (copy mode) */}
+        {store.mode === "copy" && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Model
+            </label>
+            <select
+              value={store.copyModelId}
+              onChange={(e) => store.setCopyModelId(e.target.value)}
+              className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 focus:outline-none focus:border-neutral-600"
+            >
+              {LLM_MODELS.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name} ({m.provider})
+                </option>
+              ))}
+            </select>
+          </fieldset>
         )}
 
         {/* Tone (copy mode) */}

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSimpleStudioStore, type SimpleStudioMode } from "@/store/simpleStudioStore";
+import { PromptLibrary } from "./PromptLibrary";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -381,6 +382,9 @@ export function Sidebar() {
           </div>
         </fieldset>
       </div>
+
+      {/* Prompt library */}
+      <PromptLibrary />
 
       {/* Generate button — pinned at bottom */}
       <div className="p-4 border-t border-neutral-800 shrink-0">

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -43,7 +43,8 @@ const MODES: { value: SimpleStudioMode; labelEn: string; labelAr: string }[] = [
   { value: "copy", labelEn: "Copy", labelAr: "نص" },
 ];
 
-const ASPECT_RATIOS = ["1:1", "16:9", "9:16", "4:5"];
+const PHOTO_ASPECT_RATIOS = ["1:1", "16:9", "9:16", "4:5"];
+const VIDEO_ASPECT_RATIOS = ["16:9", "9:16"];
 const BATCH_PRESETS = [1, 4, 8, 12, 20];
 const VIDEO_BATCH_PRESETS = [1, 2, 4, 8];
 const TONES = ["professional", "casual", "creative", "persuasive"];
@@ -122,6 +123,14 @@ export function Sidebar() {
   const isPhotoOrVideo = store.mode === "photo" || store.mode === "video";
   const maxBatch = store.mode === "video" ? 8 : 20;
   const batchPresets = store.mode === "video" ? VIDEO_BATCH_PRESETS : BATCH_PRESETS;
+  const aspectRatios = store.mode === "video" ? VIDEO_ASPECT_RATIOS : PHOTO_ASPECT_RATIOS;
+
+  // Reset aspect ratio when switching to video if current value isn't valid for video
+  useEffect(() => {
+    if (store.mode === "video" && !VIDEO_ASPECT_RATIOS.includes(store.aspectRatio)) {
+      store.setAspectRatio("16:9");
+    }
+  }, [store.mode, store.aspectRatio, store.setAspectRatio]);
 
   // Split models into recommended + others, filtered by search
   const recommendedSet = store.mode === "video" ? RECOMMENDED_VIDEO_MODELS : RECOMMENDED_IMAGE_MODELS;
@@ -335,7 +344,7 @@ export function Sidebar() {
                     {/* Auto option */}
                     <button
                       type="button"
-                      onClick={() => { store.setSelectedModelId(null); setModelDropdownOpen(false); setModelSearch(""); }}
+                      onClick={() => { store.setSelectedModel(null); setModelDropdownOpen(false); setModelSearch(""); }}
                       className={`w-full text-start px-3 py-2 text-xs hover:bg-neutral-700/50 transition-colors ${
                         !store.selectedModelId ? "bg-neutral-700/30 text-blue-400" : "text-neutral-300"
                       }`}
@@ -353,7 +362,7 @@ export function Sidebar() {
                           <button
                             key={`rec-${m.id}-${i}`}
                             type="button"
-                            onClick={() => { store.setSelectedModelId(m.id); setModelDropdownOpen(false); setModelSearch(""); }}
+                            onClick={() => { store.setSelectedModel(m.id, m.provider, m.name); setModelDropdownOpen(false); setModelSearch(""); }}
                             className={`w-full text-start px-3 py-2 text-xs hover:bg-neutral-700/50 transition-colors ${
                               store.selectedModelId === m.id ? "bg-neutral-700/30 text-blue-400" : "text-neutral-300"
                             }`}
@@ -375,7 +384,7 @@ export function Sidebar() {
                           <button
                             key={`all-${m.id}-${i}`}
                             type="button"
-                            onClick={() => { store.setSelectedModelId(m.id); setModelDropdownOpen(false); setModelSearch(""); }}
+                            onClick={() => { store.setSelectedModel(m.id, m.provider, m.name); setModelDropdownOpen(false); setModelSearch(""); }}
                             className={`w-full text-start px-3 py-2 text-xs hover:bg-neutral-700/50 transition-colors ${
                               store.selectedModelId === m.id ? "bg-neutral-700/30 text-blue-400" : "text-neutral-300"
                             }`}
@@ -408,7 +417,7 @@ export function Sidebar() {
               Aspect Ratio
             </label>
             <div className="flex gap-1.5">
-              {ASPECT_RATIOS.map((ratio) => (
+              {aspectRatios.map((ratio) => (
                 <button
                   key={ratio}
                   onClick={() => store.setAspectRatio(ratio)}

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -256,8 +256,8 @@ export function Sidebar() {
             >
               <option value="">Auto (default)</option>
               {isLoadingModels && <option disabled>Loading models...</option>}
-              {models.map((m) => (
-                <option key={m.id} value={m.id}>
+              {models.map((m, i) => (
+                <option key={`${m.id}-${i}`} value={m.id}>
                   {m.name} ({m.provider})
                 </option>
               ))}

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -295,16 +295,97 @@ export function Sidebar() {
             <label className="block text-xs font-medium text-neutral-400 mb-1.5">
               Duration (seconds)
             </label>
-            <select
-              value={store.videoDuration}
-              onChange={(e) => store.setVideoDuration(Number(e.target.value))}
-              className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 focus:outline-none focus:border-neutral-600"
-            >
-              {[3, 5, 10, 15].map((d) => (
-                <option key={d} value={d}>{d}s</option>
+            <div className="flex gap-1.5">
+              {[4, 5, 6, 8, 10].map((d) => (
+                <button
+                  key={d}
+                  onClick={() => store.setVideoDuration(d)}
+                  className={`flex-1 py-1.5 text-xs rounded-md border transition-colors ${
+                    store.videoDuration === d
+                      ? "bg-blue-600/20 border-blue-500 text-blue-400"
+                      : "border-neutral-700 text-neutral-400 hover:border-neutral-600"
+                  }`}
+                >
+                  {d}s
+                </button>
               ))}
-            </select>
+            </div>
+            <p className="text-[10px] text-neutral-600 mt-1">Duration depends on model (Veo: 4-8s, Kling: 5-10s)</p>
           </fieldset>
+        )}
+
+        {/* Dialogue / Audio (video mode) */}
+        {store.mode === "video" && (
+          <>
+            <fieldset className="flex items-center justify-between">
+              <label className="text-xs font-medium text-neutral-400">
+                Include Dialogue
+              </label>
+              <button
+                role="switch"
+                aria-checked={store.dialogueEnabled}
+                onClick={() => store.setDialogueEnabled(!store.dialogueEnabled)}
+                className={`relative w-9 h-5 rounded-full transition-colors ${
+                  store.dialogueEnabled ? "bg-blue-600" : "bg-neutral-700"
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 start-0.5 w-4 h-4 rounded-full bg-white transition-all ${
+                    store.dialogueEnabled ? "translate-x-4 rtl:-translate-x-4" : ""
+                  }`}
+                />
+              </button>
+            </fieldset>
+
+            {store.dialogueEnabled && (
+              <>
+                <fieldset>
+                  <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+                    Dialogue Language
+                  </label>
+                  <div className="flex gap-1.5">
+                    {([
+                      { value: "en" as const, label: "English" },
+                      { value: "ar" as const, label: "عربي" },
+                    ]).map((lang) => (
+                      <button
+                        key={lang.value}
+                        onClick={() => store.setDialogueLanguage(lang.value)}
+                        className={`flex-1 py-1.5 text-xs rounded-md border transition-colors ${
+                          store.dialogueLanguage === lang.value
+                            ? "bg-blue-600/20 border-blue-500 text-blue-400"
+                            : "border-neutral-700 text-neutral-400 hover:border-neutral-600"
+                        }`}
+                      >
+                        {lang.label}
+                      </button>
+                    ))}
+                  </div>
+                </fieldset>
+
+                <fieldset>
+                  <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+                    Dialogue Text
+                  </label>
+                  <textarea
+                    value={store.dialogueText}
+                    onChange={(e) => store.setDialogueText(e.target.value)}
+                    placeholder={
+                      store.dialogueLanguage === "ar"
+                        ? "اكتب ما يقوله الشخص..."
+                        : "Write what the character says..."
+                    }
+                    rows={2}
+                    className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 resize-none focus:outline-none focus:border-neutral-600"
+                    dir="auto"
+                  />
+                  <p className="text-[10px] text-neutral-600 mt-1">
+                    Works best with Veo 3.1 and Kling 2.6. Dialogue is injected into the prompt.
+                  </p>
+                </fieldset>
+              </>
+            )}
+          </>
         )}
 
         {/* Tone (copy mode) */}

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSimpleStudioStore, type SimpleStudioMode } from "@/store/simpleStudioStore";
 import { PromptLibrary } from "./PromptLibrary";
 
@@ -14,6 +14,24 @@ interface ProviderModel {
   provider: string;
   capabilities?: string[];
 }
+
+// Recommended models — curated best picks per mode
+const RECOMMENDED_IMAGE_MODELS = new Set([
+  "nano-banana",          // Gemini 2.5 Flash — fast, cheap
+  "nano-banana-pro",      // Gemini 3 Pro — high quality
+  "nano-banana-2",        // Gemini 3.1 Flash — balanced
+  "flux-2/pro-text-to-image",  // FLUX.2 Pro — excellent quality
+  "seedream/4.5-text-to-image", // Seedream 4.5 — great prompt following
+  "gpt-image/1.5-text-to-image", // GPT Image — good understanding
+]);
+
+const RECOMMENDED_VIDEO_MODELS = new Set([
+  "veo-3.1/text-to-video",      // Veo 3.1 — best quality + audio
+  "veo-3.1-fast/text-to-video",  // Veo 3.1 Fast — cheaper
+  "kling-2.6/text-to-video",     // Kling 2.6 — good quality + audio
+  "veo3/text-to-video",          // Veo 3 via Kie — alternative
+  "wan/2-6-text-to-video",       // Wan 2.6 — affordable
+]);
 
 // ---------------------------------------------------------------------------
 // Mode tabs
@@ -44,6 +62,9 @@ export function Sidebar() {
   const store = useSimpleStudioStore();
   const [models, setModels] = useState<ProviderModel[]>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
+  const [modelSearch, setModelSearch] = useState("");
+  const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Fetch models on mount and mode change
   useEffect(() => {
@@ -77,9 +98,30 @@ export function Sidebar() {
     return () => { cancelled = true; };
   }, [store.mode]);
 
+  // Close dropdown on click outside
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setModelDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
   const isPhotoOrVideo = store.mode === "photo" || store.mode === "video";
   const maxBatch = store.mode === "video" ? 8 : 20;
   const batchPresets = store.mode === "video" ? VIDEO_BATCH_PRESETS : BATCH_PRESETS;
+
+  // Split models into recommended + others, filtered by search
+  const recommendedSet = store.mode === "video" ? RECOMMENDED_VIDEO_MODELS : RECOMMENDED_IMAGE_MODELS;
+  const searchLower = modelSearch.toLowerCase();
+  const filteredModels = models.filter(
+    (m) => !searchLower || m.name.toLowerCase().includes(searchLower) || m.id.toLowerCase().includes(searchLower) || m.provider.toLowerCase().includes(searchLower),
+  );
+  const recommendedModels = filteredModels.filter((m) => recommendedSet.has(m.id));
+  const otherModels = filteredModels.filter((m) => !recommendedSet.has(m.id));
+  const selectedModel = models.find((m) => m.id === store.selectedModelId);
 
   return (
     <div className="flex flex-col h-full">
@@ -249,19 +291,103 @@ export function Sidebar() {
             <label className="block text-xs font-medium text-neutral-400 mb-1.5">
               Model
             </label>
-            <select
-              value={store.selectedModelId || ""}
-              onChange={(e) => store.setSelectedModelId(e.target.value || null)}
-              className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 focus:outline-none focus:border-neutral-600"
-            >
-              <option value="">Auto (default)</option>
-              {isLoadingModels && <option disabled>Loading models...</option>}
-              {models.map((m, i) => (
-                <option key={`${m.id}-${i}`} value={m.id}>
-                  {m.name} ({m.provider})
-                </option>
-              ))}
-            </select>
+            <div className="relative" ref={dropdownRef}>
+              {/* Trigger button */}
+              <button
+                type="button"
+                onClick={() => setModelDropdownOpen(!modelDropdownOpen)}
+                className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 text-start flex items-center justify-between hover:border-neutral-600 transition-colors"
+              >
+                <span className="truncate">
+                  {selectedModel ? `${selectedModel.name}` : "Auto (default)"}
+                </span>
+                <svg className={`w-4 h-4 text-neutral-500 shrink-0 transition-transform ${modelDropdownOpen ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                </svg>
+              </button>
+
+              {/* Dropdown */}
+              {modelDropdownOpen && (
+                <div className="absolute z-50 mt-1 w-full bg-neutral-800 border border-neutral-700 rounded-md shadow-xl overflow-hidden">
+                  {/* Search input */}
+                  <div className="p-2 border-b border-neutral-700">
+                    <input
+                      type="text"
+                      value={modelSearch}
+                      onChange={(e) => setModelSearch(e.target.value)}
+                      placeholder="Search models..."
+                      className="w-full bg-neutral-900 border border-neutral-700 rounded px-2.5 py-1.5 text-xs text-neutral-200 placeholder-neutral-500 focus:outline-none focus:border-neutral-600"
+                      autoFocus
+                    />
+                  </div>
+
+                  <div className="max-h-[280px] overflow-y-auto">
+                    {/* Auto option */}
+                    <button
+                      type="button"
+                      onClick={() => { store.setSelectedModelId(null); setModelDropdownOpen(false); setModelSearch(""); }}
+                      className={`w-full text-start px-3 py-2 text-xs hover:bg-neutral-700/50 transition-colors ${
+                        !store.selectedModelId ? "bg-neutral-700/30 text-blue-400" : "text-neutral-300"
+                      }`}
+                    >
+                      Auto (default)
+                    </button>
+
+                    {/* Recommended section */}
+                    {recommendedModels.length > 0 && (
+                      <>
+                        <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-blue-400 bg-neutral-800 sticky top-0">
+                          Recommended
+                        </div>
+                        {recommendedModels.map((m, i) => (
+                          <button
+                            key={`rec-${m.id}-${i}`}
+                            type="button"
+                            onClick={() => { store.setSelectedModelId(m.id); setModelDropdownOpen(false); setModelSearch(""); }}
+                            className={`w-full text-start px-3 py-2 text-xs hover:bg-neutral-700/50 transition-colors ${
+                              store.selectedModelId === m.id ? "bg-neutral-700/30 text-blue-400" : "text-neutral-300"
+                            }`}
+                          >
+                            <span>{m.name}</span>
+                            <span className="text-neutral-500 ms-1.5">{m.provider}</span>
+                          </button>
+                        ))}
+                      </>
+                    )}
+
+                    {/* All models section */}
+                    {otherModels.length > 0 && (
+                      <>
+                        <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-800 sticky top-0">
+                          All Models
+                        </div>
+                        {otherModels.map((m, i) => (
+                          <button
+                            key={`all-${m.id}-${i}`}
+                            type="button"
+                            onClick={() => { store.setSelectedModelId(m.id); setModelDropdownOpen(false); setModelSearch(""); }}
+                            className={`w-full text-start px-3 py-2 text-xs hover:bg-neutral-700/50 transition-colors ${
+                              store.selectedModelId === m.id ? "bg-neutral-700/30 text-blue-400" : "text-neutral-300"
+                            }`}
+                          >
+                            <span>{m.name}</span>
+                            <span className="text-neutral-500 ms-1.5">{m.provider}</span>
+                          </button>
+                        ))}
+                      </>
+                    )}
+
+                    {isLoadingModels && (
+                      <div className="px-3 py-2 text-xs text-neutral-500">Loading models...</div>
+                    )}
+
+                    {!isLoadingModels && filteredModels.length === 0 && modelSearch && (
+                      <div className="px-3 py-2 text-xs text-neutral-500">No models match &quot;{modelSearch}&quot;</div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
           </fieldset>
         )}
 

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSimpleStudioStore, type SimpleStudioMode } from "@/store/simpleStudioStore";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ProviderModel {
+  id: string;
+  name: string;
+  provider: string;
+  capabilities?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Mode tabs
+// ---------------------------------------------------------------------------
+
+const MODES: { value: SimpleStudioMode; labelEn: string; labelAr: string }[] = [
+  { value: "photo", labelEn: "Photo", labelAr: "صورة" },
+  { value: "video", labelEn: "Video", labelAr: "فيديو" },
+  { value: "copy", labelEn: "Copy", labelAr: "نص" },
+];
+
+const ASPECT_RATIOS = ["1:1", "16:9", "9:16", "4:5"];
+const BATCH_PRESETS = [1, 4, 8, 12, 20];
+const VIDEO_BATCH_PRESETS = [1, 2, 4, 8];
+const TONES = ["professional", "casual", "creative", "persuasive"];
+const PLATFORMS = ["general", "instagram", "x", "linkedin"];
+const OUTPUT_LANGUAGES: { value: "ar" | "en" | "both"; label: string }[] = [
+  { value: "en", label: "English" },
+  { value: "ar", label: "عربي" },
+  { value: "both", label: "Both" },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function Sidebar() {
+  const store = useSimpleStudioStore();
+  const [models, setModels] = useState<ProviderModel[]>([]);
+  const [isLoadingModels, setIsLoadingModels] = useState(false);
+
+  // Fetch models on mount and mode change
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoadingModels(true);
+
+    const capabilities =
+      store.mode === "video"
+        ? "text-to-video,image-to-video"
+        : "text-to-image,image-to-image";
+
+    fetch(`/api/models?capabilities=${capabilities}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled && data.success) {
+          setModels(data.models || []);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setIsLoadingModels(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [store.mode]);
+
+  const isPhotoOrVideo = store.mode === "photo" || store.mode === "video";
+  const maxBatch = store.mode === "video" ? 8 : 20;
+  const batchPresets = store.mode === "video" ? VIDEO_BATCH_PRESETS : BATCH_PRESETS;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Mode tabs */}
+      <div className="flex border-b border-neutral-800 shrink-0">
+        {MODES.map((m) => (
+          <button
+            key={m.value}
+            onClick={() => store.setMode(m.value)}
+            className={`flex-1 py-2.5 text-xs font-medium transition-colors ${
+              store.mode === m.value
+                ? "text-neutral-100 border-b-2 border-blue-500"
+                : "text-neutral-500 hover:text-neutral-300"
+            }`}
+          >
+            {m.labelEn}
+          </button>
+        ))}
+      </div>
+
+      {/* Form fields */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {/* Prompt */}
+        <fieldset>
+          <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+            Prompt
+          </label>
+          <textarea
+            value={store.prompt}
+            onChange={(e) => store.setPrompt(e.target.value)}
+            placeholder={
+              store.mode === "copy"
+                ? "Describe the content you want to create..."
+                : "Describe what you want to generate..."
+            }
+            rows={4}
+            className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 resize-none focus:outline-none focus:border-neutral-600"
+            dir="auto"
+          />
+        </fieldset>
+
+        {/* LLM Rewrite toggle (photo/video only) */}
+        {isPhotoOrVideo && (
+          <fieldset className="flex items-center justify-between">
+            <label className="text-xs font-medium text-neutral-400">
+              AI Prompt Enhance
+            </label>
+            <button
+              onClick={() => store.setRewriteEnabled(!store.rewriteEnabled)}
+              className={`relative w-9 h-5 rounded-full transition-colors ${
+                store.rewriteEnabled ? "bg-blue-600" : "bg-neutral-700"
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                  store.rewriteEnabled ? "translate-x-4" : "translate-x-0.5"
+                }`}
+              />
+            </button>
+          </fieldset>
+        )}
+
+        {/* Rewritten prompt preview */}
+        {store.rewriteEnabled && store.rewrittenPrompt && (
+          <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-md p-3">
+            <div className="text-[10px] uppercase tracking-wide text-blue-400 mb-1">
+              Enhanced prompt
+            </div>
+            <p className="text-xs text-neutral-300 leading-relaxed" dir="auto">
+              {store.rewrittenPrompt}
+            </p>
+          </div>
+        )}
+
+        {/* Reference images (photo mode) */}
+        {store.mode === "photo" && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Reference Images (optional)
+            </label>
+            <div className="flex gap-2">
+              {store.referenceImages.map((img, i) => (
+                <div key={i} className="relative w-16 h-16 rounded border border-neutral-700 overflow-hidden">
+                  <img src={img} alt="" className="w-full h-full object-cover" />
+                  <button
+                    onClick={() =>
+                      store.setReferenceImages(store.referenceImages.filter((_, j) => j !== i))
+                    }
+                    className="absolute top-0 end-0 w-4 h-4 bg-red-600 text-white text-[10px] flex items-center justify-center rounded-bl"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+              {store.referenceImages.length < 3 && (
+                <label className="w-16 h-16 rounded border border-dashed border-neutral-700 flex items-center justify-center text-neutral-500 hover:border-neutral-500 cursor-pointer transition-colors">
+                  <span className="text-lg">+</span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = () => {
+                        if (typeof reader.result === "string") {
+                          store.setReferenceImages([...store.referenceImages, reader.result]);
+                        }
+                      };
+                      reader.readAsDataURL(file);
+                      e.target.value = "";
+                    }}
+                  />
+                </label>
+              )}
+            </div>
+          </fieldset>
+        )}
+
+        {/* Source image (video mode — image-to-video) */}
+        {store.mode === "video" && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Source Image (optional, for image-to-video)
+            </label>
+            {store.sourceImage ? (
+              <div className="relative w-24 h-24 rounded border border-neutral-700 overflow-hidden">
+                <img src={store.sourceImage} alt="" className="w-full h-full object-cover" />
+                <button
+                  onClick={() => store.setSourceImage(null)}
+                  className="absolute top-0 end-0 w-5 h-5 bg-red-600 text-white text-xs flex items-center justify-center rounded-bl"
+                >
+                  ×
+                </button>
+              </div>
+            ) : (
+              <label className="w-24 h-24 rounded border border-dashed border-neutral-700 flex items-center justify-center text-neutral-500 hover:border-neutral-500 cursor-pointer transition-colors">
+                <span className="text-lg">+</span>
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+                    const reader = new FileReader();
+                    reader.onload = () => {
+                      if (typeof reader.result === "string") {
+                        store.setSourceImage(reader.result);
+                      }
+                    };
+                    reader.readAsDataURL(file);
+                    e.target.value = "";
+                  }}
+                />
+              </label>
+            )}
+          </fieldset>
+        )}
+
+        {/* Model selector (photo/video) */}
+        {isPhotoOrVideo && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Model
+            </label>
+            <select
+              value={store.selectedModelId || ""}
+              onChange={(e) => store.setSelectedModelId(e.target.value || null)}
+              className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 focus:outline-none focus:border-neutral-600"
+            >
+              <option value="">Auto (default)</option>
+              {isLoadingModels && <option disabled>Loading models...</option>}
+              {models.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name} ({m.provider})
+                </option>
+              ))}
+            </select>
+          </fieldset>
+        )}
+
+        {/* Aspect ratio (photo/video) */}
+        {isPhotoOrVideo && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Aspect Ratio
+            </label>
+            <div className="flex gap-1.5">
+              {ASPECT_RATIOS.map((ratio) => (
+                <button
+                  key={ratio}
+                  onClick={() => store.setAspectRatio(ratio)}
+                  className={`flex-1 py-1.5 text-xs rounded-md border transition-colors ${
+                    store.aspectRatio === ratio
+                      ? "bg-blue-600/20 border-blue-500 text-blue-400"
+                      : "border-neutral-700 text-neutral-400 hover:border-neutral-600"
+                  }`}
+                >
+                  {ratio}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+        )}
+
+        {/* Video duration (video mode) */}
+        {store.mode === "video" && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Duration (seconds)
+            </label>
+            <select
+              value={store.videoDuration}
+              onChange={(e) => store.setVideoDuration(Number(e.target.value))}
+              className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 focus:outline-none focus:border-neutral-600"
+            >
+              {[3, 5, 10, 15].map((d) => (
+                <option key={d} value={d}>{d}s</option>
+              ))}
+            </select>
+          </fieldset>
+        )}
+
+        {/* Tone (copy mode) */}
+        {store.mode === "copy" && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Tone
+            </label>
+            <select
+              value={store.tone}
+              onChange={(e) => store.setTone(e.target.value)}
+              className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 focus:outline-none focus:border-neutral-600"
+            >
+              {TONES.map((t) => (
+                <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
+              ))}
+            </select>
+          </fieldset>
+        )}
+
+        {/* Platform (copy mode) */}
+        {store.mode === "copy" && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Platform
+            </label>
+            <select
+              value={store.platform}
+              onChange={(e) => store.setPlatform(e.target.value)}
+              className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 focus:outline-none focus:border-neutral-600"
+            >
+              {PLATFORMS.map((p) => (
+                <option key={p} value={p}>{p.charAt(0).toUpperCase() + p.slice(1)}</option>
+              ))}
+            </select>
+          </fieldset>
+        )}
+
+        {/* Output language (copy mode) */}
+        {store.mode === "copy" && (
+          <fieldset>
+            <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+              Language
+            </label>
+            <div className="flex gap-1.5">
+              {OUTPUT_LANGUAGES.map((lang) => (
+                <button
+                  key={lang.value}
+                  onClick={() => store.setOutputLanguage(lang.value)}
+                  className={`flex-1 py-1.5 text-xs rounded-md border transition-colors ${
+                    store.outputLanguage === lang.value
+                      ? "bg-blue-600/20 border-blue-500 text-blue-400"
+                      : "border-neutral-700 text-neutral-400 hover:border-neutral-600"
+                  }`}
+                >
+                  {lang.label}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+        )}
+
+        {/* Batch count */}
+        <fieldset>
+          <label className="block text-xs font-medium text-neutral-400 mb-1.5">
+            {store.mode === "copy" ? "Output Count" : "Batch Count"}
+          </label>
+          <div className="flex gap-1.5">
+            {batchPresets
+              .filter((n) => n <= maxBatch)
+              .map((n) => (
+                <button
+                  key={n}
+                  onClick={() => store.setBatchCount(n)}
+                  className={`flex-1 py-1.5 text-xs rounded-md border transition-colors ${
+                    store.batchCount === n
+                      ? "bg-blue-600/20 border-blue-500 text-blue-400"
+                      : "border-neutral-700 text-neutral-400 hover:border-neutral-600"
+                  }`}
+                >
+                  {n}
+                </button>
+              ))}
+          </div>
+        </fieldset>
+      </div>
+
+      {/* Generate button — pinned at bottom */}
+      <div className="p-4 border-t border-neutral-800 shrink-0">
+        {store.isGenerating ? (
+          <button
+            onClick={() => store.cancelGeneration()}
+            className="w-full py-2.5 text-sm font-medium rounded-md bg-red-600/20 text-red-400 border border-red-600/50 hover:bg-red-600/30 transition-colors"
+          >
+            Cancel Generation
+          </button>
+        ) : (
+          <button
+            onClick={() => store.generate()}
+            disabled={!store.prompt.trim() || store.isRewriting}
+            className="w-full py-2.5 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {store.isRewriting
+              ? "Enhancing prompt..."
+              : `Generate ${store.batchCount} ${store.mode === "copy" ? "variation" : store.mode}${store.batchCount > 1 ? "s" : ""}`}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1139,6 +1139,52 @@ export const socialAutomationTasks = pgTable(
   }),
 );
 
+/**
+ * Simple Studio domain tables.
+ */
+export const savedPromptModeEnum = pgEnum("saved_prompt_mode", [
+  "photo",
+  "video",
+  "copy",
+]);
+
+export const savedPrompts = pgTable(
+  "saved_prompts",
+  {
+    id: text("id").primaryKey(),
+    workspaceId: text("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    mode: savedPromptModeEnum("mode").notNull(),
+    name: text("name").notNull(),
+    promptText: text("prompt_text").notNull(),
+    formConfig: jsonb("form_config")
+      .$type<Record<string, unknown>>()
+      .default({})
+      .notNull(),
+    isPublic: boolean("is_public").default(false).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => ({
+    workspaceDeletedIdx: index("saved_prompts_workspace_deleted_idx").on(
+      table.workspaceId,
+      table.deletedAt,
+    ),
+    publicModeDeletedIdx: index("saved_prompts_public_mode_deleted_idx").on(
+      table.isPublic,
+      table.mode,
+      table.deletedAt,
+    ),
+    createdAtIdx: index("saved_prompts_created_at_idx").on(table.createdAt),
+  }),
+);
+
 export type WorkspaceRole = typeof workspaceRoleEnum.enumValues[number];
 export type ProjectStatus = typeof projectStatusEnum.enumValues[number];
 export type AssetType = typeof assetTypeEnum.enumValues[number];
@@ -1157,3 +1203,4 @@ export type SocialTokenRefreshLeaseState =
 export type SocialWebhookDeadLetterReplayState =
   typeof socialWebhookDeadLetterReplayStateEnum.enumValues[number];
 export type AutomationTaskState = typeof automationTaskStateEnum.enumValues[number];
+export type SavedPromptMode = typeof savedPromptModeEnum.enumValues[number];

--- a/src/lib/simple-studio/promptTemplates.ts
+++ b/src/lib/simple-studio/promptTemplates.ts
@@ -1,0 +1,183 @@
+import type { SavedPrompt } from "@/store/simpleStudioStore";
+
+/**
+ * Curated seed prompts for the public prompt library.
+ * Organized by mode and category.
+ */
+export const PROMPT_TEMPLATES: SavedPrompt[] = [
+  // ── Photo: Product ──────────────────────────────────────────────
+  {
+    id: "tpl_photo_product_1",
+    mode: "photo",
+    name: "Product on White Background",
+    promptText: "Professional product photography on a clean white background with soft studio lighting, sharp focus, high resolution, commercial quality",
+    formConfig: { aspectRatio: "1:1", batchCount: 4 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_photo_product_2",
+    mode: "photo",
+    name: "Product Lifestyle Shot",
+    promptText: "Lifestyle product photography in a modern minimalist setting, natural window light, warm tones, shallow depth of field, Instagram-ready",
+    formConfig: { aspectRatio: "4:5", batchCount: 4 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_photo_product_3",
+    mode: "photo",
+    name: "Product Flat Lay",
+    promptText: "Top-down flat lay arrangement of products with complementary props, clean background, balanced composition, editorial style",
+    formConfig: { aspectRatio: "1:1", batchCount: 4 },
+    isPublic: true,
+  },
+
+  // ── Photo: Fashion ──────────────────────────────────────────────
+  {
+    id: "tpl_photo_fashion_1",
+    mode: "photo",
+    name: "Fashion Editorial",
+    promptText: "High fashion editorial photography, dramatic studio lighting, model wearing elegant outfit, bold composition, magazine quality",
+    formConfig: { aspectRatio: "4:5", batchCount: 4 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_photo_fashion_2",
+    mode: "photo",
+    name: "Street Style Portrait",
+    promptText: "Urban street style fashion photography, natural light, candid pose, bokeh city background, trendy outfit, authentic feel",
+    formConfig: { aspectRatio: "9:16", batchCount: 4 },
+    isPublic: true,
+  },
+
+  // ── Photo: Food ─────────────────────────────────────────────────
+  {
+    id: "tpl_photo_food_1",
+    mode: "photo",
+    name: "Food Photography",
+    promptText: "Appetizing food photography with natural side lighting, steam rising, rustic wooden surface, garnished beautifully, restaurant quality",
+    formConfig: { aspectRatio: "1:1", batchCount: 4 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_photo_food_2",
+    mode: "photo",
+    name: "Arabic Coffee & Dates",
+    promptText: "Traditional Arabic coffee dallah with dates on an ornate brass tray, warm ambient lighting, cultural authenticity, rich colors",
+    formConfig: { aspectRatio: "1:1", batchCount: 4 },
+    isPublic: true,
+  },
+
+  // ── Photo: Real Estate ──────────────────────────────────────────
+  {
+    id: "tpl_photo_realestate_1",
+    mode: "photo",
+    name: "Interior Design",
+    promptText: "Modern luxury interior design, spacious living room with floor-to-ceiling windows, natural light, warm neutral palette, architectural photography",
+    formConfig: { aspectRatio: "16:9", batchCount: 4 },
+    isPublic: true,
+  },
+
+  // ── Photo: Social Media ─────────────────────────────────────────
+  {
+    id: "tpl_photo_social_1",
+    mode: "photo",
+    name: "Instagram Story Background",
+    promptText: "Aesthetic gradient background for Instagram stories, soft pastel colors, minimal abstract shapes, text-friendly negative space",
+    formConfig: { aspectRatio: "9:16", batchCount: 8 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_photo_social_2",
+    mode: "photo",
+    name: "Social Media Quote Card",
+    promptText: "Elegant background for a motivational quote, subtle texture, muted warm tones, centered empty space for text overlay, sophisticated feel",
+    formConfig: { aspectRatio: "1:1", batchCount: 4 },
+    isPublic: true,
+  },
+
+  // ── Video ───────────────────────────────────────────────────────
+  {
+    id: "tpl_video_product_1",
+    mode: "video",
+    name: "Product Reveal",
+    promptText: "Smooth cinematic product reveal animation, object rotating slowly on a dark background with dramatic rim lighting, luxury feel",
+    formConfig: { aspectRatio: "1:1", videoDuration: 5, batchCount: 2 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_video_social_1",
+    mode: "video",
+    name: "Social Media Reel Intro",
+    promptText: "Dynamic short intro animation with modern motion graphics, bold colors, energetic transitions, perfect for TikTok or Reels",
+    formConfig: { aspectRatio: "9:16", videoDuration: 3, batchCount: 2 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_video_nature_1",
+    mode: "video",
+    name: "Desert Landscape",
+    promptText: "Aerial cinematic shot of vast golden sand dunes, sunrise light casting long shadows, gentle wind moving sand, Arabian desert atmosphere",
+    formConfig: { aspectRatio: "16:9", videoDuration: 5, batchCount: 2 },
+    isPublic: true,
+  },
+
+  // ── Copy: Social Media ──────────────────────────────────────────
+  {
+    id: "tpl_copy_social_1",
+    mode: "copy",
+    name: "Instagram Caption — Product Launch",
+    promptText: "Write an engaging Instagram caption for a new product launch. Include a hook, benefits, call-to-action, and relevant hashtags. Keep it under 150 words.",
+    formConfig: { tone: "casual", platform: "instagram", outputLanguage: "en", batchCount: 4 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_copy_social_2",
+    mode: "copy",
+    name: "LinkedIn Post — Business Update",
+    promptText: "Write a professional LinkedIn post announcing a company milestone or achievement. Include context, impact, and a forward-looking statement. 100-200 words.",
+    formConfig: { tone: "professional", platform: "linkedin", outputLanguage: "en", batchCount: 4 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_copy_social_3",
+    mode: "copy",
+    name: "X/Twitter Thread Hook",
+    promptText: "Write a compelling first tweet for a thread about a business lesson or industry insight. Must be attention-grabbing, under 280 characters, and make people want to read more.",
+    formConfig: { tone: "creative", platform: "x", outputLanguage: "en", batchCount: 8 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_copy_arabic_1",
+    mode: "copy",
+    name: "منشور إنستغرام — إطلاق منتج",
+    promptText: "اكتب وصف جذاب لمنشور إنستغرام عن إطلاق منتج جديد. يتضمن عبارة لافتة للانتباه، فوائد المنتج، ودعوة للتفاعل. أقل من 150 كلمة.",
+    formConfig: { tone: "casual", platform: "instagram", outputLanguage: "ar", batchCount: 4 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_copy_arabic_2",
+    mode: "copy",
+    name: "نص إعلاني — عرض خاص",
+    promptText: "اكتب نص إعلاني مقنع لعرض خاص أو تخفيضات. يتضمن الإلحاح، القيمة، والدعوة للشراء. أسلوب تسويقي احترافي.",
+    formConfig: { tone: "persuasive", platform: "general", outputLanguage: "ar", batchCount: 4 },
+    isPublic: true,
+  },
+
+  // ── Copy: General ───────────────────────────────────────────────
+  {
+    id: "tpl_copy_general_1",
+    mode: "copy",
+    name: "Email Subject Lines",
+    promptText: "Write compelling email subject lines for a promotional campaign. Each should be under 50 characters, create curiosity or urgency, and avoid spam trigger words.",
+    formConfig: { tone: "creative", platform: "general", outputLanguage: "en", batchCount: 12 },
+    isPublic: true,
+  },
+  {
+    id: "tpl_copy_general_2",
+    mode: "copy",
+    name: "Product Description",
+    promptText: "Write a compelling product description that highlights key features and benefits. Use sensory language and address customer pain points. 50-100 words.",
+    formConfig: { tone: "persuasive", platform: "general", outputLanguage: "en", batchCount: 4 },
+    isPublic: true,
+  },
+];

--- a/src/lib/studio/repository.ts
+++ b/src/lib/studio/repository.ts
@@ -7,6 +7,7 @@ import {
   member,
   organization,
   projects,
+  savedPrompts,
   type WorkspaceRole,
   workspaceSettings,
   storageProviderEnum,
@@ -971,4 +972,141 @@ export async function hardDeleteAsset(params: { assetId: string }): Promise<bool
     .returning({ id: assets.id });
 
   return deleted.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Saved Prompts CRUD
+// ---------------------------------------------------------------------------
+
+interface CreatePromptInput {
+  workspaceId: string;
+  mode: "photo" | "video" | "copy";
+  name: string;
+  promptText: string;
+  formConfig?: Record<string, unknown>;
+  isPublic?: boolean;
+}
+
+export async function createPrompt(input: CreatePromptInput) {
+  const db = getDb();
+  const now = new Date();
+
+  const [created] = await db
+    .insert(savedPrompts)
+    .values({
+      id: `sp_${randomUUID()}`,
+      workspaceId: input.workspaceId,
+      mode: input.mode,
+      name: input.name,
+      promptText: input.promptText,
+      formConfig: input.formConfig ?? {},
+      isPublic: input.isPublic ?? false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return created;
+}
+
+export async function listPrompts(workspaceId: string, mode?: string) {
+  const db = getDb();
+  const conditions = [
+    eq(savedPrompts.workspaceId, workspaceId),
+    isNull(savedPrompts.deletedAt),
+  ];
+  if (mode) {
+    conditions.push(sql`${savedPrompts.mode} = ${mode}`);
+  }
+  return db
+    .select()
+    .from(savedPrompts)
+    .where(and(...conditions))
+    .orderBy(desc(savedPrompts.updatedAt));
+}
+
+export async function listPublicPrompts(mode?: string) {
+  const db = getDb();
+  const conditions = [
+    eq(savedPrompts.isPublic, true),
+    isNull(savedPrompts.deletedAt),
+  ];
+  if (mode) {
+    conditions.push(sql`${savedPrompts.mode} = ${mode}`);
+  }
+  return db
+    .select()
+    .from(savedPrompts)
+    .where(and(...conditions))
+    .orderBy(desc(savedPrompts.createdAt));
+}
+
+export async function getPrompt(workspaceId: string, promptId: string) {
+  const db = getDb();
+  const [prompt] = await db
+    .select()
+    .from(savedPrompts)
+    .where(
+      and(
+        eq(savedPrompts.workspaceId, workspaceId),
+        eq(savedPrompts.id, promptId),
+        isNull(savedPrompts.deletedAt),
+      ),
+    );
+  return prompt ?? null;
+}
+
+interface UpdatePromptInput {
+  name?: string;
+  promptText?: string;
+  formConfig?: Record<string, unknown>;
+  isPublic?: boolean;
+}
+
+export async function updatePrompt(
+  workspaceId: string,
+  promptId: string,
+  input: UpdatePromptInput,
+) {
+  const db = getDb();
+  const now = new Date();
+
+  const setFields: Record<string, unknown> = { updatedAt: now };
+  if (input.name !== undefined) setFields.name = input.name;
+  if (input.promptText !== undefined) setFields.promptText = input.promptText;
+  if (input.formConfig !== undefined) setFields.formConfig = input.formConfig;
+  if (input.isPublic !== undefined) setFields.isPublic = input.isPublic;
+
+  const [updated] = await db
+    .update(savedPrompts)
+    .set(setFields)
+    .where(
+      and(
+        eq(savedPrompts.workspaceId, workspaceId),
+        eq(savedPrompts.id, promptId),
+        isNull(savedPrompts.deletedAt),
+      ),
+    )
+    .returning();
+
+  return updated ?? null;
+}
+
+export async function softDeletePrompt(workspaceId: string, promptId: string) {
+  const db = getDb();
+  const now = new Date();
+
+  const [deleted] = await db
+    .update(savedPrompts)
+    .set({ deletedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(savedPrompts.workspaceId, workspaceId),
+        eq(savedPrompts.id, promptId),
+        isNull(savedPrompts.deletedAt),
+      ),
+    )
+    .returning();
+
+  return deleted ?? null;
 }

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -26,6 +26,7 @@ export interface Generation {
   assetId: string | null;
   error: string | null;
   mode: SimpleStudioMode;
+  aspectRatio: string;
 }
 
 export interface SavedPrompt {
@@ -49,6 +50,9 @@ export interface SimpleStudioState {
   setRewriteEnabled: (enabled: boolean) => void;
   rewrittenPrompt: string | null;
   selectedModelId: string | null;
+  selectedModelProvider: string | null;
+  selectedModelName: string | null;
+  setSelectedModel: (id: string | null, provider?: string | null, name?: string | null) => void;
   setSelectedModelId: (id: string | null) => void;
   aspectRatio: string;
   setAspectRatio: (ratio: string) => void;
@@ -133,17 +137,22 @@ async function persistToR2(
   batchId: string,
 ): Promise<string | null> {
   try {
-    // Convert base64 data URL to blob
+    // Convert data URL or remote URL to blob
     const res = await fetch(dataUrl);
     const blob = await res.blob();
 
     const assetType = mode === "video" ? "video" : "image";
     const ext = mode === "video" ? "mp4" : "png";
+    // Use mode-aware content type rather than trusting blob.type
+    // (e.g. video results may report as application/octet-stream)
+    const contentType = mode === "video"
+      ? "video/mp4"
+      : blob.type || `image/${ext}`;
 
     // Presign
     const presign = await createStudioAssetPresign({
       assetType,
-      contentType: blob.type || `${assetType}/${ext}`,
+      contentType,
       expectedSizeBytes: blob.size,
       fileName: `simple-${mode}-${Date.now()}.${ext}`,
     });
@@ -151,7 +160,7 @@ async function persistToR2(
     // Upload to R2
     await fetch(presign.uploadUrl, {
       method: "PUT",
-      headers: { "Content-Type": blob.type || `${assetType}/${ext}` },
+      headers: { "Content-Type": contentType },
       body: blob,
     });
 
@@ -159,7 +168,7 @@ async function persistToR2(
     await finalizeStudioAssetUpload(presign.assetId, {
       uploadState: "ready",
       sizeBytes: blob.size,
-      mimeType: blob.type || `${assetType}/${ext}`,
+      mimeType: contentType,
     });
 
     return presign.assetId;
@@ -208,7 +217,11 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
   setRewriteEnabled: (enabled) => set({ rewriteEnabled: enabled }),
   rewrittenPrompt: null,
   selectedModelId: null,
-  setSelectedModelId: (id) => set({ selectedModelId: id }),
+  selectedModelProvider: null,
+  selectedModelName: null,
+  setSelectedModel: (id, provider = null, name = null) =>
+    set({ selectedModelId: id, selectedModelProvider: provider, selectedModelName: name }),
+  setSelectedModelId: (id) => set({ selectedModelId: id, selectedModelProvider: null, selectedModelName: null }),
   aspectRatio: "1:1",
   setAspectRatio: (ratio) => set({ aspectRatio: ratio }),
   batchCount: 4,
@@ -278,6 +291,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
         assetId: null,
         error: null,
         mode: state.mode,
+        aspectRatio: state.aspectRatio,
       }),
     );
 
@@ -355,12 +369,38 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
           result = fullText;
         } else {
           // Use /api/generate for photo/video
+          const images = state.mode === "photo"
+            ? state.referenceImages
+            : state.sourceImage ? [state.sourceImage] : [];
+          const hasSourceImage = state.mode === "video" && images.length > 0;
+
+          let modelId = state.selectedModelId;
+          let modelProvider = state.selectedModelProvider;
+          let modelName = state.selectedModelName;
+
+          // Auto-switch to image-to-video variant when source image is provided
+          if (hasSourceImage && modelId?.includes("/text-to-video")) {
+            modelId = modelId.replace("/text-to-video", "/image-to-video");
+          }
+
+          // Default to Veo when in video mode with no model selected
+          if (state.mode === "video" && !modelId) {
+            modelId = hasSourceImage ? "veo-3.1/image-to-video" : "veo-3.1/text-to-video";
+            modelProvider = null;
+            modelName = "Veo 3.1";
+          }
+
           const body: Record<string, unknown> = {
             prompt: finalPrompt,
-            images: state.mode === "photo" ? state.referenceImages : state.sourceImage ? [state.sourceImage] : [],
-            selectedModel: state.selectedModelId
-              ? { modelId: state.selectedModelId }
+            images,
+            selectedModel: modelId
+              ? {
+                  modelId,
+                  provider: modelProvider || undefined,
+                  displayName: modelName || modelId,
+                }
               : undefined,
+            mediaType: state.mode === "video" ? "video" : undefined,
             parameters: {
               aspectRatio: state.aspectRatio,
               ...(state.mode === "video" ? { duration: state.videoDuration } : {}),
@@ -375,7 +415,13 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
           });
           const data = await res.json();
           if (!data.success) throw new Error(data.error || "Generation failed");
-          result = data.image || data.video || data.videoUrl || data.audio || null;
+          // For video: prefer video (base64) or videoUrl (remote URL)
+          // For other modes: image, audio
+          if (state.mode === "video") {
+            result = data.video || data.videoUrl || null;
+          } else {
+            result = data.image || data.audio || null;
+          }
         }
 
         setGenerations(set, get, (prev) =>
@@ -383,7 +429,8 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
         );
 
         // Persist image/video results to R2 in the background (non-blocking)
-        if (result && state.mode !== "copy" && result.startsWith("data:")) {
+        // Results can be base64 data URLs or remote URLs (for large videos)
+        if (result && state.mode !== "copy" && (result.startsWith("data:") || result.startsWith("http"))) {
           persistToR2(result, state.mode, finalPrompt, batchId).then((assetId) => {
             if (assetId) {
               setGenerations(set, get, (prev) =>
@@ -469,6 +516,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
               assetId: asset.id as string,
               error: null,
               mode: (metadata.mode as SimpleStudioMode) || "photo",
+              aspectRatio: (metadata.aspectRatio as string) || "1:1",
             };
           },
         );
@@ -495,6 +543,8 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
           promptText: state.prompt,
           formConfig: {
             selectedModelId: state.selectedModelId,
+            selectedModelProvider: state.selectedModelProvider,
+            selectedModelName: state.selectedModelName,
             aspectRatio: state.aspectRatio,
             batchCount: state.batchCount,
             tone: state.tone,
@@ -550,6 +600,8 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
       prompt: prompt.promptText,
       rewrittenPrompt: null,
       selectedModelId: (config.selectedModelId as string) || null,
+      selectedModelProvider: (config.selectedModelProvider as string) || null,
+      selectedModelName: (config.selectedModelName as string) || null,
       aspectRatio: (config.aspectRatio as string) || "1:1",
       batchCount: (config.batchCount as number) || 4,
       tone: (config.tone as string) || "professional",

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -204,7 +204,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
     set({
       isGenerating: true,
       currentBatchId: batchId,
-      generations: [...entries, ...state.generations],
+      generations: entries,
     });
 
     const processGeneration = async (entry: Generation, sig: AbortSignal) => {
@@ -222,13 +222,22 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
 
         if (state.mode === "copy") {
           // Use /api/llm for copy mode
+          const langDirective = state.outputLanguage === "ar"
+            ? "Write in Arabic only."
+            : state.outputLanguage === "both"
+              ? "Write in both Arabic and English."
+              : "Write in English only.";
+          const fullPrompt = `You are a professional copywriter. ${langDirective} Platform: ${state.platform}. Tone: ${state.tone}. Return ONLY the copy text, no explanations or meta-commentary.\n\n${finalPrompt}`;
+
           const res = await fetch("/api/llm", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              prompt: finalPrompt,
+              prompt: fullPrompt,
+              provider: "google",
               model: "gemini-2.5-flash",
-              systemPrompt: `You are a professional copywriter. Generate ${state.outputLanguage === "ar" ? "Arabic" : state.outputLanguage === "both" ? "bilingual Arabic and English" : "English"} marketing copy for ${state.platform}. Tone: ${state.tone}. Return ONLY the copy text, no explanations.`,
+              temperature: 0.9,
+              maxTokens: 1024,
             }),
             signal: sig,
           });
@@ -317,6 +326,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           prompt: `Rewrite this prompt for better AI image/video generation results. Keep the same intent but make it more descriptive and detailed. Return ONLY the rewritten prompt, no explanations:\n\n${prompt}`,
+          provider: "google",
           model: "gemini-2.5-flash",
         }),
       });

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -7,6 +7,10 @@
  */
 
 import { create } from "zustand";
+import {
+  createStudioAssetPresign,
+  finalizeStudioAssetUpload,
+} from "@/lib/studio/client";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -115,6 +119,53 @@ async function processInChunks<T>(
     if (signal.aborted) break;
     const chunk = items.slice(i, i + concurrency);
     await Promise.allSettled(chunk.map((item) => processor(item, signal)));
+  }
+}
+
+/**
+ * Persist a base64 data URL result to R2 via presign → PUT → finalize.
+ * Returns the assetId on success, null on failure (non-fatal).
+ */
+async function persistToR2(
+  dataUrl: string,
+  mode: SimpleStudioMode,
+  prompt: string,
+  batchId: string,
+): Promise<string | null> {
+  try {
+    // Convert base64 data URL to blob
+    const res = await fetch(dataUrl);
+    const blob = await res.blob();
+
+    const assetType = mode === "video" ? "video" : "image";
+    const ext = mode === "video" ? "mp4" : "png";
+
+    // Presign
+    const presign = await createStudioAssetPresign({
+      assetType,
+      contentType: blob.type || `${assetType}/${ext}`,
+      expectedSizeBytes: blob.size,
+      fileName: `simple-${mode}-${Date.now()}.${ext}`,
+    });
+
+    // Upload to R2
+    await fetch(presign.uploadUrl, {
+      method: "PUT",
+      headers: { "Content-Type": blob.type || `${assetType}/${ext}` },
+      body: blob,
+    });
+
+    // Finalize
+    await finalizeStudioAssetUpload(presign.assetId, {
+      uploadState: "ready",
+      sizeBytes: blob.size,
+      mimeType: blob.type || `${assetType}/${ext}`,
+    });
+
+    return presign.assetId;
+  } catch {
+    // Non-fatal — generation still shows in UI, just not persisted
+    return null;
   }
 }
 
@@ -330,6 +381,17 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
         setGenerations(set, get, (prev) =>
           prev.map((g) => g.id === entry.id ? { ...g, status: "complete" as const, result } : g),
         );
+
+        // Persist image/video results to R2 in the background (non-blocking)
+        if (result && state.mode !== "copy" && result.startsWith("data:")) {
+          persistToR2(result, state.mode, finalPrompt, batchId).then((assetId) => {
+            if (assetId) {
+              setGenerations(set, get, (prev) =>
+                prev.map((g) => g.id === entry.id ? { ...g, assetId } : g),
+              );
+            }
+          });
+        }
       } catch (err) {
         if (sig.aborted) return;
         setGenerations(set, get, (prev) =>

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -124,7 +124,7 @@ async function processInChunks<T>(
 export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
   // Mode
   mode: "photo",
-  setMode: (mode) => set({ mode, rewrittenPrompt: null }),
+  setMode: (mode) => set({ mode, rewrittenPrompt: null, generations: [] }),
 
   // Form state
   prompt: "",

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -1,0 +1,415 @@
+/**
+ * Simple Studio Store
+ *
+ * Lightweight Zustand store for the form-based Simple Studio mode.
+ * Completely independent from workflowStore — no dependency on
+ * nodes, edges, React Flow, or the workflow execution pipeline.
+ */
+
+import { create } from "zustand";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SimpleStudioMode = "photo" | "video" | "copy";
+
+export interface Generation {
+  id: string;
+  batchId: string;
+  status: "pending" | "generating" | "complete" | "failed";
+  result: string | null;
+  assetId: string | null;
+  error: string | null;
+  mode: SimpleStudioMode;
+}
+
+export interface SavedPrompt {
+  id: string;
+  mode: SimpleStudioMode;
+  name: string;
+  promptText: string;
+  formConfig: Record<string, unknown>;
+  isPublic: boolean;
+}
+
+export interface SimpleStudioState {
+  // Mode
+  mode: SimpleStudioMode;
+  setMode: (mode: SimpleStudioMode) => void;
+
+  // Form state
+  prompt: string;
+  setPrompt: (prompt: string) => void;
+  rewriteEnabled: boolean;
+  setRewriteEnabled: (enabled: boolean) => void;
+  rewrittenPrompt: string | null;
+  selectedModelId: string | null;
+  setSelectedModelId: (id: string | null) => void;
+  aspectRatio: string;
+  setAspectRatio: (ratio: string) => void;
+  batchCount: number;
+  setBatchCount: (count: number) => void;
+  referenceImages: string[];
+  setReferenceImages: (images: string[]) => void;
+  sourceImage: string | null;
+  setSourceImage: (image: string | null) => void;
+  videoDuration: number;
+  setVideoDuration: (duration: number) => void;
+  tone: string;
+  setTone: (tone: string) => void;
+  platform: string;
+  setPlatform: (platform: string) => void;
+  outputLanguage: "ar" | "en" | "both";
+  setOutputLanguage: (lang: "ar" | "en" | "both") => void;
+
+  // Generation
+  isGenerating: boolean;
+  isRewriting: boolean;
+  currentBatchId: string | null;
+  generations: Generation[];
+  generate: () => Promise<void>;
+  cancelGeneration: () => void;
+  rewritePrompt: () => Promise<void>;
+
+  // Gallery
+  loadRecentResults: () => Promise<void>;
+
+  // Prompts
+  savedPrompts: SavedPrompt[];
+  publicPrompts: SavedPrompt[];
+  saveCurrentPrompt: (name: string) => Promise<void>;
+  loadSavedPrompts: () => Promise<void>;
+  loadPublicPrompts: () => Promise<void>;
+  applyPrompt: (prompt: SavedPrompt) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level abort controller (non-reactive)
+// ---------------------------------------------------------------------------
+
+let abortController: AbortController | null = null;
+
+const CONCURRENT_LIMIT = 4;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function processInChunks<T>(
+  items: T[],
+  concurrency: number,
+  processor: (item: T, signal: AbortSignal) => Promise<void>,
+  signal: AbortSignal,
+): Promise<void> {
+  for (let i = 0; i < items.length; i += concurrency) {
+    if (signal.aborted) break;
+    const chunk = items.slice(i, i + concurrency);
+    await Promise.allSettled(chunk.map((item) => processor(item, signal)));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
+  // Mode
+  mode: "photo",
+  setMode: (mode) => set({ mode, rewrittenPrompt: null }),
+
+  // Form state
+  prompt: "",
+  setPrompt: (prompt) => set({ prompt, rewrittenPrompt: null }),
+  rewriteEnabled: false,
+  setRewriteEnabled: (enabled) => set({ rewriteEnabled: enabled }),
+  rewrittenPrompt: null,
+  selectedModelId: null,
+  setSelectedModelId: (id) => set({ selectedModelId: id }),
+  aspectRatio: "1:1",
+  setAspectRatio: (ratio) => set({ aspectRatio: ratio }),
+  batchCount: 4,
+  setBatchCount: (count) => set({ batchCount: count }),
+  referenceImages: [],
+  setReferenceImages: (images) => set({ referenceImages: images }),
+  sourceImage: null,
+  setSourceImage: (image) => set({ sourceImage: image }),
+  videoDuration: 5,
+  setVideoDuration: (duration) => set({ videoDuration: duration }),
+  tone: "professional",
+  setTone: (tone) => set({ tone }),
+  platform: "general",
+  setPlatform: (platform) => set({ platform }),
+  outputLanguage: "en",
+  setOutputLanguage: (lang) => set({ outputLanguage: lang }),
+
+  // Generation
+  isGenerating: false,
+  isRewriting: false,
+  currentBatchId: null,
+  generations: [],
+
+  generate: async () => {
+    const state = get();
+    if (state.isGenerating) return;
+
+    // Rewrite prompt if enabled and not already done
+    if (state.rewriteEnabled && !state.rewrittenPrompt) {
+      await get().rewritePrompt();
+      if (!get().rewrittenPrompt) return; // rewrite failed
+    }
+
+    const finalPrompt = get().rewrittenPrompt || get().prompt;
+    if (!finalPrompt.trim()) return;
+
+    const batchId = crypto.randomUUID();
+    abortController = new AbortController();
+    const signal = abortController.signal;
+
+    // Create pending generation entries
+    const entries: Generation[] = Array.from(
+      { length: state.batchCount },
+      (_, i) => ({
+        id: `gen_${batchId}_${i}`,
+        batchId,
+        status: "pending" as const,
+        result: null,
+        assetId: null,
+        error: null,
+        mode: state.mode,
+      }),
+    );
+
+    set({
+      isGenerating: true,
+      currentBatchId: batchId,
+      generations: [...entries, ...state.generations],
+    });
+
+    const processGeneration = async (entry: Generation, sig: AbortSignal) => {
+      if (sig.aborted) return;
+
+      // Mark as generating
+      set((s) => ({
+        generations: s.generations.map((g) =>
+          g.id === entry.id ? { ...g, status: "generating" as const } : g,
+        ),
+      }));
+
+      try {
+        let result: string | null = null;
+
+        if (state.mode === "copy") {
+          // Use /api/llm for copy mode
+          const res = await fetch("/api/llm", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              prompt: finalPrompt,
+              model: "gemini-2.5-flash",
+              systemPrompt: `You are a professional copywriter. Generate ${state.outputLanguage === "ar" ? "Arabic" : state.outputLanguage === "both" ? "bilingual Arabic and English" : "English"} marketing copy for ${state.platform}. Tone: ${state.tone}. Return ONLY the copy text, no explanations.`,
+            }),
+            signal: sig,
+          });
+          const data = await res.json();
+          if (!data.success) throw new Error(data.error || "LLM generation failed");
+          result = data.text || data.response;
+        } else {
+          // Use /api/generate for photo/video
+          const body: Record<string, unknown> = {
+            prompt: finalPrompt,
+            images: state.mode === "photo" ? state.referenceImages : state.sourceImage ? [state.sourceImage] : [],
+            selectedModel: state.selectedModelId
+              ? { modelId: state.selectedModelId }
+              : undefined,
+            parameters: {
+              aspectRatio: state.aspectRatio,
+              ...(state.mode === "video" ? { duration: state.videoDuration } : {}),
+            },
+          };
+
+          const res = await fetch("/api/generate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+            signal: sig,
+          });
+          const data = await res.json();
+          if (!data.success) throw new Error(data.error || "Generation failed");
+          result = data.image || data.video || data.videoUrl || data.audio || null;
+        }
+
+        set((s) => ({
+          generations: s.generations.map((g) =>
+            g.id === entry.id
+              ? { ...g, status: "complete" as const, result }
+              : g,
+          ),
+        }));
+      } catch (err) {
+        if (sig.aborted) return;
+        set((s) => ({
+          generations: s.generations.map((g) =>
+            g.id === entry.id
+              ? {
+                  ...g,
+                  status: "failed" as const,
+                  error: err instanceof Error ? err.message : "Generation failed",
+                }
+              : g,
+          ),
+        }));
+      }
+    };
+
+    await processInChunks(entries, CONCURRENT_LIMIT, processGeneration, signal);
+
+    set({ isGenerating: false, currentBatchId: null });
+    abortController = null;
+  },
+
+  cancelGeneration: () => {
+    if (abortController) {
+      abortController.abort();
+      abortController = null;
+    }
+    set((s) => ({
+      isGenerating: false,
+      currentBatchId: null,
+      generations: s.generations.map((g) =>
+        g.status === "pending" || g.status === "generating"
+          ? { ...g, status: "failed" as const, error: "Cancelled" }
+          : g,
+      ),
+    }));
+  },
+
+  rewritePrompt: async () => {
+    const { prompt } = get();
+    if (!prompt.trim()) return;
+
+    set({ isRewriting: true });
+
+    try {
+      const res = await fetch("/api/llm", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt: `Rewrite this prompt for better AI image/video generation results. Keep the same intent but make it more descriptive and detailed. Return ONLY the rewritten prompt, no explanations:\n\n${prompt}`,
+          model: "gemini-2.5-flash",
+        }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        set({ rewrittenPrompt: data.text || data.response || null });
+      }
+    } catch {
+      // Silently fail — user can still generate with original prompt
+    } finally {
+      set({ isRewriting: false });
+    }
+  },
+
+  // Gallery
+  loadRecentResults: async () => {
+    try {
+      const res = await fetch("/api/studio/assets?source=simple");
+      const data = await res.json();
+      if (data.success && data.assets) {
+        const entries: Generation[] = data.assets.map(
+          (asset: Record<string, unknown>) => {
+            const metadata = (asset.metadata as Record<string, unknown>) || {};
+            return {
+              id: asset.id as string,
+              batchId: (metadata.batchId as string) || "unknown",
+              status: "complete" as const,
+              result: asset.storageKey as string,
+              assetId: asset.id as string,
+              error: null,
+              mode: (metadata.mode as SimpleStudioMode) || "photo",
+            };
+          },
+        );
+        set({ generations: entries });
+      }
+    } catch {
+      // Non-fatal — gallery just stays empty
+    }
+  },
+
+  // Prompts
+  savedPrompts: [],
+  publicPrompts: [],
+
+  saveCurrentPrompt: async (name: string) => {
+    const state = get();
+    try {
+      const res = await fetch("/api/studio/prompts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: state.mode,
+          name,
+          promptText: state.prompt,
+          formConfig: {
+            selectedModelId: state.selectedModelId,
+            aspectRatio: state.aspectRatio,
+            batchCount: state.batchCount,
+            tone: state.tone,
+            platform: state.platform,
+            outputLanguage: state.outputLanguage,
+            videoDuration: state.videoDuration,
+          },
+        }),
+      });
+      const data = await res.json();
+      if (data.success && data.prompt) {
+        set((s) => ({ savedPrompts: [data.prompt, ...s.savedPrompts] }));
+      }
+    } catch {
+      // Non-fatal
+    }
+  },
+
+  loadSavedPrompts: async () => {
+    const { mode } = get();
+    try {
+      const res = await fetch(`/api/studio/prompts?mode=${mode}`);
+      const data = await res.json();
+      if (data.success && data.prompts) {
+        set({ savedPrompts: data.prompts });
+      }
+    } catch {
+      // Non-fatal
+    }
+  },
+
+  loadPublicPrompts: async () => {
+    const { mode } = get();
+    try {
+      const res = await fetch(`/api/studio/prompts/public?mode=${mode}`);
+      const data = await res.json();
+      if (data.success && data.prompts) {
+        set({ publicPrompts: data.prompts });
+      }
+    } catch {
+      // Non-fatal
+    }
+  },
+
+  applyPrompt: (prompt: SavedPrompt) => {
+    const config = prompt.formConfig || {};
+    set({
+      mode: prompt.mode,
+      prompt: prompt.promptText,
+      rewrittenPrompt: null,
+      selectedModelId: (config.selectedModelId as string) || null,
+      aspectRatio: (config.aspectRatio as string) || "1:1",
+      batchCount: (config.batchCount as number) || 4,
+      tone: (config.tone as string) || "professional",
+      platform: (config.platform as string) || "general",
+      outputLanguage: (config.outputLanguage as "ar" | "en" | "both") || "en",
+      videoDuration: (config.videoDuration as number) || 5,
+    });
+  },
+}));

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -71,11 +71,12 @@ export interface SimpleStudioState {
   outputLanguage: "ar" | "en" | "both";
   setOutputLanguage: (lang: "ar" | "en" | "both") => void;
 
-  // Generation
+  // Generation (per-mode)
   isGenerating: boolean;
   isRewriting: boolean;
   currentBatchId: string | null;
-  generations: Generation[];
+  generationsByMode: Record<SimpleStudioMode, Generation[]>;
+  generations: Generation[]; // derived — current mode's generations
   generate: () => Promise<void>;
   cancelGeneration: () => void;
   rewritePrompt: () => Promise<void>;
@@ -121,10 +122,33 @@ async function processInChunks<T>(
 // Store
 // ---------------------------------------------------------------------------
 
+/**
+ * Helper: update generations for the current mode.
+ * Syncs both `generations` (derived) and `generationsByMode[mode]`.
+ */
+function setGenerations(
+  set: (fn: (s: SimpleStudioState) => Partial<SimpleStudioState>) => void,
+  get: () => SimpleStudioState,
+  updater: (prev: Generation[]) => Generation[],
+) {
+  set((s) => {
+    const mode = get().mode;
+    const updated = updater(s.generationsByMode[mode]);
+    return {
+      generations: updated,
+      generationsByMode: { ...s.generationsByMode, [mode]: updated },
+    };
+  });
+}
+
 export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
   // Mode
   mode: "photo",
-  setMode: (mode) => set({ mode, rewrittenPrompt: null, generations: [] }),
+  setMode: (mode) => set((s) => ({
+    mode,
+    rewrittenPrompt: null,
+    generations: s.generationsByMode[mode],
+  })),
 
   // Form state
   prompt: "",
@@ -163,6 +187,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
   isGenerating: false,
   isRewriting: false,
   currentBatchId: null,
+  generationsByMode: { photo: [], video: [], copy: [] },
   generations: [],
 
   generate: async () => {
@@ -205,21 +230,16 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
       }),
     );
 
-    set({
-      isGenerating: true,
-      currentBatchId: batchId,
-      generations: entries,
-    });
+    setGenerations(set, get, () => entries);
+    set({ isGenerating: true, currentBatchId: batchId });
 
     const processGeneration = async (entry: Generation, sig: AbortSignal) => {
       if (sig.aborted) return;
 
       // Mark as generating
-      set((s) => ({
-        generations: s.generations.map((g) =>
-          g.id === entry.id ? { ...g, status: "generating" as const } : g,
-        ),
-      }));
+      setGenerations(set, get, (prev) =>
+        prev.map((g) => g.id === entry.id ? { ...g, status: "generating" as const } : g),
+      );
 
       try {
         let result: string | null = null;
@@ -307,26 +327,18 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
           result = data.image || data.video || data.videoUrl || data.audio || null;
         }
 
-        set((s) => ({
-          generations: s.generations.map((g) =>
-            g.id === entry.id
-              ? { ...g, status: "complete" as const, result }
-              : g,
-          ),
-        }));
+        setGenerations(set, get, (prev) =>
+          prev.map((g) => g.id === entry.id ? { ...g, status: "complete" as const, result } : g),
+        );
       } catch (err) {
         if (sig.aborted) return;
-        set((s) => ({
-          generations: s.generations.map((g) =>
+        setGenerations(set, get, (prev) =>
+          prev.map((g) =>
             g.id === entry.id
-              ? {
-                  ...g,
-                  status: "failed" as const,
-                  error: err instanceof Error ? err.message : "Generation failed",
-                }
+              ? { ...g, status: "failed" as const, error: err instanceof Error ? err.message : "Generation failed" }
               : g,
           ),
-        }));
+        );
       }
     };
 
@@ -341,15 +353,14 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
       abortController.abort();
       abortController = null;
     }
-    set((s) => ({
-      isGenerating: false,
-      currentBatchId: null,
-      generations: s.generations.map((g) =>
+    setGenerations(set, get, (prev) =>
+      prev.map((g) =>
         g.status === "pending" || g.status === "generating"
           ? { ...g, status: "failed" as const, error: "Cancelled" }
           : g,
       ),
-    }));
+    );
+    set({ isGenerating: false, currentBatchId: null });
   },
 
   rewritePrompt: async () => {
@@ -399,7 +410,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
             };
           },
         );
-        set({ generations: entries });
+        setGenerations(set, get, () => entries);
       }
     } catch {
       // Non-fatal — gallery just stays empty

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -56,6 +56,12 @@ export interface SimpleStudioState {
   setSourceImage: (image: string | null) => void;
   videoDuration: number;
   setVideoDuration: (duration: number) => void;
+  dialogueEnabled: boolean;
+  setDialogueEnabled: (enabled: boolean) => void;
+  dialogueText: string;
+  setDialogueText: (text: string) => void;
+  dialogueLanguage: "ar" | "en";
+  setDialogueLanguage: (lang: "ar" | "en") => void;
   tone: string;
   setTone: (tone: string) => void;
   platform: string;
@@ -136,6 +142,12 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
   setSourceImage: (image) => set({ sourceImage: image }),
   videoDuration: 5,
   setVideoDuration: (duration) => set({ videoDuration: duration }),
+  dialogueEnabled: false,
+  setDialogueEnabled: (enabled) => set({ dialogueEnabled: enabled }),
+  dialogueText: "",
+  setDialogueText: (text) => set({ dialogueText: text }),
+  dialogueLanguage: "en",
+  setDialogueLanguage: (lang) => set({ dialogueLanguage: lang }),
   tone: "professional",
   setTone: (tone) => set({ tone }),
   platform: "general",
@@ -159,8 +171,17 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
       if (!get().rewrittenPrompt) return; // rewrite failed
     }
 
-    const finalPrompt = get().rewrittenPrompt || get().prompt;
+    let finalPrompt = get().rewrittenPrompt || get().prompt;
     if (!finalPrompt.trim()) return;
+
+    // Inject dialogue into video prompts when enabled
+    if (state.mode === "video" && state.dialogueEnabled && state.dialogueText.trim()) {
+      const langHint = state.dialogueLanguage === "ar"
+        ? "speaking in Arabic"
+        : "speaking in English";
+      // Use colon-style dialogue to suppress subtitles (Veo 3.1 pattern)
+      finalPrompt = `${finalPrompt}. The character is ${langHint}, saying: "${state.dialogueText.trim()}"`;
+    }
 
     const batchId = crypto.randomUUID();
     abortController = new AbortController();
@@ -359,6 +380,9 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
             platform: state.platform,
             outputLanguage: state.outputLanguage,
             videoDuration: state.videoDuration,
+            dialogueEnabled: state.dialogueEnabled,
+            dialogueText: state.dialogueText,
+            dialogueLanguage: state.dialogueLanguage,
           },
         }),
       });
@@ -410,6 +434,9 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
       platform: (config.platform as string) || "general",
       outputLanguage: (config.outputLanguage as "ar" | "en" | "both") || "en",
       videoDuration: (config.videoDuration as number) || 5,
+      dialogueEnabled: (config.dialogueEnabled as boolean) || false,
+      dialogueText: (config.dialogueText as string) || "",
+      dialogueLanguage: (config.dialogueLanguage as "ar" | "en") || "en",
     });
   },
 }));

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -249,29 +249,39 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
             throw new Error(errText || "Copy generation failed");
           }
 
-          // Read the streaming response to completion
+          // Read AI SDK v6 UI message stream to completion
+          // Format: lines of `data: {"type":"text-delta","id":"0","delta":"..."}`
           const reader = res.body?.getReader();
           if (!reader) throw new Error("No response body");
           const decoder = new TextDecoder();
+          let buffer = "";
           let fullText = "";
+
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
-            fullText += decoder.decode(value, { stream: true });
+            buffer += decoder.decode(value, { stream: true });
+
+            // Process complete lines
+            const lines = buffer.split("\n");
+            buffer = lines.pop() || "";
+            for (const line of lines) {
+              const trimmed = line.trim();
+              if (!trimmed.startsWith("data: ")) continue;
+              const payload = trimmed.slice(6);
+              if (payload === "[DONE]") continue;
+              try {
+                const parsed = JSON.parse(payload);
+                if (parsed.type === "text-delta" && parsed.delta) {
+                  fullText += parsed.delta;
+                }
+              } catch {
+                // skip unparseable lines
+              }
+            }
           }
 
-          // Extract text from AI SDK UI message stream format
-          // The stream contains lines like: 0:"text chunk"\n
-          const textParts = fullText
-            .split("\n")
-            .filter((line) => line.startsWith("0:"))
-            .map((line) => {
-              try { return JSON.parse(line.slice(2)); }
-              catch { return ""; }
-            })
-            .join("");
-
-          result = textParts || fullText;
+          result = fullText;
         } else {
           // Use /api/generate for photo/video
           const body: Record<string, unknown> = {

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -62,6 +62,8 @@ export interface SimpleStudioState {
   setDialogueText: (text: string) => void;
   dialogueLanguage: "ar" | "en";
   setDialogueLanguage: (lang: "ar" | "en") => void;
+  copyModelId: string;
+  setCopyModelId: (id: string) => void;
   tone: string;
   setTone: (tone: string) => void;
   platform: string;
@@ -148,6 +150,8 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
   setDialogueText: (text) => set({ dialogueText: text }),
   dialogueLanguage: "en",
   setDialogueLanguage: (lang) => set({ dialogueLanguage: lang }),
+  copyModelId: "gemini-2.5-flash",
+  setCopyModelId: (id) => set({ copyModelId: id }),
   tone: "professional",
   setTone: (tone) => set({ tone }),
   platform: "general",
@@ -221,29 +225,53 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
         let result: string | null = null;
 
         if (state.mode === "copy") {
-          // Use /api/llm for copy mode
+          // Use /api/studio/copy streaming endpoint
           const langDirective = state.outputLanguage === "ar"
             ? "Write in Arabic only."
             : state.outputLanguage === "both"
               ? "Write in both Arabic and English."
               : "Write in English only.";
-          const fullPrompt = `You are a professional copywriter. ${langDirective} Platform: ${state.platform}. Tone: ${state.tone}. Return ONLY the copy text, no explanations or meta-commentary.\n\n${finalPrompt}`;
+          const systemPrompt = `You are a professional copywriter. ${langDirective} Platform: ${state.platform}. Tone: ${state.tone}. Return ONLY the copy text, no explanations or meta-commentary.`;
 
-          const res = await fetch("/api/llm", {
+          const res = await fetch("/api/studio/copy", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              prompt: fullPrompt,
-              provider: "google",
-              model: "gemini-2.5-flash",
-              temperature: 0.9,
-              maxTokens: 1024,
+              messages: [{ id: entry.id, role: "user", parts: [{ type: "text", text: finalPrompt }] }],
+              model: state.copyModelId,
+              system: systemPrompt,
             }),
             signal: sig,
           });
-          const data = await res.json();
-          if (!data.success) throw new Error(data.error || "LLM generation failed");
-          result = data.text || data.response;
+
+          if (!res.ok) {
+            const errText = await res.text();
+            throw new Error(errText || "Copy generation failed");
+          }
+
+          // Read the streaming response to completion
+          const reader = res.body?.getReader();
+          if (!reader) throw new Error("No response body");
+          const decoder = new TextDecoder();
+          let fullText = "";
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            fullText += decoder.decode(value, { stream: true });
+          }
+
+          // Extract text from AI SDK UI message stream format
+          // The stream contains lines like: 0:"text chunk"\n
+          const textParts = fullText
+            .split("\n")
+            .filter((line) => line.startsWith("0:"))
+            .map((line) => {
+              try { return JSON.parse(line.slice(2)); }
+              catch { return ""; }
+            })
+            .join("");
+
+          result = textParts || fullText;
         } else {
           // Use /api/generate for photo/video
           const body: Record<string, unknown> = {
@@ -393,6 +421,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
             dialogueEnabled: state.dialogueEnabled,
             dialogueText: state.dialogueText,
             dialogueLanguage: state.dialogueLanguage,
+            copyModelId: state.copyModelId,
           },
         }),
       });
@@ -447,6 +476,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
       dialogueEnabled: (config.dialogueEnabled as boolean) || false,
       dialogueText: (config.dialogueText as string) || "",
       dialogueLanguage: (config.dialogueLanguage as "ar" | "en") || "en",
+      copyModelId: (config.copyModelId as string) || "gemini-2.5-flash",
     });
   },
 }));


### PR DESCRIPTION
## Summary

- **New Simple Studio mode** at `/studio/simple` — a form-based UI for quick batch generation across three modes: Photo, Video, and Copy (LLM text)
- **DB layer**: `saved_prompts` table with CRUD repository and API routes for saving/loading prompt presets
- **Zustand store** (`simpleStudioStore`): independent from workflowStore, handles batch generation with chunked concurrency (4 parallel), per-mode generation history, AI SDK v6 streaming for copy, dialogue injection for video, and R2 persistence
- **Sidebar**: mode tabs, prompt input, AI prompt enhance toggle, reference/source images, searchable model selector with Recommended/All categories, aspect ratio, duration, dialogue fields, LLM model selector, tone/platform/language for copy
- **Results gallery**: grouped by batch, responsive grid adapting to mode and aspect ratio
- **Generation cards**: aspect-ratio-aware rendering (1:1, 16:9, 9:16, 4:5), click-to-preview lightbox for images and videos, hover-to-play video thumbnails
- **Copy mode**: streaming LLM endpoint (`/api/studio/copy`) with multi-provider support (Google, OpenAI, Anthropic) via AI SDK v6
- **Video fixes**: correct provider/displayName routing so non-Gemini video models work, auto-switch text-to-video → image-to-video when source image provided, mode-aware content type for R2 persistence
- **Header**: mode switcher pill (Simple/Workflow), workflow-only controls hidden in Simple mode

Implements #54, #55, #56, #57, #58, #59, #60, #61

## Test plan

- [ ] Navigate to `/studio/simple` — three mode tabs (Photo, Video, Copy) render
- [ ] Photo mode: select model, write prompt, generate batch → images appear in gallery with correct aspect ratio
- [ ] Video mode: select Veo/Kling model, write prompt, generate → video plays in card; click opens lightbox with autoplay
- [ ] Video mode with source image: auto-switches to image-to-video variant
- [ ] Copy mode: select LLM model, write prompt, generate → streamed text appears in cards
- [ ] Click image/video → lightbox opens; Escape/backdrop closes it; Download button works
- [ ] Switch between modes → generations preserved per mode
- [ ] Save/load prompt presets via Prompt Library
- [ ] Aspect ratio selector respected in card rendering (especially 9:16 portrait)
- [ ] Header pill toggles between Simple and Workflow modes
- [ ] All existing tests pass (151/152, 1 pre-existing failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)