### PR TITLE
fix: Simple Studio UX improvements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -294,6 +294,24 @@ body {
   animation: fanExit 0.15s ease-in forwards;
 }
 
+/* Simple Studio — card entrance */
+@keyframes cardEnter {
+  from { opacity: 0; transform: translateY(8px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.animate-card-enter {
+  animation: cardEnter 0.25s ease-out both;
+}
+
+/* Simple Studio — lightbox fade */
+@keyframes lightboxFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-lightbox-enter {
+  animation: lightboxFadeIn 0.2s ease-out;
+}
+
 @theme inline {
   --font-heading: var(--font-sans);
   --font-sans: var(--font-sans);

--- a/src/components/simple-studio/GenerationCard.tsx
+++ b/src/components/simple-studio/GenerationCard.tsx
@@ -74,7 +74,7 @@ function Lightbox({
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm animate-lightbox-enter"
       onClick={onClose}
     >
       {/* Content container */}
@@ -179,11 +179,12 @@ export function GenerationCard({ generation, batchItems, batchIndex, onRetry }: 
   const closePreview = useCallback(() => setPreviewOpen(false), []);
 
   const aspect = aspectClass(aspectRatio);
+  const staggerDelay = batchIndex !== undefined ? { animationDelay: `${batchIndex * 50}ms` } : undefined;
 
   // Loading state
   if (status === "pending" || status === "generating") {
     return (
-      <div className={`${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg flex items-center justify-center`}>
+      <div className={`${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg flex items-center justify-center animate-card-enter`} style={staggerDelay}>
         <div className="flex flex-col items-center gap-2">
           <div className="w-6 h-6 border-2 border-neutral-600 border-t-neutral-300 rounded-full animate-spin" />
           <span className="text-[11px] text-neutral-500">
@@ -197,7 +198,7 @@ export function GenerationCard({ generation, batchItems, batchIndex, onRetry }: 
   // Error state
   if (status === "failed") {
     return (
-      <div className={`${aspect} bg-neutral-800/50 border border-red-900/30 rounded-lg flex items-center justify-center p-3`}>
+      <div className={`${aspect} bg-neutral-800/50 border border-red-900/30 rounded-lg flex items-center justify-center p-3 animate-card-enter`} style={staggerDelay}>
         <div className="flex flex-col items-center gap-2 text-center">
           <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
@@ -219,7 +220,7 @@ export function GenerationCard({ generation, batchItems, batchIndex, onRetry }: 
   // Copy mode — text card
   if (mode === "copy" && result) {
     return (
-      <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-lg p-4 min-h-[120px]">
+      <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-lg p-4 min-h-[120px] animate-card-enter" style={staggerDelay}>
         <p className="text-sm text-neutral-200 leading-relaxed whitespace-pre-wrap" dir="auto">
           {result}
         </p>
@@ -244,7 +245,8 @@ export function GenerationCard({ generation, batchItems, batchIndex, onRetry }: 
     return (
       <>
         <div
-          className={`relative ${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group cursor-pointer`}
+          className={`relative ${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group cursor-pointer animate-card-enter`}
+          style={staggerDelay}
           onClick={openPreview}
         >
           <video
@@ -276,7 +278,8 @@ export function GenerationCard({ generation, batchItems, batchIndex, onRetry }: 
     return (
       <>
         <div
-          className={`relative ${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group cursor-pointer`}
+          className={`relative ${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg overflow-hidden group cursor-pointer animate-card-enter`}
+          style={staggerDelay}
           onClick={openPreview}
         >
           <img

--- a/src/components/simple-studio/GenerationCard.tsx
+++ b/src/components/simple-studio/GenerationCard.tsx
@@ -23,33 +23,61 @@ function aspectClass(ratio: string): string {
 // ---------------------------------------------------------------------------
 
 function Lightbox({
-  generation,
+  batchItems,
+  initialIndex,
   onClose,
 }: {
-  generation: Generation;
+  batchItems: Generation[];
+  initialIndex: number;
   onClose: () => void;
 }) {
-  const { result, mode, aspectRatio } = generation;
+  const [index, setIndex] = useState(initialIndex);
 
-  // Close on Escape
+  // Filter to only completed items with results for navigation
+  const navigable = batchItems.filter((g) => g.status === "complete" && g.result);
+  const navIndex = navigable.findIndex((g) => g.id === batchItems[index]?.id);
+  const current = navIndex >= 0 ? navigable[navIndex] : null;
+
+  const hasPrev = navIndex > 0;
+  const hasNext = navIndex < navigable.length - 1;
+
+  const goPrev = useCallback(() => {
+    if (hasPrev) {
+      const prev = navigable[navIndex - 1];
+      const realIndex = batchItems.findIndex((g) => g.id === prev.id);
+      if (realIndex >= 0) setIndex(realIndex);
+    }
+  }, [hasPrev, navIndex, navigable, batchItems]);
+
+  const goNext = useCallback(() => {
+    if (hasNext) {
+      const next = navigable[navIndex + 1];
+      const realIndex = batchItems.findIndex((g) => g.id === next.id);
+      if (realIndex >= 0) setIndex(realIndex);
+    }
+  }, [hasNext, navIndex, navigable, batchItems]);
+
+  // Keyboard: Escape, ArrowLeft, ArrowRight
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
+      else if (e.key === "ArrowLeft") goPrev();
+      else if (e.key === "ArrowRight") goNext();
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  }, [onClose, goPrev, goNext]);
 
-  if (!result) return null;
+  if (!current?.result) return null;
 
-  const isVideo = mode === "video";
+  const isVideo = current.mode === "video";
 
   return (
     <div
       className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
     >
-      {/* Content container — stop propagation so clicking media doesn't close */}
+      {/* Content container */}
       <div
         className="relative max-w-[90vw] max-h-[90vh] flex flex-col items-center"
         onClick={(e) => e.stopPropagation()}
@@ -65,33 +93,68 @@ function Lightbox({
           </svg>
         </button>
 
+        {/* Prev arrow */}
+        {hasPrev && (
+          <button
+            onClick={goPrev}
+            className="absolute start-0 top-1/2 -translate-y-1/2 -ms-12 p-2 text-neutral-400 hover:text-white transition-colors"
+            title="Previous"
+          >
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+            </svg>
+          </button>
+        )}
+
+        {/* Next arrow */}
+        {hasNext && (
+          <button
+            onClick={goNext}
+            className="absolute end-0 top-1/2 -translate-y-1/2 -me-12 p-2 text-neutral-400 hover:text-white transition-colors"
+            title="Next"
+          >
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+            </svg>
+          </button>
+        )}
+
         {isVideo ? (
           <video
-            src={result}
+            key={current.id}
+            src={current.result!}
             className="max-w-[90vw] max-h-[85vh] rounded-lg"
-            style={{ aspectRatio: aspectRatio.replace(":", "/") }}
+            style={{ aspectRatio: current.aspectRatio.replace(":", "/") }}
             controls
             autoPlay
           />
         ) : (
           <img
-            src={result}
+            key={current.id}
+            src={current.result!}
             alt=""
             className="max-w-[90vw] max-h-[85vh] rounded-lg object-contain"
           />
         )}
 
-        {/* Download button */}
-        <a
-          href={result}
-          download={`generation.${isVideo ? "mp4" : "png"}`}
-          className="mt-3 px-4 py-1.5 text-xs font-medium bg-neutral-800 text-neutral-200 rounded-md hover:bg-neutral-700 transition-colors flex items-center gap-1.5"
-        >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
-          </svg>
-          Download
-        </a>
+        {/* Bottom bar: counter + download */}
+        <div className="mt-3 flex items-center gap-4">
+          {navigable.length > 1 && (
+            <span className="text-[11px] text-neutral-500">
+              {navIndex + 1} / {navigable.length}
+            </span>
+          )}
+          <a
+            href={current.result!}
+            download={`generation.${isVideo ? "mp4" : "png"}`}
+            className="px-4 py-1.5 text-xs font-medium bg-neutral-800 text-neutral-200 rounded-md hover:bg-neutral-700 transition-colors flex items-center gap-1.5"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+            </svg>
+            Download
+          </a>
+        </div>
       </div>
     </div>
   );
@@ -103,10 +166,12 @@ function Lightbox({
 
 interface GenerationCardProps {
   generation: Generation;
+  batchItems?: Generation[];
+  batchIndex?: number;
   onRetry?: () => void;
 }
 
-export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
+export function GenerationCard({ generation, batchItems, batchIndex, onRetry }: GenerationCardProps) {
   const { status, result, error, mode, aspectRatio } = generation;
   const [previewOpen, setPreviewOpen] = useState(false);
 
@@ -121,7 +186,7 @@ export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
       <div className={`${aspect} bg-neutral-800/50 border border-neutral-700/50 rounded-lg flex items-center justify-center`}>
         <div className="flex flex-col items-center gap-2">
           <div className="w-6 h-6 border-2 border-neutral-600 border-t-neutral-300 rounded-full animate-spin" />
-          <span className="text-[10px] text-neutral-500">
+          <span className="text-[11px] text-neutral-500">
             {status === "pending" ? "Queued" : "Generating..."}
           </span>
         </div>
@@ -137,11 +202,11 @@ export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
           <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
           </svg>
-          <span className="text-[10px] text-red-400 line-clamp-2">{error || "Failed"}</span>
+          <span className="text-[11px] text-red-400 line-clamp-2">{error || "Failed"}</span>
           {onRetry && (
             <button
               onClick={onRetry}
-              className="text-[10px] text-blue-400 hover:text-blue-300 underline"
+              className="text-[11px] text-blue-400 hover:text-blue-300 underline"
             >
               Retry
             </button>
@@ -161,7 +226,7 @@ export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
         <div className="mt-3 flex justify-end">
           <button
             onClick={() => navigator.clipboard.writeText(result)}
-            className="text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
+            className="text-[11px] text-neutral-400 hover:text-neutral-200 transition-colors"
           >
             Copy
           </button>
@@ -169,6 +234,10 @@ export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
       </div>
     );
   }
+
+  const lightboxProps = batchItems && batchIndex !== undefined
+    ? { batchItems, initialIndex: batchIndex }
+    : { batchItems: [generation], initialIndex: 0 };
 
   // Video result
   if (mode === "video" && result) {
@@ -197,7 +266,7 @@ export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
           </div>
           <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
         </div>
-        {previewOpen && <Lightbox generation={generation} onClose={closePreview} />}
+        {previewOpen && <Lightbox {...lightboxProps} onClose={closePreview} />}
       </>
     );
   }
@@ -218,7 +287,7 @@ export function GenerationCard({ generation, onRetry }: GenerationCardProps) {
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
         </div>
-        {previewOpen && <Lightbox generation={generation} onClose={closePreview} />}
+        {previewOpen && <Lightbox {...lightboxProps} onClose={closePreview} />}
       </>
     );
   }

--- a/src/components/simple-studio/PromptLibrary.tsx
+++ b/src/components/simple-studio/PromptLibrary.tsx
@@ -63,7 +63,7 @@ export function PromptLibrary() {
         {prompt.trim() && (
           <button
             onClick={() => setSaveDialogOpen(true)}
-            className="text-[10px] text-blue-400 hover:text-blue-300 transition-colors"
+            className="text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
           >
             Save Prompt
           </button>
@@ -144,7 +144,7 @@ function PromptItem({
       <div className="text-xs font-medium text-neutral-300 group-hover:text-neutral-100 truncate" dir="auto">
         {prompt.name}
       </div>
-      <div className="text-[10px] text-neutral-500 mt-0.5 line-clamp-2" dir="auto">
+      <div className="text-[11px] text-neutral-500 mt-0.5 line-clamp-2" dir="auto">
         {prompt.promptText}
       </div>
     </button>

--- a/src/components/simple-studio/PromptLibrary.tsx
+++ b/src/components/simple-studio/PromptLibrary.tsx
@@ -35,9 +35,9 @@ export function PromptLibrary() {
   };
 
   return (
-    <div className="border-t border-neutral-800">
+    <div className="bg-neutral-800/30 border border-neutral-700/50 rounded-lg mt-2 overflow-hidden">
       {/* Tabs + save button */}
-      <div className="flex items-center justify-between px-4 pt-3">
+      <div className="flex items-center justify-between px-3 pt-2.5">
         <div className="flex gap-3">
           <button
             onClick={() => setActiveTab("templates")}
@@ -72,7 +72,7 @@ export function PromptLibrary() {
 
       {/* Save dialog */}
       {saveDialogOpen && (
-        <div className="px-4 py-2">
+        <div className="px-3 py-2">
           <div className="flex gap-2">
             <input
               value={saveName}
@@ -100,7 +100,7 @@ export function PromptLibrary() {
       )}
 
       {/* Prompt list */}
-      <div className="px-4 py-2 space-y-1.5 max-h-[200px] overflow-y-auto">
+      <div className="px-3 py-2 space-y-1.5 max-h-[200px] overflow-y-auto">
         {activeTab === "templates" && (
           <>
             {filteredTemplates.length === 0 ? (

--- a/src/components/simple-studio/ResultsGallery.tsx
+++ b/src/components/simple-studio/ResultsGallery.tsx
@@ -3,9 +3,19 @@
 import { useSimpleStudioStore } from "@/store/simpleStudioStore";
 import { GenerationCard } from "./GenerationCard";
 
+function formatRelativeTime(ts?: number): string {
+  if (!ts) return "";
+  const diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
 export function ResultsGallery() {
   const generations = useSimpleStudioStore((s) => s.generations);
   const mode = useSimpleStudioStore((s) => s.mode);
+  const retryGeneration = useSimpleStudioStore((s) => s.retryGeneration);
 
   if (generations.length === 0) {
     return (
@@ -65,11 +75,34 @@ export function ResultsGallery() {
           gridCols = "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4";
         }
 
+        const firstItem = batch.items[0];
+        const promptExcerpt = firstItem?.prompt || "";
+        const truncated = promptExcerpt.length > 80
+          ? promptExcerpt.slice(0, 80) + "..."
+          : promptExcerpt;
+
         return (
           <div key={batch.batchId}>
+            {/* Batch header */}
+            {truncated && (
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-xs text-neutral-400 truncate max-w-[70%]" dir="auto">
+                  {truncated}
+                </p>
+                <div className="flex items-center gap-2 text-[11px] text-neutral-500 shrink-0">
+                  {firstItem?.modelName && <span>{firstItem.modelName}</span>}
+                  <span>{formatRelativeTime(firstItem?.createdAt)}</span>
+                  <span>{batch.items.length} items</span>
+                </div>
+              </div>
+            )}
             <div className={`grid ${gridCols} gap-3`}>
               {batch.items.map((gen) => (
-                <GenerationCard key={gen.id} generation={gen} />
+                <GenerationCard
+                  key={gen.id}
+                  generation={gen}
+                  onRetry={() => retryGeneration(gen.id)}
+                />
               ))}
             </div>
           </div>

--- a/src/components/simple-studio/ResultsGallery.tsx
+++ b/src/components/simple-studio/ResultsGallery.tsx
@@ -120,10 +120,12 @@ export function ResultsGallery() {
               </div>
             )}
             <div className={`grid ${gridCols} gap-3`}>
-              {batch.items.map((gen) => (
+              {batch.items.map((gen, idx) => (
                 <GenerationCard
                   key={gen.id}
                   generation={gen}
+                  batchItems={batch.items}
+                  batchIndex={idx}
                   onRetry={() => retryGeneration(gen.id)}
                 />
               ))}

--- a/src/components/simple-studio/ResultsGallery.tsx
+++ b/src/components/simple-studio/ResultsGallery.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { PROMPT_TEMPLATES } from "@/lib/simple-studio/promptTemplates";
 import { GenerationCard } from "./GenerationCard";
 
 function formatRelativeTime(ts?: number): string {
@@ -17,10 +18,14 @@ export function ResultsGallery() {
   const mode = useSimpleStudioStore((s) => s.mode);
   const retryGeneration = useSimpleStudioStore((s) => s.retryGeneration);
 
+  const applyPrompt = useSimpleStudioStore((s) => s.applyPrompt);
+
   if (generations.length === 0) {
+    const templates = PROMPT_TEMPLATES.filter((t) => t.mode === mode).slice(0, 6);
+
     return (
       <div className="h-full flex items-center justify-center text-neutral-500">
-        <div className="text-center">
+        <div className="text-center max-w-lg px-4">
           <svg
             className="w-12 h-12 mx-auto mb-3 text-neutral-700"
             fill="none"
@@ -35,9 +40,27 @@ export function ResultsGallery() {
             />
           </svg>
           <p className="text-sm">Your generated content will appear here</p>
-          <p className="text-xs mt-1 text-neutral-600">
-            Fill in the form and click Generate
+          <p className="text-xs mt-1 text-neutral-600 mb-5">
+            Fill in the form and click Generate, or try a template:
           </p>
+          {templates.length > 0 && (
+            <div className="grid grid-cols-2 gap-2">
+              {templates.map((tpl) => (
+                <button
+                  key={tpl.id}
+                  onClick={() => applyPrompt(tpl)}
+                  className="text-start p-3 rounded-lg border border-neutral-800 bg-neutral-900/50 hover:border-neutral-700 hover:bg-neutral-800/50 transition-colors group"
+                >
+                  <div className="text-xs font-medium text-neutral-300 group-hover:text-neutral-100 truncate" dir="auto">
+                    {tpl.name}
+                  </div>
+                  <div className="text-[11px] text-neutral-500 mt-1 line-clamp-2" dir="auto">
+                    {tpl.promptText}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -79,6 +79,22 @@ export function Sidebar() {
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
   const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const isMac = typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent);
+
+  // Cmd/Ctrl+Enter to generate
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        const s = useSimpleStudioStore.getState();
+        if (s.prompt.trim() && !s.isGenerating && !s.isRewriting) {
+          s.generate();
+        }
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   // Fetch models on mount and mode change
   useEffect(() => {
@@ -691,6 +707,9 @@ export function Sidebar() {
               : `Generate ${store.batchCount} ${store.mode === "copy" ? "variation" : store.mode}${store.batchCount > 1 ? "s" : ""}`}
           </button>
         )}
+        <p className="text-[11px] text-neutral-600 text-center mt-1.5">
+          {isMac ? "\u2318" : "Ctrl"}+Enter to generate
+        </p>
       </div>
     </div>
   );

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -77,6 +77,7 @@ export function Sidebar() {
   const [modelsFetchError, setModelsFetchError] = useState(false);
   const [modelSearch, setModelSearch] = useState("");
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
+  const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Fetch models on mount and mode change
@@ -184,9 +185,17 @@ export function Sidebar() {
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {/* Prompt */}
         <fieldset>
-          <label className="block text-xs font-medium text-neutral-400 mb-1.5">
-            Prompt
-          </label>
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="text-xs font-medium text-neutral-400">
+              Prompt
+            </label>
+            <button
+              onClick={() => setPromptLibraryOpen(!promptLibraryOpen)}
+              className="text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
+            >
+              {promptLibraryOpen ? "Hide Library" : "Prompt Library"}
+            </button>
+          </div>
           <textarea
             value={store.prompt}
             onChange={(e) => store.setPrompt(e.target.value)}
@@ -199,6 +208,7 @@ export function Sidebar() {
             className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 resize-none focus:outline-none focus:border-neutral-600"
             dir="auto"
           />
+          {promptLibraryOpen && <PromptLibrary />}
         </fieldset>
 
         {/* LLM Rewrite toggle (photo/video only) */}
@@ -660,9 +670,6 @@ export function Sidebar() {
           </div>
         </fieldset>
       </div>
-
-      {/* Prompt library */}
-      <PromptLibrary />
 
       {/* Generate button — pinned at bottom */}
       <div className="p-4 border-t border-neutral-800 shrink-0">

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -295,7 +295,7 @@ export function Sidebar() {
         {/* Rewritten prompt preview */}
         {store.rewriteEnabled && store.rewrittenPrompt && (
           <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-md p-3">
-            <div className="text-[10px] uppercase tracking-wide text-blue-400 mb-1">
+            <div className="text-[11px] uppercase tracking-wide text-blue-400 mb-1">
               Enhanced prompt
             </div>
             <p className="text-xs text-neutral-300 leading-relaxed" dir="auto">
@@ -442,7 +442,7 @@ export function Sidebar() {
                     {/* Recommended section */}
                     {recommendedModels.length > 0 && (
                       <>
-                        <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-blue-400 bg-neutral-800 sticky top-0">
+                        <div className="px-3 py-1.5 text-[11px] uppercase tracking-wide text-blue-400 bg-neutral-800 sticky top-0">
                           Recommended
                         </div>
                         {recommendedModels.map((m, i) => (
@@ -464,7 +464,7 @@ export function Sidebar() {
                     {/* All models section */}
                     {otherModels.length > 0 && (
                       <>
-                        <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-800 sticky top-0">
+                        <div className="px-3 py-1.5 text-[11px] uppercase tracking-wide text-neutral-500 bg-neutral-800 sticky top-0">
                           All Models
                         </div>
                         {otherModels.map((m, i) => (
@@ -546,7 +546,7 @@ export function Sidebar() {
                 </button>
               ))}
             </div>
-            <p className="text-[10px] text-neutral-600 mt-1">Duration depends on model (Veo: 4-8s, Kling: 5-10s)</p>
+            <p className="text-[11px] text-neutral-600 mt-1">Duration depends on model (Veo: 4-8s, Kling: 5-10s)</p>
           </fieldset>
         )}
 
@@ -615,7 +615,7 @@ export function Sidebar() {
                     className="w-full bg-neutral-800 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 resize-none focus:outline-none focus:border-neutral-600"
                     dir="auto"
                   />
-                  <p className="text-[10px] text-neutral-600 mt-1">
+                  <p className="text-[11px] text-neutral-600 mt-1">
                     Works best with Veo 3.1 and Kling 2.6. Dialogue is injected into the prompt.
                   </p>
                 </fieldset>

--- a/src/components/simple-studio/Sidebar.tsx
+++ b/src/components/simple-studio/Sidebar.tsx
@@ -66,6 +66,48 @@ const OUTPUT_LANGUAGES: { value: "ar" | "en" | "both"; label: string }[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function GeneratingProgress({
+  generations,
+  currentBatchId,
+  onCancel,
+}: {
+  generations: import("@/store/simpleStudioStore").Generation[];
+  currentBatchId: string | null;
+  onCancel: () => void;
+}) {
+  const batch = currentBatchId
+    ? generations.filter((g) => g.batchId === currentBatchId)
+    : [];
+  const total = batch.length;
+  const done = batch.filter((g) => g.status === "complete" || g.status === "failed").length;
+  const pct = total > 0 ? (done / total) * 100 : 0;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs text-neutral-400">
+        <span>Generating...</span>
+        <span>{done}/{total}</span>
+      </div>
+      <div className="w-full h-1 bg-neutral-700 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-blue-500 rounded-full transition-all duration-300"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <button
+        onClick={onCancel}
+        className="w-full py-2 text-sm font-medium rounded-md bg-red-600/20 text-red-400 border border-red-600/50 hover:bg-red-600/30 transition-colors"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -690,12 +732,11 @@ export function Sidebar() {
       {/* Generate button — pinned at bottom */}
       <div className="p-4 border-t border-neutral-800 shrink-0">
         {store.isGenerating ? (
-          <button
-            onClick={() => store.cancelGeneration()}
-            className="w-full py-2.5 text-sm font-medium rounded-md bg-red-600/20 text-red-400 border border-red-600/50 hover:bg-red-600/30 transition-colors"
-          >
-            Cancel Generation
-          </button>
+          <GeneratingProgress
+            generations={store.generations}
+            currentBatchId={store.currentBatchId}
+            onCancel={() => store.cancelGeneration()}
+          />
         ) : (
           <button
             onClick={() => store.generate()}

--- a/src/store/simpleStudioStore.ts
+++ b/src/store/simpleStudioStore.ts
@@ -27,6 +27,9 @@ export interface Generation {
   error: string | null;
   mode: SimpleStudioMode;
   aspectRatio: string;
+  prompt: string;
+  createdAt: number;
+  modelName: string | null;
 }
 
 export interface SavedPrompt {
@@ -87,6 +90,7 @@ export interface SimpleStudioState {
   generations: Generation[]; // derived — current mode's generations
   generate: () => Promise<void>;
   cancelGeneration: () => void;
+  retryGeneration: (id: string) => Promise<void>;
   rewritePrompt: () => Promise<void>;
 
   // Gallery
@@ -296,6 +300,8 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
     const signal = abortController.signal;
 
     // Create pending generation entries
+    const now = Date.now();
+    const displayModelName = state.selectedModelName || "Auto";
     const entries: Generation[] = Array.from(
       { length: state.batchCount },
       (_, i) => ({
@@ -307,6 +313,9 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
         error: null,
         mode: genMode,
         aspectRatio: state.aspectRatio,
+        prompt: finalPrompt,
+        createdAt: now,
+        modelName: displayModelName,
       }),
     );
 
@@ -501,6 +510,133 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
     set({ isGenerating: false, currentBatchId: null });
   },
 
+  retryGeneration: async (id: string) => {
+    const state = get();
+    const gen = state.generations.find((g) => g.id === id);
+    if (!gen || gen.status !== "failed") return;
+
+    const genMode = gen.mode;
+
+    // Mark as generating
+    setGenerations(set, genMode, (prev) =>
+      prev.map((g) => g.id === id ? { ...g, status: "generating" as const, error: null } : g),
+    );
+
+    const retryController = new AbortController();
+    const sig = retryController.signal;
+
+    try {
+      let result: string | null = null;
+
+      if (genMode === "copy") {
+        const langDirective = state.outputLanguage === "ar"
+          ? "Write in Arabic only."
+          : state.outputLanguage === "both"
+            ? "Write in both Arabic and English."
+            : "Write in English only.";
+        const systemPrompt = `You are a professional copywriter. ${langDirective} Platform: ${state.platform}. Tone: ${state.tone}. Return ONLY the copy text, no explanations or meta-commentary.`;
+
+        const res = await fetch("/api/studio/copy", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            messages: [{ id, role: "user", parts: [{ type: "text", text: gen.prompt }] }],
+            model: state.copyModelId,
+            system: systemPrompt,
+          }),
+          signal: sig,
+        });
+
+        if (!res.ok) {
+          let errMsg = "Copy generation failed";
+          try { const errData = await res.json(); errMsg = errData.error || errMsg; } catch { errMsg = (await res.text()) || errMsg; }
+          throw new Error(errMsg);
+        }
+
+        const reader = res.body?.getReader();
+        if (!reader) throw new Error("No response body");
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let fullText = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (sig.aborted) { reader.cancel(); break; }
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith("data: ")) continue;
+            const payload = trimmed.slice(6);
+            if (payload === "[DONE]") continue;
+            try { const parsed = JSON.parse(payload); if (parsed.type === "text-delta" && parsed.delta) fullText += parsed.delta; } catch { /* skip */ }
+          }
+        }
+        result = fullText;
+      } else {
+        const images = genMode === "photo"
+          ? state.referenceImages
+          : state.sourceImage ? [state.sourceImage] : [];
+        const hasSourceImage = genMode === "video" && images.length > 0;
+
+        let modelId = state.selectedModelId;
+        let modelProvider = state.selectedModelProvider;
+        let modelName = state.selectedModelName;
+
+        if (hasSourceImage && modelId?.includes("/text-to-video")) {
+          modelId = modelId.replace("/text-to-video", "/image-to-video");
+        }
+        if (genMode === "video" && !modelId) {
+          modelId = hasSourceImage ? "veo-3.1/image-to-video" : "veo-3.1/text-to-video";
+          modelProvider = null;
+          modelName = "Veo 3.1";
+        }
+
+        const body: Record<string, unknown> = {
+          prompt: gen.prompt,
+          images,
+          selectedModel: modelId ? { modelId, provider: modelProvider || undefined, displayName: modelName || modelId } : undefined,
+          mediaType: genMode === "video" ? "video" : undefined,
+          parameters: { aspectRatio: gen.aspectRatio, ...(genMode === "video" ? { duration: state.videoDuration } : {}) },
+        };
+
+        const res = await fetch("/api/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+          signal: sig,
+        });
+        const data = await res.json();
+        if (!data.success) throw new Error(data.error || "Generation failed");
+        result = genMode === "video" ? (data.video || data.videoUrl || null) : (data.image || data.audio || null);
+      }
+
+      setGenerations(set, genMode, (prev) =>
+        prev.map((g) => g.id === id ? { ...g, status: "complete" as const, result } : g),
+      );
+
+      if (result && genMode !== "copy" && (result.startsWith("data:") || result.startsWith("http"))) {
+        persistToR2(result, genMode, gen.prompt, gen.batchId).then((assetId) => {
+          if (assetId) {
+            setGenerations(set, genMode, (prev) =>
+              prev.map((g) => g.id === id ? { ...g, assetId } : g),
+            );
+          }
+        }).catch(() => {});
+      }
+    } catch (err) {
+      if (sig.aborted) return;
+      setGenerations(set, genMode, (prev) =>
+        prev.map((g) =>
+          g.id === id
+            ? { ...g, status: "failed" as const, error: err instanceof Error ? err.message : "Generation failed" }
+            : g,
+        ),
+      );
+    }
+  },
+
   rewritePrompt: async () => {
     const { prompt } = get();
     if (!prompt.trim()) return;
@@ -547,6 +683,9 @@ export const useSimpleStudioStore = create<SimpleStudioState>((set, get) => ({
               error: null,
               mode: (metadata.mode as SimpleStudioMode) || "photo",
               aspectRatio: (metadata.aspectRatio as string) || "1:1",
+              prompt: (metadata.prompt as string) || "",
+              createdAt: (metadata.createdAt as number) || Date.now(),
+              modelName: (metadata.modelName as string) || null,
             };
           },
         );


### PR DESCRIPTION
## Summary

- **Prompt Library relocated** next to the prompt textarea as a collapsible section (was misplaced at bottom of sidebar, stealing fixed vertical space)
- **Retry wired** for failed generations — `onRetry` was dead code, now functional via new `retryGeneration()` store method
- **Cmd/Ctrl+Enter** keyboard shortcut to trigger generation from anywhere on the page
- **Batch progress counter** with progress bar and X/Y count during generation (replaces plain cancel button)
- **Batch headers** showing truncated prompt excerpt, model name, relative timestamp, and item count
- **Empty state improved** with clickable template suggestions filtered by current mode
- **Lightbox prev/next** navigation with arrow keys/buttons and counter within batch
- **Text size bump** from 10px to 11px across all simple-studio components for readability
- **Entrance animations** — staggered card fade-in and lightbox backdrop fade

## Test plan

- [ ] Open `/studio/simple`, verify Prompt Library toggle appears next to "Prompt" label
- [ ] Toggle Prompt Library open/closed, apply a template, verify form fills
- [ ] Press Cmd+Enter (Mac) or Ctrl+Enter (Windows) to trigger generation
- [ ] During generation, verify progress bar shows X/Y count with Cancel button
- [ ] After generation, verify batch headers show prompt, model, timestamp
- [ ] Click a failed generation's Retry button, verify it re-generates
- [ ] Click an image to open lightbox, use arrow keys to navigate within batch
- [ ] Verify empty state shows template suggestion cards
- [ ] Verify all hint text is >= 11px (no 10px text except reference image close button)
- [ ] Verify cards animate in with staggered delay, lightbox fades in

🤖 Generated with [Claude Code](https://claude.com/claude-code)