### PR TITLE
fix: simple studio race conditions, data loss, and UI bugs

### DIFF
--- a/src/app/api/studio/copy/route.ts
+++ b/src/app/api/studio/copy/route.ts
@@ -73,8 +73,15 @@ export async function POST(request: Request) {
     return result.toUIMessageStreamResponse();
   } catch (error) {
     console.error("[Copy API Error]", error);
-    return new Response(
-      error instanceof Error ? error.message : "Copy generation failed",
+    const message = error instanceof Error ? error.message : "Copy generation failed";
+    // Don't leak internal details (env var names, stack traces) to the client
+    const safeMessage = message.includes("not configured")
+      ? "Model API key not configured"
+      : message.includes("Unknown model")
+        ? "Unsupported model selected"
+        : "Copy generation failed";
+    return Response.json(
+      { success: false, error: safeMessage },
       { status: 500 },
     );
   }

--- a/src/components/simple-studio/ResultsGallery.tsx
+++ b/src/components/simple-studio/ResultsGallery.tsx
@@ -33,48 +33,48 @@ export function ResultsGallery() {
     );
   }
 
-  // Group generations by batchId
+  // Group generations by batchId in a single pass
   const batches: { batchId: string; items: typeof generations }[] = [];
-  const seen = new Set<string>();
+  const batchMap = new Map<string, typeof generations>();
 
   for (const gen of generations) {
-    if (!seen.has(gen.batchId)) {
-      seen.add(gen.batchId);
-      batches.push({
-        batchId: gen.batchId,
-        items: generations.filter((g) => g.batchId === gen.batchId),
-      });
+    let items = batchMap.get(gen.batchId);
+    if (!items) {
+      items = [];
+      batchMap.set(gen.batchId, items);
+      batches.push({ batchId: gen.batchId, items });
     }
-  }
-
-  // Detect aspect ratio from the first item in the batch (all share the same)
-  const firstAspect = generations[0]?.aspectRatio || "1:1";
-  const isPortrait = firstAspect === "9:16";
-
-  // Grid columns based on mode and aspect ratio
-  let gridCols: string;
-  if (mode === "copy") {
-    gridCols = "grid-cols-1 md:grid-cols-2";
-  } else if (isPortrait) {
-    // Portrait (9:16) — narrower cards, more columns
-    gridCols = "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
-  } else if (mode === "video") {
-    gridCols = "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3";
-  } else {
-    gridCols = "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4";
+    items.push(gen);
   }
 
   return (
     <div className="p-4 space-y-6">
-      {batches.map((batch) => (
-        <div key={batch.batchId}>
-          <div className={`grid ${gridCols} gap-3`}>
-            {batch.items.map((gen) => (
-              <GenerationCard key={gen.id} generation={gen} />
-            ))}
+      {batches.map((batch) => {
+        // Determine grid columns per-batch based on its own aspect ratio
+        const batchAspect = batch.items[0]?.aspectRatio || "1:1";
+        const isPortrait = batchAspect === "9:16";
+
+        let gridCols: string;
+        if (mode === "copy") {
+          gridCols = "grid-cols-1 md:grid-cols-2";
+        } else if (isPortrait) {
+          gridCols = "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+        } else if (mode === "video") {
+          gridCols = "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3";
+        } else {
+          gridCols = "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4";
+        }
+
+        return (
+          <div key={batch.batchId}>
+            <div className={`grid ${gridCols} gap-3`}>
+              {batch.items.map((gen) => (
+                <GenerationCard key={gen.id} generation={gen} />
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSimpleStudioStore, type SimpleStudioMode } from "@/store/simpleStudioStore";
 import { PromptLibrary } from "./PromptLibrary";
 
@@ -71,26 +71,29 @@ const OUTPUT_LANGUAGES: { value: "ar" | "en" | "both"; label: string }[] = [
 
 export function Sidebar() {
   const store = useSimpleStudioStore();
+  const mode = useSimpleStudioStore((s) => s.mode);
   const [models, setModels] = useState<ProviderModel[]>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
+  const [modelsFetchError, setModelsFetchError] = useState(false);
   const [modelSearch, setModelSearch] = useState("");
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Fetch models on mount and mode change
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     setIsLoadingModels(true);
+    setModelsFetchError(false);
 
     const capabilities =
-      store.mode === "video"
+      mode === "video"
         ? "text-to-video,image-to-video"
         : "text-to-image,image-to-image";
 
-    fetch(`/api/models?capabilities=${capabilities}`)
+    fetch(`/api/models?capabilities=${capabilities}`, { signal: controller.signal })
       .then((r) => r.json())
       .then((data) => {
-        if (!cancelled && data.success) {
+        if (data.success) {
           // Deduplicate models by ID
           const seen = new Set<string>();
           const unique = (data.models || []).filter((m: ProviderModel) => {
@@ -99,47 +102,63 @@ export function Sidebar() {
             return true;
           });
           setModels(unique);
+        } else {
+          setModelsFetchError(true);
         }
       })
-      .catch(() => {})
+      .catch((err) => {
+        if (err?.name !== "AbortError") setModelsFetchError(true);
+      })
       .finally(() => {
-        if (!cancelled) setIsLoadingModels(false);
+        setIsLoadingModels(false);
       });
 
-    return () => { cancelled = true; };
-  }, [store.mode]);
+    return () => controller.abort();
+  }, [mode]);
 
-  // Close dropdown on click outside
+  // Reset dropdown state when mode changes
   useEffect(() => {
-    function handleClick(e: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setModelDropdownOpen(false);
-      }
+    setModelDropdownOpen(false);
+    setModelSearch("");
+  }, [mode]);
+
+  // Close dropdown on click outside — only listen when open
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+      setModelDropdownOpen(false);
     }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
-  const isPhotoOrVideo = store.mode === "photo" || store.mode === "video";
-  const maxBatch = store.mode === "video" ? 8 : 20;
-  const batchPresets = store.mode === "video" ? VIDEO_BATCH_PRESETS : BATCH_PRESETS;
-  const aspectRatios = store.mode === "video" ? VIDEO_ASPECT_RATIOS : PHOTO_ASPECT_RATIOS;
+  useEffect(() => {
+    if (!modelDropdownOpen) return;
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [modelDropdownOpen, handleClickOutside]);
+
+  const isPhotoOrVideo = mode === "photo" || mode === "video";
+  const maxBatch = mode === "video" ? 8 : 20;
+  const batchPresets = mode === "video" ? VIDEO_BATCH_PRESETS : BATCH_PRESETS;
+  const aspectRatios = mode === "video" ? VIDEO_ASPECT_RATIOS : PHOTO_ASPECT_RATIOS;
 
   // Reset aspect ratio when switching to video if current value isn't valid for video
   useEffect(() => {
-    if (store.mode === "video" && !VIDEO_ASPECT_RATIOS.includes(store.aspectRatio)) {
+    if (mode === "video" && !VIDEO_ASPECT_RATIOS.includes(store.aspectRatio)) {
       store.setAspectRatio("16:9");
     }
-  }, [store.mode, store.aspectRatio, store.setAspectRatio]);
+  }, [mode, store.aspectRatio, store.setAspectRatio]);
 
-  // Split models into recommended + others, filtered by search
-  const recommendedSet = store.mode === "video" ? RECOMMENDED_VIDEO_MODELS : RECOMMENDED_IMAGE_MODELS;
-  const searchLower = modelSearch.toLowerCase();
-  const filteredModels = models.filter(
-    (m) => !searchLower || m.name.toLowerCase().includes(searchLower) || m.id.toLowerCase().includes(searchLower) || m.provider.toLowerCase().includes(searchLower),
-  );
-  const recommendedModels = filteredModels.filter((m) => recommendedSet.has(m.id));
-  const otherModels = filteredModels.filter((m) => !recommendedSet.has(m.id));
+  // Split models into recommended + others, filtered by search (memoized)
+  const recommendedSet = mode === "video" ? RECOMMENDED_VIDEO_MODELS : RECOMMENDED_IMAGE_MODELS;
+  const { recommendedModels, otherModels } = useMemo(() => {
+    const searchLower = modelSearch.toLowerCase();
+    const filtered = models.filter(
+      (m) => !searchLower || m.name.toLowerCase().includes(searchLower) || m.id.toLowerCase().includes(searchLower) || m.provider.toLowerCase().includes(searchLower),
+    );
+    return {
+      recommendedModels: filtered.filter((m) => recommendedSet.has(m.id)),
+      otherModels: filtered.filter((m) => !recommendedSet.has(m.id)),
+    };
+  }, [models, modelSearch, recommendedSet]);
   const selectedModel = models.find((m) => m.id === store.selectedModelId);
 
   return (
@@ -400,7 +419,11 @@ export function Sidebar() {
                       <div className="px-3 py-2 text-xs text-neutral-500">Loading models...</div>
                     )}
 
-                    {!isLoadingModels && filteredModels.length === 0 && modelSearch && (
+                    {modelsFetchError && !isLoadingModels && (
+                      <div className="px-3 py-2 text-xs text-red-400">Failed to load models</div>
+                    )}
+
+                    {!isLoadingModels && !modelsFetchError && recommendedModels.length === 0 && otherModels.length === 0 && modelSearch && (
                       <div className="px-3 py-2 text-xs text-neutral-500">No models match &quot;{modelSearch}&quot;</div>
                     )}
                   </div>

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -183,19 +183,21 @@ async function persistToR2(
 // ---------------------------------------------------------------------------
 
 /**
- * Helper: update generations for the current mode.
+ * Helper: update generations for a specific mode.
+ * Accepts an explicit `mode` to avoid stale-closure bugs when the user
+ * switches modes while a generation batch is in-flight.
  * Syncs both `generations` (derived) and `generationsByMode[mode]`.
  */
 function setGenerations(
   set: (fn: (s: SimpleStudioState) => Partial<SimpleStudioState>) => void,
-  get: () => SimpleStudioState,
+  mode: SimpleStudioMode,
   updater: (prev: Generation[]) => Generation[],
 ) {
   set((s) => {
-    const mode = get().mode;
     const updated = updater(s.generationsByMode[mode]);
     return {
-      generations: updated,
+      // Only update derived `generations` if the user is still viewing this mode
+      ...(s.mode === mode ? { generations: updated } : {}),
       generationsByMode: { ...s.generationsByMode, [mode]: updated },
     };
   });
@@ -258,14 +260,23 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
     const state = get();
     if (state.isGenerating) return;
 
+    // Lock generation immediately to prevent double-invocation during rewrite
+    set({ isGenerating: true });
+
     // Rewrite prompt if enabled and not already done
     if (state.rewriteEnabled && !state.rewrittenPrompt) {
       await get().rewritePrompt();
-      if (!get().rewrittenPrompt) return; // rewrite failed
+      if (!get().rewrittenPrompt) {
+        set({ isGenerating: false });
+        return; // rewrite failed
+      }
     }
 
     let finalPrompt = get().rewrittenPrompt || get().prompt;
-    if (!finalPrompt.trim()) return;
+    if (!finalPrompt.trim()) {
+      set({ isGenerating: false });
+      return;
+    }
 
     // Inject dialogue into video prompts when enabled
     if (state.mode === "video" && state.dialogueEnabled && state.dialogueText.trim()) {
@@ -275,6 +286,10 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
       // Use colon-style dialogue to suppress subtitles (Veo 3.1 pattern)
       finalPrompt = `${finalPrompt}. The character is ${langHint}, saying: "${state.dialogueText.trim()}"`;
     }
+
+    // Capture mode at generation start so mode switches during generation
+    // don't corrupt the wrong mode's results
+    const genMode = state.mode;
 
     const batchId = crypto.randomUUID();
     abortController = new AbortController();
@@ -290,19 +305,20 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
         result: null,
         assetId: null,
         error: null,
-        mode: state.mode,
+        mode: genMode,
         aspectRatio: state.aspectRatio,
       }),
     );
 
-    setGenerations(set, get, () => entries);
-    set({ isGenerating: true, currentBatchId: batchId });
+    // Prepend new batch entries (keep previous results)
+    setGenerations(set, genMode, (prev) => [...entries, ...prev]);
+    set({ currentBatchId: batchId });
 
     const processGeneration = async (entry: Generation, sig: AbortSignal) => {
       if (sig.aborted) return;
 
       // Mark as generating
-      setGenerations(set, get, (prev) =>
+      setGenerations(set, genMode, (prev) =>
         prev.map((g) => g.id === entry.id ? { ...g, status: "generating" as const } : g),
       );
 
@@ -345,6 +361,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
+            if (sig.aborted) { reader.cancel(); break; }
             buffer += decoder.decode(value, { stream: true });
 
             // Process complete lines
@@ -424,24 +441,26 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
           }
         }
 
-        setGenerations(set, get, (prev) =>
+        setGenerations(set, genMode, (prev) =>
           prev.map((g) => g.id === entry.id ? { ...g, status: "complete" as const, result } : g),
         );
 
         // Persist image/video results to R2 in the background (non-blocking)
         // Results can be base64 data URLs or remote URLs (for large videos)
-        if (result && state.mode !== "copy" && (result.startsWith("data:") || result.startsWith("http"))) {
-          persistToR2(result, state.mode, finalPrompt, batchId).then((assetId) => {
+        if (result && genMode !== "copy" && (result.startsWith("data:") || result.startsWith("http"))) {
+          persistToR2(result, genMode, finalPrompt, batchId).then((assetId) => {
             if (assetId) {
-              setGenerations(set, get, (prev) =>
+              setGenerations(set, genMode, (prev) =>
                 prev.map((g) => g.id === entry.id ? { ...g, assetId } : g),
               );
             }
+          }).catch(() => {
+            // Non-fatal — asset just won't be persisted
           });
         }
       } catch (err) {
         if (sig.aborted) return;
-        setGenerations(set, get, (prev) =>
+        setGenerations(set, genMode, (prev) =>
           prev.map((g) =>
             g.id === entry.id
               ? { ...g, status: "failed" as const, error: err instanceof Error ? err.message : "Generation failed" }
@@ -462,13 +481,17 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
       abortController.abort();
       abortController = null;
     }
-    setGenerations(set, get, (prev) =>
-      prev.map((g) =>
-        g.status === "pending" || g.status === "generating"
-          ? { ...g, status: "failed" as const, error: "Cancelled" }
-          : g,
-      ),
-    );
+    // Cancel pending/generating entries across all modes
+    const modes: SimpleStudioMode[] = ["photo", "video", "copy"];
+    for (const m of modes) {
+      setGenerations(set, m, (prev) =>
+        prev.map((g) =>
+          g.status === "pending" || g.status === "generating"
+            ? { ...g, status: "failed" as const, error: "Cancelled" }
+            : g,
+        ),
+      );
+    }
     set({ isGenerating: false, currentBatchId: null });
   },
 
@@ -502,6 +525,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
   // Gallery
   loadRecentResults: async () => {
     try {
+      const currentMode = get().mode;
       const res = await fetch("/api/studio/assets?source=simple");
       const data = await res.json();
       if (data.success && data.assets) {
@@ -520,7 +544,7 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
             };
           },
         );
-        setGenerations(set, get, () => entries);
+        setGenerations(set, currentMode, () => entries);
       }
     } catch {
       // Non-fatal — gallery just stays empty

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -346,8 +346,14 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
           });
 
           if (!res.ok) {
-            const errText = await res.text();
-            throw new Error(errText || "Copy generation failed");
+            let errMsg = "Copy generation failed";
+            try {
+              const errData = await res.json();
+              errMsg = errData.error || errMsg;
+            } catch {
+              errMsg = (await res.text()) || errMsg;
+            }
+            throw new Error(errMsg);
           }
 
           // Read AI SDK v6 UI message stream to completion


### PR DESCRIPTION
## Summary

- **Store race conditions fixed**: `setGenerations` now takes explicit mode param instead of reading live store mode, preventing stale-mode writes when user switches tabs during generation. `isGenerating` locked before rewrite await to prevent double-invocation.
- **Generation data loss fixed**: New batches prepend to existing results instead of replacing them, so previous generations are preserved across multiple Generate clicks.
- **Stream cancellation**: Copy mode stream read loop now checks `sig.aborted` and cancels the reader immediately instead of consuming the entire response.
- **Sidebar reliability**: Model fetch uses `AbortController` for proper cleanup, shows error state on failure instead of infinite "Loading models...", resets dropdown state on mode switch, and only attaches click-outside listener when dropdown is open.
- **Per-batch grid layout**: `ResultsGallery` now computes grid columns per-batch based on each batch's aspect ratio, not the first generation's ratio globally. Also replaced O(n²) grouping with single-pass Map.
- **API error sanitization**: Copy API returns JSON error responses with sanitized messages that don't leak env var names or internal details.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test:run` — 2477/2478 pass (1 pre-existing failure in unrelated `social/automation/rules`)
- [ ] Generate a photo batch, switch to Video tab, verify photo results are still there when switching back
- [ ] Generate two photo batches in a row, verify both appear in gallery
- [ ] Start a copy generation, cancel immediately, verify stream stops
- [ ] Disconnect network, switch modes, verify "Failed to load models" appears
- [ ] Generate batches with different aspect ratios (1:1 then 9:16), verify each batch uses correct grid columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)