### PR TITLE
feat: add Simple Studio dashboard shell with inline forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ logs/*.json
 .agents/
 
 .superset/.superpowers/
+
+# git worktrees
+.worktrees/

--- a/docs/superpowers/plans/2026-04-06-simple-studio-dashboard-shell.md
+++ b/docs/superpowers/plans/2026-04-06-simple-studio-dashboard-shell.md
@@ -1,0 +1,2671 @@
+# Simple Studio Dashboard Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a new top-level `/simple-studio` pillar with a social-style sidebar shell (`SidebarProvider` + `SidebarInset`), five routes (Images / Videos / Copy / Library / Prompt Library), inline form-first pages with a right-side info panel, a dedicated Library gallery, and a Prompt Library tabbed view — all reusing the existing `useSimpleStudioStore` and `/api/studio/prompts` backend without modification. The old `/studio/simple` route stays untouched during PR 1 and is deleted in a separate PR 2.
+
+**Architecture:** A new route tree under `src/app/simple-studio/` wraps its children in `SimpleStudioLayout` (which mirrors `SocialLayout`). Each form route renders its per-mode form component inline inside a shared `FormPageLayout` (form body left, `FormInfoPanel` right). `LibraryGallery` replaces the old ResultsGallery on the `/library` route. `PromptLibraryTabs` shows templates (public prompts) and saved prompts via the existing store actions. A tiny `useSimpleStudioShellStore` holds UI-only state (SavePromptDialog open/close, library filter, active tab). A `urlToMode.ts` module maps friendly URL segments (`images` / `videos` / `copy`) to the existing mode enum (`photo` / `video` / `copy`). AppSwitcher's pillar list is updated to split "AI Studio" into "Simple Studio" and "Advanced Workflow".
+
+**Tech Stack:** Next.js 16 (App Router), TypeScript, Zustand, shadcn/ui (Sidebar / Sheet / Dialog / Tabs / Separator / Button), Tailwind CSS, Vitest + Testing Library, pnpm 10.
+
+**Spec:** `docs/superpowers/specs/2026-04-06-simple-studio-dashboard-shell-design.md`
+
+---
+
+## Prerequisites
+
+Before starting Task 1, the executing engineer should:
+
+1. Have the spec file open as a reference.
+2. Run `pnpm install` to ensure dependencies are in sync.
+3. Confirm the current branch is `develop` and create a feature branch:
+   ```bash
+   git checkout develop
+   git pull
+   git checkout -b feature/simple-studio-dashboard-shell
+   ```
+4. Verify baseline tests pass: `pnpm test:run` (record any pre-existing failures unrelated to this work so they aren't attributed to the plan).
+5. Read `src/store/simpleStudioStore.ts` lines 19-106 to understand the shape of `SimpleStudioMode`, `Generation`, `SavedPrompt`, and the store interface. Every form component interacts with this store — the engineer must know the field names.
+6. Read `src/components/social/SocialLayout.tsx`, `SocialAppSidebar.tsx`, and `SocialSiteHeader.tsx` in full. The new shell mirrors this structure exactly; these are the canonical examples.
+
+---
+
+## File Structure
+
+**Created files:**
+
+```
+src/app/simple-studio/
+  layout.tsx                            server: auth gate + <SimpleStudioLayout>
+  page.tsx                              redirect → /simple-studio/images
+  images/page.tsx                       renders <ImageForm />
+  videos/page.tsx                       renders <VideoForm />
+  copy/page.tsx                         renders <CopyForm />
+  library/page.tsx                      renders <LibraryGallery />
+  prompt-library/page.tsx               renders <PromptLibraryTabs />
+
+src/components/simple-studio-shell/
+  SimpleStudioLayout.tsx                client: SidebarProvider + Inset + mode sync
+  SimpleStudioAppSidebar.tsx            client: nav sidebar with AppSwitcher + NavUser
+  SimpleStudioSiteHeader.tsx            client: page title + contextual action
+  LibraryGallery.tsx                    client: generations grid w/ mode filter
+  PromptLibraryTabs.tsx                 client: templates + saved tabs
+  SavePromptDialog.tsx                  client: dialog shared by form pages + prompt library
+  urlToMode.ts                          URL segment ↔ SimpleStudioMode mapping
+  forms/
+    FormPageLayout.tsx                  shared 2-column layout
+    FormInfoPanel.tsx                   aspect ratio, cost, example, tips
+    ImageForm.tsx                       photo-mode form
+    VideoForm.tsx                       video-mode form
+    CopyForm.tsx                        copy-mode form
+  __tests__/
+    urlToMode.test.ts
+    SimpleStudioAppSidebar.test.tsx
+    SimpleStudioSiteHeader.test.tsx
+    LibraryGallery.test.tsx
+    PromptLibraryTabs.test.tsx
+    SavePromptDialog.test.tsx
+  forms/__tests__/
+    FormPageLayout.test.tsx
+    ImageForm.test.tsx
+    VideoForm.test.tsx
+    CopyForm.test.tsx
+
+src/store/
+  simpleStudioShellStore.ts             Zustand UI-only store
+
+src/store/__tests__/
+  simpleStudioShellStore.test.ts
+```
+
+**Modified files:**
+
+- `src/components/AppSwitcher.tsx` — update `PILLAR_ITEMS` to split Simple Studio / Advanced Workflow.
+
+**Explicitly untouched:**
+
+- `src/app/studio/simple/*` (old page).
+- `src/components/simple-studio/*` (old sidebar + gallery).
+- `src/store/simpleStudioStore.ts` (old store — read-only dependency).
+- `src/lib/db/schema.ts` (reuses existing `savedPrompts` table).
+- `src/app/api/studio/prompts/**` (reuses existing routes).
+
+---
+
+## Task 1: URL-to-mode mapping module
+
+**Files:**
+- Create: `src/components/simple-studio-shell/urlToMode.ts`
+- Test: `src/components/simple-studio-shell/__tests__/urlToMode.test.ts`
+
+This is a pure function module with no dependencies — perfect first task to validate the directory structure works.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/__tests__/urlToMode.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  URL_SEGMENT_TO_MODE,
+  MODE_TO_URL_SEGMENT,
+  modeFromPathname,
+} from "../urlToMode";
+
+describe("urlToMode", () => {
+  describe("URL_SEGMENT_TO_MODE", () => {
+    it("maps images → photo", () => {
+      expect(URL_SEGMENT_TO_MODE.images).toBe("photo");
+    });
+    it("maps videos → video", () => {
+      expect(URL_SEGMENT_TO_MODE.videos).toBe("video");
+    });
+    it("maps copy → copy", () => {
+      expect(URL_SEGMENT_TO_MODE.copy).toBe("copy");
+    });
+  });
+
+  describe("MODE_TO_URL_SEGMENT", () => {
+    it("is the inverse of URL_SEGMENT_TO_MODE", () => {
+      expect(MODE_TO_URL_SEGMENT.photo).toBe("images");
+      expect(MODE_TO_URL_SEGMENT.video).toBe("videos");
+      expect(MODE_TO_URL_SEGMENT.copy).toBe("copy");
+    });
+  });
+
+  describe("modeFromPathname", () => {
+    it("returns photo for /simple-studio/images", () => {
+      expect(modeFromPathname("/simple-studio/images")).toBe("photo");
+    });
+    it("returns video for /simple-studio/videos", () => {
+      expect(modeFromPathname("/simple-studio/videos")).toBe("video");
+    });
+    it("returns copy for /simple-studio/copy", () => {
+      expect(modeFromPathname("/simple-studio/copy")).toBe("copy");
+    });
+    it("handles trailing segments", () => {
+      expect(modeFromPathname("/simple-studio/images/")).toBe("photo");
+    });
+    it("returns null for /simple-studio/library", () => {
+      expect(modeFromPathname("/simple-studio/library")).toBeNull();
+    });
+    it("returns null for /simple-studio/prompt-library", () => {
+      expect(modeFromPathname("/simple-studio/prompt-library")).toBeNull();
+    });
+    it("returns null for /simple-studio", () => {
+      expect(modeFromPathname("/simple-studio")).toBeNull();
+    });
+    it("returns null for unrelated paths", () => {
+      expect(modeFromPathname("/studio/simple")).toBeNull();
+      expect(modeFromPathname("/social/calendar")).toBeNull();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/urlToMode.test.ts`
+Expected: FAIL with "Cannot find module '../urlToMode'".
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/components/simple-studio-shell/urlToMode.ts`:
+
+```ts
+import type { SimpleStudioMode } from "@/store/simpleStudioStore";
+
+export const URL_SEGMENT_TO_MODE: Record<"images" | "videos" | "copy", SimpleStudioMode> = {
+  images: "photo",
+  videos: "video",
+  copy: "copy",
+};
+
+export const MODE_TO_URL_SEGMENT: Record<SimpleStudioMode, "images" | "videos" | "copy"> = {
+  photo: "images",
+  video: "videos",
+  copy: "copy",
+};
+
+const PATH_REGEX = /^\/simple-studio\/(images|videos|copy)(?:\/|$)/;
+
+export function modeFromPathname(pathname: string): SimpleStudioMode | null {
+  const match = pathname.match(PATH_REGEX);
+  if (!match) return null;
+  const segment = match[1] as "images" | "videos" | "copy";
+  return URL_SEGMENT_TO_MODE[segment] ?? null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/urlToMode.test.ts`
+Expected: PASS, all 11 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/simple-studio-shell/urlToMode.ts src/components/simple-studio-shell/__tests__/urlToMode.test.ts
+git commit -m "feat(simple-studio): add URL segment to mode mapping module"
+```
+
+---
+
+## Task 2: Shell store (UI-only state)
+
+**Files:**
+- Create: `src/store/simpleStudioShellStore.ts`
+- Test: `src/store/__tests__/simpleStudioShellStore.test.ts`
+
+A small Zustand store for dialog, library filter, and prompt library tab state. No API calls.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/store/__tests__/simpleStudioShellStore.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSimpleStudioShellStore } from "../simpleStudioShellStore";
+
+describe("useSimpleStudioShellStore", () => {
+  beforeEach(() => {
+    // Reset store to initial state between tests
+    useSimpleStudioShellStore.setState({
+      savePromptDialogOpen: false,
+      libraryModeFilter: "all",
+      promptLibraryTab: "templates",
+    });
+  });
+
+  describe("save prompt dialog", () => {
+    it("initializes closed", () => {
+      expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(false);
+    });
+
+    it("openSavePromptDialog sets open to true", () => {
+      useSimpleStudioShellStore.getState().openSavePromptDialog();
+      expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(true);
+    });
+
+    it("closeSavePromptDialog sets open to false", () => {
+      useSimpleStudioShellStore.setState({ savePromptDialogOpen: true });
+      useSimpleStudioShellStore.getState().closeSavePromptDialog();
+      expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(false);
+    });
+  });
+
+  describe("library mode filter", () => {
+    it("defaults to all", () => {
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("all");
+    });
+
+    it("setLibraryModeFilter updates the filter", () => {
+      useSimpleStudioShellStore.getState().setLibraryModeFilter("photo");
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("photo");
+
+      useSimpleStudioShellStore.getState().setLibraryModeFilter("video");
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("video");
+
+      useSimpleStudioShellStore.getState().setLibraryModeFilter("copy");
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("copy");
+
+      useSimpleStudioShellStore.getState().setLibraryModeFilter("all");
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("all");
+    });
+  });
+
+  describe("prompt library tab", () => {
+    it("defaults to templates", () => {
+      expect(useSimpleStudioShellStore.getState().promptLibraryTab).toBe("templates");
+    });
+
+    it("setPromptLibraryTab switches between templates and saved", () => {
+      useSimpleStudioShellStore.getState().setPromptLibraryTab("saved");
+      expect(useSimpleStudioShellStore.getState().promptLibraryTab).toBe("saved");
+
+      useSimpleStudioShellStore.getState().setPromptLibraryTab("templates");
+      expect(useSimpleStudioShellStore.getState().promptLibraryTab).toBe("templates");
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/store/__tests__/simpleStudioShellStore.test.ts`
+Expected: FAIL with "Cannot find module '../simpleStudioShellStore'".
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/store/simpleStudioShellStore.ts`:
+
+```ts
+import { create } from "zustand";
+
+export type LibraryModeFilter = "all" | "photo" | "video" | "copy";
+export type PromptLibraryTab = "templates" | "saved";
+
+interface SimpleStudioShellState {
+  // Save prompt dialog
+  savePromptDialogOpen: boolean;
+  openSavePromptDialog: () => void;
+  closeSavePromptDialog: () => void;
+
+  // Library filter
+  libraryModeFilter: LibraryModeFilter;
+  setLibraryModeFilter: (mode: LibraryModeFilter) => void;
+
+  // Prompt library active tab
+  promptLibraryTab: PromptLibraryTab;
+  setPromptLibraryTab: (tab: PromptLibraryTab) => void;
+}
+
+export const useSimpleStudioShellStore = create<SimpleStudioShellState>((set) => ({
+  savePromptDialogOpen: false,
+  openSavePromptDialog: () => set({ savePromptDialogOpen: true }),
+  closeSavePromptDialog: () => set({ savePromptDialogOpen: false }),
+
+  libraryModeFilter: "all",
+  setLibraryModeFilter: (mode) => set({ libraryModeFilter: mode }),
+
+  promptLibraryTab: "templates",
+  setPromptLibraryTab: (tab) => set({ promptLibraryTab: tab }),
+}));
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/store/__tests__/simpleStudioShellStore.test.ts`
+Expected: PASS, all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/simpleStudioShellStore.ts src/store/__tests__/simpleStudioShellStore.test.ts
+git commit -m "feat(simple-studio): add shell UI-only store"
+```
+
+---
+
+## Task 3: SimpleStudioAppSidebar component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/SimpleStudioAppSidebar.tsx`
+- Test: `src/components/simple-studio-shell/__tests__/SimpleStudioAppSidebar.test.tsx`
+
+Mirrors `SocialAppSidebar.tsx` structure. Two nav groups (Create / Browse), AppSwitcher header, NavUser footer.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/__tests__/SimpleStudioAppSidebar.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SimpleStudioAppSidebar } from "../SimpleStudioAppSidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+// Mock next/navigation to control pathname
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/simple-studio/images",
+}));
+
+// Mock authClient.useSession to provide a stable user
+vi.mock("@/lib/auth/client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { name: "Test User", email: "test@example.com", image: "" } },
+    }),
+  },
+}));
+
+function renderSidebar() {
+  return render(
+    <SidebarProvider>
+      <SimpleStudioAppSidebar />
+    </SidebarProvider>,
+  );
+}
+
+describe("SimpleStudioAppSidebar", () => {
+  it("renders all five nav items", () => {
+    renderSidebar();
+    expect(screen.getByText("Images")).toBeInTheDocument();
+    expect(screen.getByText("Videos")).toBeInTheDocument();
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+    expect(screen.getByText("Library")).toBeInTheDocument();
+    expect(screen.getByText("Prompt Library")).toBeInTheDocument();
+  });
+
+  it("renders Create and Browse group labels", () => {
+    renderSidebar();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Browse")).toBeInTheDocument();
+  });
+
+  it("renders the AppSwitcher trigger with Simple Studio label", () => {
+    renderSidebar();
+    expect(screen.getByText("Simple Studio")).toBeInTheDocument();
+  });
+
+  it("renders the user's name in the footer", () => {
+    renderSidebar();
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/SimpleStudioAppSidebar.test.tsx`
+Expected: FAIL with "Cannot find module '../SimpleStudioAppSidebar'".
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/components/simple-studio-shell/SimpleStudioAppSidebar.tsx`:
+
+```tsx
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  ImageIcon,
+  VideoIcon,
+  FileTextIcon,
+  GalleryThumbnailsIcon,
+  BookmarkIcon,
+  PaletteIcon,
+} from "lucide-react";
+import { NavUser } from "@/components/nav-user";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarSeparator,
+} from "@/components/ui/sidebar";
+import { AppSwitcher } from "@/components/AppSwitcher";
+import { authClient } from "@/lib/auth/client";
+
+const CREATE_ITEMS = [
+  { href: "/simple-studio/images", label: "Images", icon: ImageIcon },
+  { href: "/simple-studio/videos", label: "Videos", icon: VideoIcon },
+  { href: "/simple-studio/copy", label: "Copy", icon: FileTextIcon },
+];
+
+const BROWSE_ITEMS = [
+  { href: "/simple-studio/library", label: "Library", icon: GalleryThumbnailsIcon },
+  { href: "/simple-studio/prompt-library", label: "Prompt Library", icon: BookmarkIcon },
+];
+
+export function SimpleStudioAppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const pathname = usePathname();
+  const session = authClient.useSession();
+
+  const user = {
+    name: session.data?.user?.name || "User",
+    email: session.data?.user?.email || "",
+    avatar: session.data?.user?.image || "",
+  };
+
+  const isActive = (href: string) =>
+    pathname === href || pathname?.startsWith(href + "/");
+
+  return (
+    <Sidebar collapsible="offcanvas" {...props}>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <AppSwitcher>
+              <div className="flex w-full items-center gap-2 rounded-md p-1.5 text-start text-sm font-semibold hover:bg-sidebar-accent cursor-pointer">
+                <PaletteIcon className="size-5" />
+                <span className="text-base font-semibold">Simple Studio</span>
+              </div>
+            </AppSwitcher>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Create</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {CREATE_ITEMS.map((item) => (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton
+                    isActive={isActive(item.href)}
+                    render={<Link href={item.href} />}
+                  >
+                    <item.icon />
+                    <span>{item.label}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarSeparator />
+
+        <SidebarGroup>
+          <SidebarGroupLabel>Browse</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {BROWSE_ITEMS.map((item) => (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton
+                    isActive={isActive(item.href)}
+                    render={<Link href={item.href} />}
+                  >
+                    <item.icon />
+                    <span>{item.label}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarFooter>
+        <NavUser user={user} />
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/SimpleStudioAppSidebar.test.tsx`
+Expected: PASS, all 4 tests green.
+
+Note: if the test fails with a `<Link>` rendering error, ensure `next/link` is being mocked appropriately or that the `Sidebar` primitive supports `render={<Link />}` in the current version (it does in the existing `SocialAppSidebar.tsx` — match that pattern exactly).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/simple-studio-shell/SimpleStudioAppSidebar.tsx src/components/simple-studio-shell/__tests__/SimpleStudioAppSidebar.test.tsx
+git commit -m "feat(simple-studio): add app sidebar with Create/Browse groups"
+```
+
+---
+
+## Task 4: SimpleStudioSiteHeader component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/SimpleStudioSiteHeader.tsx`
+- Test: `src/components/simple-studio-shell/__tests__/SimpleStudioSiteHeader.test.tsx`
+
+Site header with contextual right-side action that varies by route.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/__tests__/SimpleStudioSiteHeader.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { SimpleStudioSiteHeader } from "../SimpleStudioSiteHeader";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+const pathnameMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathnameMock(),
+}));
+
+function renderHeader() {
+  return render(
+    <SidebarProvider>
+      <SimpleStudioSiteHeader />
+    </SidebarProvider>,
+  );
+}
+
+describe("SimpleStudioSiteHeader", () => {
+  beforeEach(() => {
+    useSimpleStudioShellStore.setState({
+      savePromptDialogOpen: false,
+      libraryModeFilter: "all",
+      promptLibraryTab: "templates",
+    });
+  });
+
+  it("shows 'Images' title on /simple-studio/images", () => {
+    pathnameMock.mockReturnValue("/simple-studio/images");
+    renderHeader();
+    expect(screen.getByRole("heading", { name: "Images" })).toBeInTheDocument();
+  });
+
+  it("shows 'Library' title on /simple-studio/library", () => {
+    pathnameMock.mockReturnValue("/simple-studio/library");
+    renderHeader();
+    expect(screen.getByRole("heading", { name: "Library" })).toBeInTheDocument();
+  });
+
+  it("shows 'Prompt Library' title on /simple-studio/prompt-library", () => {
+    pathnameMock.mockReturnValue("/simple-studio/prompt-library");
+    renderHeader();
+    expect(screen.getByRole("heading", { name: "Prompt Library" })).toBeInTheDocument();
+  });
+
+  it("shows a Save prompt button on a form route", () => {
+    pathnameMock.mockReturnValue("/simple-studio/images");
+    renderHeader();
+    expect(screen.getByRole("button", { name: /save prompt/i })).toBeInTheDocument();
+  });
+
+  it("Save prompt button opens the dialog via the store", async () => {
+    pathnameMock.mockReturnValue("/simple-studio/images");
+    renderHeader();
+    await userEvent.click(screen.getByRole("button", { name: /save prompt/i }));
+    expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(true);
+  });
+
+  it("shows a New Saved Prompt button on the prompt-library route", () => {
+    pathnameMock.mockReturnValue("/simple-studio/prompt-library");
+    renderHeader();
+    expect(screen.getByRole("button", { name: /new saved prompt/i })).toBeInTheDocument();
+  });
+
+  it("shows filter pills on the library route", () => {
+    pathnameMock.mockReturnValue("/simple-studio/library");
+    renderHeader();
+    expect(screen.getByRole("button", { name: /^all$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^photo$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^video$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeInTheDocument();
+  });
+
+  it("clicking a filter pill updates the store", async () => {
+    pathnameMock.mockReturnValue("/simple-studio/library");
+    renderHeader();
+    await userEvent.click(screen.getByRole("button", { name: /^photo$/i }));
+    expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("photo");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/SimpleStudioSiteHeader.test.tsx`
+Expected: FAIL with "Cannot find module '../SimpleStudioSiteHeader'".
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/components/simple-studio-shell/SimpleStudioSiteHeader.tsx`:
+
+```tsx
+"use client";
+
+import { usePathname } from "next/navigation";
+import { PlusIcon, BookmarkIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import {
+  useSimpleStudioShellStore,
+  type LibraryModeFilter,
+} from "@/store/simpleStudioShellStore";
+
+const PAGE_TITLES: Record<string, string> = {
+  "/simple-studio/images": "Images",
+  "/simple-studio/videos": "Videos",
+  "/simple-studio/copy": "Copy",
+  "/simple-studio/library": "Library",
+  "/simple-studio/prompt-library": "Prompt Library",
+};
+
+const FILTER_VALUES: { value: LibraryModeFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "photo", label: "Photo" },
+  { value: "video", label: "Video" },
+  { value: "copy", label: "Copy" },
+];
+
+function resolveTitle(pathname: string | null): string {
+  if (!pathname) return "Simple Studio";
+  const exact = PAGE_TITLES[pathname];
+  if (exact) return exact;
+  const prefixMatch = Object.entries(PAGE_TITLES).find(([path]) =>
+    pathname.startsWith(path + "/"),
+  );
+  return prefixMatch ? prefixMatch[1] : "Simple Studio";
+}
+
+function isFormRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return (
+    pathname === "/simple-studio/images" ||
+    pathname === "/simple-studio/videos" ||
+    pathname === "/simple-studio/copy" ||
+    pathname.startsWith("/simple-studio/images/") ||
+    pathname.startsWith("/simple-studio/videos/") ||
+    pathname.startsWith("/simple-studio/copy/")
+  );
+}
+
+export function SimpleStudioSiteHeader() {
+  const pathname = usePathname();
+  const title = resolveTitle(pathname);
+  const openSavePromptDialog = useSimpleStudioShellStore(
+    (s) => s.openSavePromptDialog,
+  );
+  const libraryModeFilter = useSimpleStudioShellStore((s) => s.libraryModeFilter);
+  const setLibraryModeFilter = useSimpleStudioShellStore(
+    (s) => s.setLibraryModeFilter,
+  );
+
+  const isLibrary = pathname === "/simple-studio/library";
+  const isPromptLibrary = pathname === "/simple-studio/prompt-library";
+  const isForm = isFormRoute(pathname);
+
+  return (
+    <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
+      <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+        <SidebarTrigger className="-ms-1" />
+        <Separator
+          orientation="vertical"
+          className="mx-2 h-4 data-vertical:self-auto"
+        />
+        <h1 className="text-base font-medium">{title}</h1>
+
+        <div className="ms-auto flex items-center gap-2">
+          {isLibrary &&
+            FILTER_VALUES.map((f) => (
+              <Button
+                key={f.value}
+                size="sm"
+                variant={libraryModeFilter === f.value ? "default" : "ghost"}
+                onClick={() => setLibraryModeFilter(f.value)}
+              >
+                {f.label}
+              </Button>
+            ))}
+
+          {isForm && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => openSavePromptDialog()}
+            >
+              <BookmarkIcon className="size-4" />
+              Save prompt
+            </Button>
+          )}
+
+          {isPromptLibrary && (
+            <Button size="sm" onClick={() => openSavePromptDialog()}>
+              <PlusIcon className="size-4" />
+              New Saved Prompt
+            </Button>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/SimpleStudioSiteHeader.test.tsx`
+Expected: PASS, all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/simple-studio-shell/SimpleStudioSiteHeader.tsx src/components/simple-studio-shell/__tests__/SimpleStudioSiteHeader.test.tsx
+git commit -m "feat(simple-studio): add site header with contextual route actions"
+```
+
+---
+
+## Task 5: SimpleStudioLayout component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/SimpleStudioLayout.tsx`
+
+No dedicated test — this is a thin composition. Its children (the sidebar, header, and forms) are tested independently. If the layout breaks, route-level integration tests in Task 14 will catch it.
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/components/simple-studio-shell/SimpleStudioLayout.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { SimpleStudioAppSidebar } from "./SimpleStudioAppSidebar";
+import { SimpleStudioSiteHeader } from "./SimpleStudioSiteHeader";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { modeFromPathname } from "./urlToMode";
+
+interface SimpleStudioLayoutProps {
+  children: React.ReactNode;
+}
+
+export function SimpleStudioLayout({ children }: SimpleStudioLayoutProps) {
+  const pathname = usePathname();
+  const setMode = useSimpleStudioStore((s) => s.setMode);
+  const loadRecentResults = useSimpleStudioStore((s) => s.loadRecentResults);
+  const initialized = useRef(false);
+
+  // Sync store mode with URL on every pathname change
+  useEffect(() => {
+    const mode = modeFromPathname(pathname ?? "");
+    if (mode) {
+      setMode(mode);
+    }
+  }, [pathname, setMode]);
+
+  // Load recent results once on first mount
+  if (!initialized.current) {
+    initialized.current = true;
+    loadRecentResults();
+  }
+
+  return (
+    <SidebarProvider
+      style={
+        {
+          "--sidebar-width": "calc(var(--spacing) * 64)",
+          "--header-height": "calc(var(--spacing) * 12)",
+        } as React.CSSProperties
+      }
+    >
+      <SimpleStudioAppSidebar variant="inset" />
+      <SidebarInset>
+        <SimpleStudioSiteHeader />
+        <div className="flex flex-1 flex-col">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Sanity-check by typecheck**
+
+Run: `pnpm lint`
+Expected: no TypeScript errors in the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/simple-studio-shell/SimpleStudioLayout.tsx
+git commit -m "feat(simple-studio): add layout wrapper with pathname-to-mode sync"
+```
+
+---
+
+## Task 6: Route layout.tsx, page.tsx, and five empty child pages
+
+**Files:**
+- Create: `src/app/simple-studio/layout.tsx`
+- Create: `src/app/simple-studio/page.tsx`
+- Create: `src/app/simple-studio/images/page.tsx`
+- Create: `src/app/simple-studio/videos/page.tsx`
+- Create: `src/app/simple-studio/copy/page.tsx`
+- Create: `src/app/simple-studio/library/page.tsx`
+- Create: `src/app/simple-studio/prompt-library/page.tsx`
+
+All five child pages are placeholder "Coming Soon" stubs for now — they'll be filled in by later tasks. This task proves the routing and shell work end-to-end.
+
+- [ ] **Step 1: Create the auth-gated server layout**
+
+Create `src/app/simple-studio/layout.tsx`:
+
+```tsx
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { getServerAuthSession } from "@/lib/auth/session";
+import { SimpleStudioLayout } from "@/components/simple-studio-shell/SimpleStudioLayout";
+
+export default async function SimpleStudioRootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const session = await getServerAuthSession(await headers());
+
+  if (!session?.user) {
+    redirect("/sign-in?next=%2Fsimple-studio%2Fimages");
+  }
+
+  return <SimpleStudioLayout>{children}</SimpleStudioLayout>;
+}
+```
+
+- [ ] **Step 2: Create the root redirect**
+
+Create `src/app/simple-studio/page.tsx`:
+
+```tsx
+import { redirect } from "next/navigation";
+
+export default function SimpleStudioRootPage() {
+  redirect("/simple-studio/images");
+}
+```
+
+- [ ] **Step 3: Create five placeholder child pages**
+
+Create `src/app/simple-studio/images/page.tsx`:
+
+```tsx
+export default function ImagesPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">Images page — coming soon.</div>
+  );
+}
+```
+
+Create `src/app/simple-studio/videos/page.tsx`:
+
+```tsx
+export default function VideosPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">Videos page — coming soon.</div>
+  );
+}
+```
+
+Create `src/app/simple-studio/copy/page.tsx`:
+
+```tsx
+export default function CopyPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">Copy page — coming soon.</div>
+  );
+}
+```
+
+Create `src/app/simple-studio/library/page.tsx`:
+
+```tsx
+export default function LibraryPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">Library page — coming soon.</div>
+  );
+}
+```
+
+Create `src/app/simple-studio/prompt-library/page.tsx`:
+
+```tsx
+export default function PromptLibraryPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">
+      Prompt Library page — coming soon.
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Manual smoke test**
+
+Run: `pnpm dev` (background or separate terminal), then visit `http://localhost:3000/simple-studio` in a browser while signed in.
+
+Expected:
+- Redirects to `/simple-studio/images`.
+- Shell renders with sidebar, header, "Images" title.
+- Clicking Videos / Copy / Library / Prompt Library in the sidebar navigates and updates the header title.
+- Clicking Videos on the sidebar while on Images sets the mode to `video` in the store (verifiable via React DevTools if the executing engineer wants to confirm).
+- Unauthenticated visit to `/simple-studio` redirects to `/sign-in?next=%2Fsimple-studio%2Fimages`.
+
+Stop `pnpm dev` after verifying.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/simple-studio/
+git commit -m "feat(simple-studio): add route shell with five placeholder pages"
+```
+
+---
+
+## Task 7: AppSwitcher pillar update
+
+**Files:**
+- Modify: `src/components/AppSwitcher.tsx`
+
+Split the "AI Studio" entry into "Simple Studio" and "Advanced Workflow".
+
+- [ ] **Step 1: Read current AppSwitcher state**
+
+Run: `cat src/components/AppSwitcher.tsx` (or use the Read tool) to confirm the current `PILLAR_ITEMS` matches what the spec described. If it has diverged, update this task's patch accordingly.
+
+Expected shape:
+```tsx
+const PILLAR_ITEMS = [
+  { href: "/studio", label: "AI Studio", icon: PaletteIcon },
+  { href: "/editor/projects", label: "Video Editor", icon: VideoIcon },
+  { href: "/social", label: "Social Hub", icon: ActivityIcon },
+  { href: "/analytics", label: "Analytics", icon: BarChart3Icon },
+]
+```
+
+- [ ] **Step 2: Update the import list**
+
+In `src/components/AppSwitcher.tsx`, update the lucide-react import to add `WorkflowIcon`:
+
+```tsx
+import {
+  PaletteIcon,
+  VideoIcon,
+  ActivityIcon,
+  BarChart3Icon,
+  WorkflowIcon,
+} from "lucide-react";
+```
+
+- [ ] **Step 3: Update PILLAR_ITEMS**
+
+Replace the existing `PILLAR_ITEMS` array with:
+
+```tsx
+const PILLAR_ITEMS = [
+  { href: "/simple-studio/images", label: "Simple Studio", icon: PaletteIcon },
+  { href: "/studio", label: "Advanced Workflow", icon: WorkflowIcon },
+  { href: "/editor/projects", label: "Video Editor", icon: VideoIcon },
+  { href: "/social", label: "Social Hub", icon: ActivityIcon },
+  { href: "/analytics", label: "Analytics", icon: BarChart3Icon },
+]
+```
+
+- [ ] **Step 4: Verify lint and typecheck pass**
+
+Run: `pnpm lint`
+Expected: no errors.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run: `pnpm dev`, open the app, click the AppSwitcher trigger in any pillar.
+
+Expected:
+- Dropdown shows Simple Studio, Advanced Workflow, Video Editor, Social Hub, Analytics, Command Center.
+- Clicking "Simple Studio" navigates to `/simple-studio/images`.
+- Clicking "Advanced Workflow" navigates to `/studio` (the advanced node editor).
+- When on any `/simple-studio/*` route, "Simple Studio" shows the "current" label in the dropdown.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/AppSwitcher.tsx
+git commit -m "feat(app-switcher): split AI Studio into Simple + Advanced Workflow pillars"
+```
+
+---
+
+## Task 8: FormPageLayout and FormInfoPanel shared components
+
+**Files:**
+- Create: `src/components/simple-studio-shell/forms/FormPageLayout.tsx`
+- Create: `src/components/simple-studio-shell/forms/FormInfoPanel.tsx`
+- Test: `src/components/simple-studio-shell/forms/__tests__/FormPageLayout.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/forms/__tests__/FormPageLayout.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FormPageLayout } from "../FormPageLayout";
+
+describe("FormPageLayout", () => {
+  it("renders the form body slot", () => {
+    render(
+      <FormPageLayout infoPanel={<div>Info</div>}>
+        <div>Form body</div>
+      </FormPageLayout>,
+    );
+    expect(screen.getByText("Form body")).toBeInTheDocument();
+  });
+
+  it("renders the info panel slot", () => {
+    render(
+      <FormPageLayout infoPanel={<div>Info content</div>}>
+        <div>Form body</div>
+      </FormPageLayout>,
+    );
+    expect(screen.getByText("Info content")).toBeInTheDocument();
+  });
+
+  it("renders both slots in the same document", () => {
+    render(
+      <FormPageLayout infoPanel={<div data-testid="panel">Panel</div>}>
+        <div data-testid="body">Body</div>
+      </FormPageLayout>,
+    );
+    expect(screen.getByTestId("body")).toBeInTheDocument();
+    expect(screen.getByTestId("panel")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/forms/__tests__/FormPageLayout.test.tsx`
+Expected: FAIL with "Cannot find module '../FormPageLayout'".
+
+- [ ] **Step 3: Write the minimal implementation of FormPageLayout**
+
+Create `src/components/simple-studio-shell/forms/FormPageLayout.tsx`:
+
+```tsx
+"use client";
+
+import type { ReactNode } from "react";
+
+interface FormPageLayoutProps {
+  children: ReactNode;
+  infoPanel: ReactNode;
+}
+
+export function FormPageLayout({ children, infoPanel }: FormPageLayoutProps) {
+  return (
+    <div className="flex flex-1 flex-col-reverse gap-6 overflow-y-auto p-6 lg:flex-row">
+      <div className="flex-1">
+        <div className="mx-auto w-full max-w-2xl">{children}</div>
+      </div>
+      <aside className="lg:w-80 lg:shrink-0">{infoPanel}</aside>
+    </div>
+  );
+}
+```
+
+Note: `flex-col-reverse` on mobile puts the info panel above the form body (matching the mobile behavior in the spec).
+
+- [ ] **Step 4: Write the minimal FormInfoPanel**
+
+Create `src/components/simple-studio-shell/forms/FormInfoPanel.tsx`:
+
+```tsx
+"use client";
+
+import type { ReactNode } from "react";
+
+interface FormInfoPanelProps {
+  aspectRatios?: { value: string; label: string }[];
+  batchPresets?: number[];
+  outputExample?: ReactNode;
+  tips?: ReactNode;
+  currentAspectRatio?: string;
+  onAspectRatioChange?: (value: string) => void;
+  currentBatchCount?: number;
+  onBatchCountChange?: (value: number) => void;
+  estimatedCost?: ReactNode;
+}
+
+export function FormInfoPanel({
+  aspectRatios,
+  batchPresets,
+  outputExample,
+  tips,
+  currentAspectRatio,
+  onAspectRatioChange,
+  currentBatchCount,
+  onBatchCountChange,
+  estimatedCost,
+}: FormInfoPanelProps) {
+  return (
+    <div className="space-y-4 rounded-lg border bg-card p-4 text-sm">
+      {aspectRatios && aspectRatios.length > 0 && (
+        <section>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Aspect ratio
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {aspectRatios.map((r) => (
+              <button
+                key={r.value}
+                type="button"
+                className={`rounded-md border px-3 py-1 text-xs ${
+                  currentAspectRatio === r.value
+                    ? "border-primary bg-primary/10"
+                    : "border-border hover:bg-muted"
+                }`}
+                onClick={() => onAspectRatioChange?.(r.value)}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {batchPresets && batchPresets.length > 0 && (
+        <section>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Batch count
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {batchPresets.map((n) => (
+              <button
+                key={n}
+                type="button"
+                className={`rounded-md border px-3 py-1 text-xs ${
+                  currentBatchCount === n
+                    ? "border-primary bg-primary/10"
+                    : "border-border hover:bg-muted"
+                }`}
+                onClick={() => onBatchCountChange?.(n)}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {estimatedCost && (
+        <section>
+          <div className="mb-1 text-xs font-medium text-muted-foreground">
+            Estimated cost
+          </div>
+          <div>{estimatedCost}</div>
+        </section>
+      )}
+
+      {outputExample && (
+        <section>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Output example
+          </div>
+          {outputExample}
+        </section>
+      )}
+
+      {tips && (
+        <section className="text-xs text-muted-foreground">{tips}</section>
+      )}
+    </div>
+  );
+}
+```
+
+Note: this is intentionally a minimal styled shell. Visual polish (exact shadcn card styling, icons, layout tuning) can be tweaked during manual QA — the test only asserts structure.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/forms/__tests__/FormPageLayout.test.tsx`
+Expected: PASS, all 3 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/simple-studio-shell/forms/FormPageLayout.tsx src/components/simple-studio-shell/forms/FormInfoPanel.tsx src/components/simple-studio-shell/forms/__tests__/FormPageLayout.test.tsx
+git commit -m "feat(simple-studio): add shared FormPageLayout and FormInfoPanel"
+```
+
+---
+
+## Task 9: ImageForm component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/forms/ImageForm.tsx`
+- Test: `src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx`
+
+Renders an inline image-generation form wired to `useSimpleStudioStore`. For v1 the form is intentionally minimal — prompt textarea, model picker placeholder (reuses existing model list if possible; otherwise a read-only display of the currently selected model name), and Generate button. Aspect ratio and batch count come from `FormInfoPanel`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { ImageForm } from "../ImageForm";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+
+describe("ImageForm", () => {
+  beforeEach(() => {
+    useSimpleStudioStore.setState({
+      mode: "photo",
+      prompt: "",
+      aspectRatio: "1:1",
+      batchCount: 4,
+      isGenerating: false,
+    });
+  });
+
+  it("renders a prompt textarea", () => {
+    render(<ImageForm />);
+    expect(screen.getByLabelText(/prompt/i)).toBeInTheDocument();
+  });
+
+  it("renders a Generate button", () => {
+    render(<ImageForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeInTheDocument();
+  });
+
+  it("typing in the prompt textarea updates the store", async () => {
+    render(<ImageForm />);
+    const textarea = screen.getByLabelText(/prompt/i);
+    await userEvent.type(textarea, "A cat");
+    expect(useSimpleStudioStore.getState().prompt).toBe("A cat");
+  });
+
+  it("clicking Generate calls the store's generate action", async () => {
+    const generateSpy = vi.fn().mockResolvedValue(undefined);
+    useSimpleStudioStore.setState({
+      prompt: "A cat",
+      generate: generateSpy,
+    });
+    render(<ImageForm />);
+    await userEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(generateSpy).toHaveBeenCalled();
+  });
+
+  it("Generate button is disabled when prompt is empty", () => {
+    useSimpleStudioStore.setState({ prompt: "" });
+    render(<ImageForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+  });
+
+  it("Generate button is disabled while generating", () => {
+    useSimpleStudioStore.setState({ prompt: "A cat", isGenerating: true });
+    render(<ImageForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx`
+Expected: FAIL with "Cannot find module '../ImageForm'".
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/components/simple-studio-shell/forms/ImageForm.tsx`:
+
+```tsx
+"use client";
+
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { Button } from "@/components/ui/button";
+import { FormPageLayout } from "./FormPageLayout";
+import { FormInfoPanel } from "./FormInfoPanel";
+
+const ASPECT_RATIOS = [
+  { value: "1:1", label: "1:1" },
+  { value: "16:9", label: "16:9" },
+  { value: "9:16", label: "9:16" },
+  { value: "4:5", label: "4:5" },
+];
+
+const BATCH_PRESETS = [1, 4, 8, 12];
+
+export function ImageForm() {
+  const prompt = useSimpleStudioStore((s) => s.prompt);
+  const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
+  const aspectRatio = useSimpleStudioStore((s) => s.aspectRatio);
+  const setAspectRatio = useSimpleStudioStore((s) => s.setAspectRatio);
+  const batchCount = useSimpleStudioStore((s) => s.batchCount);
+  const setBatchCount = useSimpleStudioStore((s) => s.setBatchCount);
+  const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
+  const generate = useSimpleStudioStore((s) => s.generate);
+  const selectedModelName = useSimpleStudioStore((s) => s.selectedModelName);
+
+  const disabled = isGenerating || prompt.trim().length === 0;
+
+  return (
+    <FormPageLayout
+      infoPanel={
+        <FormInfoPanel
+          aspectRatios={ASPECT_RATIOS}
+          batchPresets={BATCH_PRESETS}
+          currentAspectRatio={aspectRatio}
+          onAspectRatioChange={setAspectRatio}
+          currentBatchCount={batchCount}
+          onBatchCountChange={setBatchCount}
+          estimatedCost={<span>{batchCount} image{batchCount > 1 ? "s" : ""}</span>}
+          outputExample={
+            <div className="aspect-square w-full rounded-md border bg-muted" />
+          }
+          tips={<p>Describe the scene, style, and subject for best results.</p>}
+        />
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="image-prompt" className="mb-2 block text-sm font-medium">
+            Prompt
+          </label>
+          <textarea
+            id="image-prompt"
+            className="min-h-32 w-full resize-y rounded-md border bg-background p-3 text-sm"
+            placeholder="Describe the image you want to generate…"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Model: {selectedModelName || "Auto"}
+        </div>
+
+        <Button
+          type="button"
+          size="lg"
+          disabled={disabled}
+          onClick={() => {
+            void generate();
+          }}
+        >
+          {isGenerating ? "Generating…" : "Generate"}
+        </Button>
+      </div>
+    </FormPageLayout>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx`
+Expected: PASS, all 6 tests green.
+
+- [ ] **Step 5: Wire ImageForm into the page**
+
+Replace `src/app/simple-studio/images/page.tsx` with:
+
+```tsx
+import { ImageForm } from "@/components/simple-studio-shell/forms/ImageForm";
+
+export default function ImagesPage() {
+  return <ImageForm />;
+}
+```
+
+- [ ] **Step 6: Manual smoke test**
+
+Run: `pnpm dev`, visit `/simple-studio/images` while signed in.
+
+Expected:
+- Form renders inline with info panel on the right.
+- Typing in the textarea enables the Generate button.
+- Clicking Generate triggers the existing generation flow (results appear in the store's `generations` array; they won't render anywhere yet until Task 12's LibraryGallery wires in).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/simple-studio-shell/forms/ImageForm.tsx src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx src/app/simple-studio/images/page.tsx
+git commit -m "feat(simple-studio): add ImageForm wired to generation store"
+```
+
+---
+
+## Task 10: VideoForm component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/forms/VideoForm.tsx`
+- Test: `src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx`
+
+Analogous to ImageForm with video-specific fields (duration, different aspect ratios).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { VideoForm } from "../VideoForm";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+
+describe("VideoForm", () => {
+  beforeEach(() => {
+    useSimpleStudioStore.setState({
+      mode: "video",
+      prompt: "",
+      aspectRatio: "16:9",
+      batchCount: 1,
+      videoDuration: 5,
+      isGenerating: false,
+    });
+  });
+
+  it("renders a prompt textarea", () => {
+    render(<VideoForm />);
+    expect(screen.getByLabelText(/prompt/i)).toBeInTheDocument();
+  });
+
+  it("renders a Generate button", () => {
+    render(<VideoForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeInTheDocument();
+  });
+
+  it("typing updates the store prompt", async () => {
+    render(<VideoForm />);
+    await userEvent.type(screen.getByLabelText(/prompt/i), "Sunset");
+    expect(useSimpleStudioStore.getState().prompt).toBe("Sunset");
+  });
+
+  it("clicking Generate calls the store's generate action", async () => {
+    const generateSpy = vi.fn().mockResolvedValue(undefined);
+    useSimpleStudioStore.setState({ prompt: "Sunset", generate: generateSpy });
+    render(<VideoForm />);
+    await userEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(generateSpy).toHaveBeenCalled();
+  });
+
+  it("Generate button is disabled when prompt is empty", () => {
+    useSimpleStudioStore.setState({ prompt: "" });
+    render(<VideoForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx`
+Expected: FAIL with "Cannot find module '../VideoForm'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/components/simple-studio-shell/forms/VideoForm.tsx`:
+
+```tsx
+"use client";
+
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { Button } from "@/components/ui/button";
+import { FormPageLayout } from "./FormPageLayout";
+import { FormInfoPanel } from "./FormInfoPanel";
+
+const ASPECT_RATIOS = [
+  { value: "16:9", label: "16:9" },
+  { value: "9:16", label: "9:16" },
+];
+
+const BATCH_PRESETS = [1, 2, 4];
+const DURATIONS = [5, 8, 10];
+
+export function VideoForm() {
+  const prompt = useSimpleStudioStore((s) => s.prompt);
+  const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
+  const aspectRatio = useSimpleStudioStore((s) => s.aspectRatio);
+  const setAspectRatio = useSimpleStudioStore((s) => s.setAspectRatio);
+  const batchCount = useSimpleStudioStore((s) => s.batchCount);
+  const setBatchCount = useSimpleStudioStore((s) => s.setBatchCount);
+  const videoDuration = useSimpleStudioStore((s) => s.videoDuration);
+  const setVideoDuration = useSimpleStudioStore((s) => s.setVideoDuration);
+  const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
+  const generate = useSimpleStudioStore((s) => s.generate);
+  const selectedModelName = useSimpleStudioStore((s) => s.selectedModelName);
+
+  const disabled = isGenerating || prompt.trim().length === 0;
+
+  return (
+    <FormPageLayout
+      infoPanel={
+        <FormInfoPanel
+          aspectRatios={ASPECT_RATIOS}
+          batchPresets={BATCH_PRESETS}
+          currentAspectRatio={aspectRatio}
+          onAspectRatioChange={setAspectRatio}
+          currentBatchCount={batchCount}
+          onBatchCountChange={setBatchCount}
+          estimatedCost={<span>{batchCount} video{batchCount > 1 ? "s" : ""}</span>}
+          outputExample={
+            <div className="aspect-video w-full rounded-md border bg-muted" />
+          }
+          tips={<p>Describe the motion and scene. Videos take longer to generate.</p>}
+        />
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="video-prompt" className="mb-2 block text-sm font-medium">
+            Prompt
+          </label>
+          <textarea
+            id="video-prompt"
+            className="min-h-32 w-full resize-y rounded-md border bg-background p-3 text-sm"
+            placeholder="Describe the video you want to generate…"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">Duration</label>
+          <div className="flex gap-2">
+            {DURATIONS.map((d) => (
+              <button
+                key={d}
+                type="button"
+                className={`rounded-md border px-3 py-1 text-xs ${
+                  videoDuration === d
+                    ? "border-primary bg-primary/10"
+                    : "border-border hover:bg-muted"
+                }`}
+                onClick={() => setVideoDuration(d)}
+              >
+                {d}s
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Model: {selectedModelName || "Auto (Veo 3.1)"}
+        </div>
+
+        <Button
+          type="button"
+          size="lg"
+          disabled={disabled}
+          onClick={() => {
+            void generate();
+          }}
+        >
+          {isGenerating ? "Generating…" : "Generate"}
+        </Button>
+      </div>
+    </FormPageLayout>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx`
+Expected: PASS, all 5 tests green.
+
+- [ ] **Step 5: Wire VideoForm into the page**
+
+Replace `src/app/simple-studio/videos/page.tsx` with:
+
+```tsx
+import { VideoForm } from "@/components/simple-studio-shell/forms/VideoForm";
+
+export default function VideosPage() {
+  return <VideoForm />;
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/simple-studio-shell/forms/VideoForm.tsx src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx src/app/simple-studio/videos/page.tsx
+git commit -m "feat(simple-studio): add VideoForm wired to generation store"
+```
+
+---
+
+## Task 11: CopyForm component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/forms/CopyForm.tsx`
+- Test: `src/components/simple-studio-shell/forms/__tests__/CopyForm.test.tsx`
+
+Copy (text) generation form — no aspect ratio (meaningless for text), adds tone and platform selectors.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/forms/__tests__/CopyForm.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { CopyForm } from "../CopyForm";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+
+describe("CopyForm", () => {
+  beforeEach(() => {
+    useSimpleStudioStore.setState({
+      mode: "copy",
+      prompt: "",
+      tone: "professional",
+      platform: "general",
+      copyModelId: "gemini-2.5-flash",
+      batchCount: 1,
+      isGenerating: false,
+    });
+  });
+
+  it("renders a prompt textarea", () => {
+    render(<CopyForm />);
+    expect(screen.getByLabelText(/prompt/i)).toBeInTheDocument();
+  });
+
+  it("renders tone and platform selectors", () => {
+    render(<CopyForm />);
+    expect(screen.getByLabelText(/tone/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/platform/i)).toBeInTheDocument();
+  });
+
+  it("renders a Generate button", () => {
+    render(<CopyForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeInTheDocument();
+  });
+
+  it("clicking Generate calls generate", async () => {
+    const generateSpy = vi.fn().mockResolvedValue(undefined);
+    useSimpleStudioStore.setState({ prompt: "Ad copy", generate: generateSpy });
+    render(<CopyForm />);
+    await userEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(generateSpy).toHaveBeenCalled();
+  });
+
+  it("Generate is disabled with empty prompt", () => {
+    useSimpleStudioStore.setState({ prompt: "" });
+    render(<CopyForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/forms/__tests__/CopyForm.test.tsx`
+Expected: FAIL with "Cannot find module '../CopyForm'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/components/simple-studio-shell/forms/CopyForm.tsx`:
+
+```tsx
+"use client";
+
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { Button } from "@/components/ui/button";
+import { FormPageLayout } from "./FormPageLayout";
+import { FormInfoPanel } from "./FormInfoPanel";
+
+const TONES = ["professional", "casual", "creative", "persuasive"];
+const PLATFORMS = ["general", "instagram", "x", "linkedin"];
+const BATCH_PRESETS = [1, 4, 8];
+
+export function CopyForm() {
+  const prompt = useSimpleStudioStore((s) => s.prompt);
+  const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
+  const tone = useSimpleStudioStore((s) => s.tone);
+  const setTone = useSimpleStudioStore((s) => s.setTone);
+  const platform = useSimpleStudioStore((s) => s.platform);
+  const setPlatform = useSimpleStudioStore((s) => s.setPlatform);
+  const batchCount = useSimpleStudioStore((s) => s.batchCount);
+  const setBatchCount = useSimpleStudioStore((s) => s.setBatchCount);
+  const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
+  const generate = useSimpleStudioStore((s) => s.generate);
+  const copyModelId = useSimpleStudioStore((s) => s.copyModelId);
+
+  const disabled = isGenerating || prompt.trim().length === 0;
+
+  return (
+    <FormPageLayout
+      infoPanel={
+        <FormInfoPanel
+          batchPresets={BATCH_PRESETS}
+          currentBatchCount={batchCount}
+          onBatchCountChange={setBatchCount}
+          estimatedCost={<span>{batchCount} variant{batchCount > 1 ? "s" : ""}</span>}
+          tips={<p>Give the model context: audience, product, and desired action.</p>}
+        />
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="copy-prompt" className="mb-2 block text-sm font-medium">
+            Prompt
+          </label>
+          <textarea
+            id="copy-prompt"
+            className="min-h-32 w-full resize-y rounded-md border bg-background p-3 text-sm"
+            placeholder="What should the copy be about?"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="copy-tone" className="mb-2 block text-sm font-medium">
+              Tone
+            </label>
+            <select
+              id="copy-tone"
+              className="w-full rounded-md border bg-background p-2 text-sm"
+              value={tone}
+              onChange={(e) => setTone(e.target.value)}
+            >
+              {TONES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="copy-platform" className="mb-2 block text-sm font-medium">
+              Platform
+            </label>
+            <select
+              id="copy-platform"
+              className="w-full rounded-md border bg-background p-2 text-sm"
+              value={platform}
+              onChange={(e) => setPlatform(e.target.value)}
+            >
+              {PLATFORMS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Model: {copyModelId}
+        </div>
+
+        <Button
+          type="button"
+          size="lg"
+          disabled={disabled}
+          onClick={() => {
+            void generate();
+          }}
+        >
+          {isGenerating ? "Generating…" : "Generate"}
+        </Button>
+      </div>
+    </FormPageLayout>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/forms/__tests__/CopyForm.test.tsx`
+Expected: PASS, all 5 tests green.
+
+- [ ] **Step 5: Wire CopyForm into the page**
+
+Replace `src/app/simple-studio/copy/page.tsx` with:
+
+```tsx
+import { CopyForm } from "@/components/simple-studio-shell/forms/CopyForm";
+
+export default function CopyPage() {
+  return <CopyForm />;
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/simple-studio-shell/forms/CopyForm.tsx src/components/simple-studio-shell/forms/__tests__/CopyForm.test.tsx src/app/simple-studio/copy/page.tsx
+git commit -m "feat(simple-studio): add CopyForm with tone and platform controls"
+```
+
+---
+
+## Task 12: LibraryGallery component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/LibraryGallery.tsx`
+- Test: `src/components/simple-studio-shell/__tests__/LibraryGallery.test.tsx`
+
+Cross-mode generations grid that reads from `useSimpleStudioStore.generationsByMode` and filters by `useSimpleStudioShellStore.libraryModeFilter`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/__tests__/LibraryGallery.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, beforeEach } from "vitest";
+import { LibraryGallery } from "../LibraryGallery";
+import { useSimpleStudioStore, type Generation } from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+function makeGen(overrides: Partial<Generation>): Generation {
+  return {
+    id: "g1",
+    batchId: "b1",
+    status: "complete",
+    result: "data:image/png;base64,xxx",
+    assetId: null,
+    error: null,
+    mode: "photo",
+    aspectRatio: "1:1",
+    prompt: "A cat",
+    createdAt: Date.now(),
+    modelName: "Auto",
+    ...overrides,
+  };
+}
+
+describe("LibraryGallery", () => {
+  beforeEach(() => {
+    useSimpleStudioStore.setState({
+      generationsByMode: {
+        photo: [makeGen({ id: "p1", mode: "photo", prompt: "Photo one" })],
+        video: [makeGen({ id: "v1", mode: "video", prompt: "Video one", result: "data:video/mp4;base64,xxx" })],
+        copy: [makeGen({ id: "c1", mode: "copy", prompt: "Copy one", result: "Text output" })],
+      },
+      generations: [],
+      mode: "photo",
+    });
+    useSimpleStudioShellStore.setState({ libraryModeFilter: "all" });
+  });
+
+  it("renders all generations when filter is 'all'", () => {
+    render(<LibraryGallery />);
+    expect(screen.getByText("Photo one")).toBeInTheDocument();
+    expect(screen.getByText("Video one")).toBeInTheDocument();
+    expect(screen.getByText("Copy one")).toBeInTheDocument();
+  });
+
+  it("renders only photo generations when filter is 'photo'", () => {
+    useSimpleStudioShellStore.setState({ libraryModeFilter: "photo" });
+    render(<LibraryGallery />);
+    expect(screen.getByText("Photo one")).toBeInTheDocument();
+    expect(screen.queryByText("Video one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Copy one")).not.toBeInTheDocument();
+  });
+
+  it("renders only video generations when filter is 'video'", () => {
+    useSimpleStudioShellStore.setState({ libraryModeFilter: "video" });
+    render(<LibraryGallery />);
+    expect(screen.queryByText("Photo one")).not.toBeInTheDocument();
+    expect(screen.getByText("Video one")).toBeInTheDocument();
+    expect(screen.queryByText("Copy one")).not.toBeInTheDocument();
+  });
+
+  it("renders only copy generations when filter is 'copy'", () => {
+    useSimpleStudioShellStore.setState({ libraryModeFilter: "copy" });
+    render(<LibraryGallery />);
+    expect(screen.queryByText("Photo one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Video one")).not.toBeInTheDocument();
+    expect(screen.getByText("Copy one")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no generations", () => {
+    useSimpleStudioStore.setState({
+      generationsByMode: { photo: [], video: [], copy: [] },
+      generations: [],
+    });
+    render(<LibraryGallery />);
+    expect(screen.getByText(/no generations yet/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/LibraryGallery.test.tsx`
+Expected: FAIL with "Cannot find module '../LibraryGallery'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/components/simple-studio-shell/LibraryGallery.tsx`:
+
+```tsx
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { useSimpleStudioStore, type Generation } from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+function GenerationCard({ gen }: { gen: Generation }) {
+  if (gen.mode === "copy") {
+    return (
+      <div className="rounded-lg border p-4">
+        <div className="mb-2 text-xs text-muted-foreground">
+          copy · {new Date(gen.createdAt).toLocaleDateString()}
+        </div>
+        <div className="mb-2 text-sm font-medium line-clamp-2">{gen.prompt}</div>
+        <div className="text-sm line-clamp-4 whitespace-pre-wrap">
+          {gen.result ?? "(no output)"}
+        </div>
+      </div>
+    );
+  }
+
+  if (gen.mode === "video") {
+    return (
+      <div className="rounded-lg border overflow-hidden">
+        <div className="aspect-video bg-muted">
+          {gen.result && (
+            <video
+              src={gen.result}
+              className="h-full w-full object-cover"
+              muted
+              playsInline
+            />
+          )}
+        </div>
+        <div className="p-3">
+          <div className="mb-1 text-xs text-muted-foreground">
+            video · {new Date(gen.createdAt).toLocaleDateString()}
+          </div>
+          <div className="text-sm line-clamp-2">{gen.prompt}</div>
+        </div>
+      </div>
+    );
+  }
+
+  // photo
+  return (
+    <div className="rounded-lg border overflow-hidden">
+      <div className="aspect-square bg-muted">
+        {gen.result && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={gen.result} alt={gen.prompt} className="h-full w-full object-cover" />
+        )}
+      </div>
+      <div className="p-3">
+        <div className="mb-1 text-xs text-muted-foreground">
+          photo · {new Date(gen.createdAt).toLocaleDateString()}
+        </div>
+        <div className="text-sm line-clamp-2">{gen.prompt}</div>
+      </div>
+    </div>
+  );
+}
+
+export function LibraryGallery() {
+  const generationsByMode = useSimpleStudioStore((s) => s.generationsByMode);
+  const filter = useSimpleStudioShellStore((s) => s.libraryModeFilter);
+
+  const visible = useMemo(() => {
+    const all = [
+      ...generationsByMode.photo,
+      ...generationsByMode.video,
+      ...generationsByMode.copy,
+    ].sort((a, b) => b.createdAt - a.createdAt);
+    if (filter === "all") return all;
+    return all.filter((g) => g.mode === filter);
+  }, [generationsByMode, filter]);
+
+  if (visible.length === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 p-12 text-center">
+        <div className="text-sm text-muted-foreground">No generations yet.</div>
+        <div className="flex gap-2">
+          <Link
+            href="/simple-studio/images"
+            className="rounded-md border px-3 py-1 text-sm hover:bg-muted"
+          >
+            Create images
+          </Link>
+          <Link
+            href="/simple-studio/videos"
+            className="rounded-md border px-3 py-1 text-sm hover:bg-muted"
+          >
+            Create videos
+          </Link>
+          <Link
+            href="/simple-studio/copy"
+            className="rounded-md border px-3 py-1 text-sm hover:bg-muted"
+          >
+            Write copy
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 p-6 md:grid-cols-3 lg:grid-cols-4">
+      {visible.map((gen) => (
+        <GenerationCard key={gen.id} gen={gen} />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/LibraryGallery.test.tsx`
+Expected: PASS, all 5 tests green.
+
+- [ ] **Step 5: Wire LibraryGallery into the page**
+
+Replace `src/app/simple-studio/library/page.tsx` with:
+
+```tsx
+import { LibraryGallery } from "@/components/simple-studio-shell/LibraryGallery";
+
+export default function LibraryPage() {
+  return <LibraryGallery />;
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/simple-studio-shell/LibraryGallery.tsx src/components/simple-studio-shell/__tests__/LibraryGallery.test.tsx src/app/simple-studio/library/page.tsx
+git commit -m "feat(simple-studio): add LibraryGallery with mode filter"
+```
+
+---
+
+## Task 13: SavePromptDialog component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/SavePromptDialog.tsx`
+- Test: `src/components/simple-studio-shell/__tests__/SavePromptDialog.test.tsx`
+
+A shadcn Dialog that asks for a name and calls `useSimpleStudioStore.saveCurrentPrompt(name)`. The dialog open state is owned by `useSimpleStudioShellStore`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/__tests__/SavePromptDialog.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { SavePromptDialog } from "../SavePromptDialog";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+describe("SavePromptDialog", () => {
+  beforeEach(() => {
+    useSimpleStudioShellStore.setState({ savePromptDialogOpen: true });
+    useSimpleStudioStore.setState({ prompt: "A cat", mode: "photo" });
+  });
+
+  it("renders the dialog when open is true", () => {
+    render(<SavePromptDialog />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("shows a name input", () => {
+    render(<SavePromptDialog />);
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+  });
+
+  it("shows an editable prompt textarea seeded with the current store prompt", () => {
+    render(<SavePromptDialog />);
+    const textarea = screen.getByLabelText(/prompt text/i) as HTMLTextAreaElement;
+    expect(textarea).toBeInTheDocument();
+    expect(textarea.value).toBe("A cat");
+  });
+
+  it("calls setPrompt then saveCurrentPrompt with the edited prompt on Save", async () => {
+    const setPromptSpy = vi.fn();
+    const saveSpy = vi.fn().mockResolvedValue(undefined);
+    useSimpleStudioStore.setState({ setPrompt: setPromptSpy, saveCurrentPrompt: saveSpy });
+    render(<SavePromptDialog />);
+    const textarea = screen.getByLabelText(/prompt text/i);
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, "A fluffy cat");
+    await userEvent.type(screen.getByLabelText(/name/i), "Cat v2");
+    await userEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    expect(setPromptSpy).toHaveBeenCalledWith("A fluffy cat");
+    expect(saveSpy).toHaveBeenCalledWith("Cat v2");
+    expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(false);
+  });
+
+  it("Save button is disabled when name is empty", () => {
+    render(<SavePromptDialog />);
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("Save button is disabled when prompt text is empty", async () => {
+    useSimpleStudioStore.setState({ prompt: "" });
+    render(<SavePromptDialog />);
+    await userEvent.type(screen.getByLabelText(/name/i), "Empty");
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("does not render when open is false", () => {
+    useSimpleStudioShellStore.setState({ savePromptDialogOpen: false });
+    render(<SavePromptDialog />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/SavePromptDialog.test.tsx`
+Expected: FAIL with "Cannot find module '../SavePromptDialog'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/components/simple-studio-shell/SavePromptDialog.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+export function SavePromptDialog() {
+  const open = useSimpleStudioShellStore((s) => s.savePromptDialogOpen);
+  const closeDialog = useSimpleStudioShellStore((s) => s.closeSavePromptDialog);
+  const storePrompt = useSimpleStudioStore((s) => s.prompt);
+  const mode = useSimpleStudioStore((s) => s.mode);
+  const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
+  const saveCurrentPrompt = useSimpleStudioStore((s) => s.saveCurrentPrompt);
+
+  const [name, setName] = useState("");
+  const [promptText, setPromptText] = useState(storePrompt);
+  const [saving, setSaving] = useState(false);
+
+  // Re-seed the dialog's local prompt from the store whenever the dialog opens
+  useEffect(() => {
+    if (open) {
+      setPromptText(storePrompt);
+      setName("");
+    }
+  }, [open, storePrompt]);
+
+  const disabled =
+    saving || name.trim().length === 0 || promptText.trim().length === 0;
+
+  const handleSave = async () => {
+    if (disabled) return;
+    setSaving(true);
+    try {
+      // If the user edited the prompt in the dialog, push it to the store
+      // so saveCurrentPrompt picks it up.
+      if (promptText !== storePrompt) {
+        setPrompt(promptText);
+      }
+      await saveCurrentPrompt(name.trim());
+      closeDialog();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) closeDialog();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Save prompt</DialogTitle>
+          <DialogDescription>
+            Save a {mode} prompt to your library for later use.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="save-prompt-name" className="mb-1 block text-sm font-medium">
+              Name
+            </label>
+            <input
+              id="save-prompt-name"
+              type="text"
+              className="w-full rounded-md border bg-background p-2 text-sm"
+              placeholder="e.g. Cinematic sunset"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="save-prompt-text"
+              className="mb-1 block text-sm font-medium"
+            >
+              Prompt text
+            </label>
+            <textarea
+              id="save-prompt-text"
+              className="max-h-48 min-h-24 w-full resize-y rounded-md border bg-background p-2 text-sm"
+              placeholder="Describe the prompt…"
+              value={promptText}
+              onChange={(e) => setPromptText(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={disabled}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/SavePromptDialog.test.tsx`
+Expected: PASS, all 6 tests green.
+
+- [ ] **Step 5: Mount the dialog in SimpleStudioLayout**
+
+Edit `src/components/simple-studio-shell/SimpleStudioLayout.tsx`. Add the import and render `<SavePromptDialog />` inside the `SidebarInset` just after the header:
+
+```tsx
+import { SavePromptDialog } from "./SavePromptDialog";
+
+// …inside <SidebarInset>…
+<SimpleStudioSiteHeader />
+<div className="flex flex-1 flex-col">{children}</div>
+<SavePromptDialog />
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/simple-studio-shell/SavePromptDialog.tsx src/components/simple-studio-shell/__tests__/SavePromptDialog.test.tsx src/components/simple-studio-shell/SimpleStudioLayout.tsx
+git commit -m "feat(simple-studio): add SavePromptDialog with name + preview"
+```
+
+---
+
+## Task 14: PromptLibraryTabs component
+
+**Files:**
+- Create: `src/components/simple-studio-shell/PromptLibraryTabs.tsx`
+- Test: `src/components/simple-studio-shell/__tests__/PromptLibraryTabs.test.tsx`
+
+Tabs for Templates (public prompts) and Saved (private prompts).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/simple-studio-shell/__tests__/PromptLibraryTabs.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { PromptLibraryTabs } from "../PromptLibraryTabs";
+import {
+  useSimpleStudioStore,
+  type SavedPrompt,
+} from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+const routerPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+}));
+
+function makePrompt(overrides: Partial<SavedPrompt>): SavedPrompt {
+  return {
+    id: "p1",
+    mode: "photo",
+    name: "Demo",
+    promptText: "Demo prompt",
+    formConfig: {},
+    isPublic: false,
+    ...overrides,
+  };
+}
+
+describe("PromptLibraryTabs", () => {
+  beforeEach(() => {
+    routerPush.mockClear();
+    useSimpleStudioShellStore.setState({ promptLibraryTab: "templates" });
+    useSimpleStudioStore.setState({
+      savedPrompts: [
+        makePrompt({ id: "s1", name: "Saved one", promptText: "Saved text" }),
+      ],
+      publicPrompts: [
+        makePrompt({
+          id: "t1",
+          name: "Template one",
+          promptText: "Template text",
+          isPublic: true,
+        }),
+      ],
+      applyPrompt: vi.fn(),
+      loadSavedPrompts: vi.fn().mockResolvedValue(undefined),
+      loadPublicPrompts: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it("shows templates by default", () => {
+    render(<PromptLibraryTabs />);
+    expect(screen.getByText("Template one")).toBeInTheDocument();
+  });
+
+  it("switches to Saved tab on click", async () => {
+    render(<PromptLibraryTabs />);
+    await userEvent.click(screen.getByRole("tab", { name: /saved/i }));
+    expect(screen.getByText("Saved one")).toBeInTheDocument();
+    expect(useSimpleStudioShellStore.getState().promptLibraryTab).toBe("saved");
+  });
+
+  it("clicking Use on a template applies and navigates", async () => {
+    const applySpy = vi.fn();
+    useSimpleStudioStore.setState({ applyPrompt: applySpy });
+    render(<PromptLibraryTabs />);
+    await userEvent.click(screen.getByRole("button", { name: /use/i }));
+    expect(applySpy).toHaveBeenCalled();
+    expect(routerPush).toHaveBeenCalledWith("/simple-studio/images");
+  });
+
+  it("shows empty state when no templates", () => {
+    useSimpleStudioStore.setState({ publicPrompts: [] });
+    render(<PromptLibraryTabs />);
+    expect(screen.getByText(/no templates yet/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no saved prompts", async () => {
+    useSimpleStudioStore.setState({ savedPrompts: [] });
+    render(<PromptLibraryTabs />);
+    await userEvent.click(screen.getByRole("tab", { name: /saved/i }));
+    expect(screen.getByText(/no saved prompts yet/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/PromptLibraryTabs.test.tsx`
+Expected: FAIL with "Cannot find module '../PromptLibraryTabs'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/components/simple-studio-shell/PromptLibraryTabs.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import {
+  useSimpleStudioStore,
+  type SavedPrompt,
+} from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+import { MODE_TO_URL_SEGMENT } from "./urlToMode";
+
+function PromptCard({
+  prompt,
+  onUse,
+}: {
+  prompt: SavedPrompt;
+  onUse: (p: SavedPrompt) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="font-medium text-sm">{prompt.name}</div>
+        <span className="text-xs rounded-full border px-2 py-0.5 text-muted-foreground">
+          {prompt.mode}
+        </span>
+      </div>
+      <div className="text-xs text-muted-foreground line-clamp-3">
+        {prompt.promptText}
+      </div>
+      <div className="pt-2">
+        <Button size="sm" onClick={() => onUse(prompt)}>
+          Use
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function PromptLibraryTabs() {
+  const router = useRouter();
+  const tab = useSimpleStudioShellStore((s) => s.promptLibraryTab);
+  const setTab = useSimpleStudioShellStore((s) => s.setPromptLibraryTab);
+
+  const savedPrompts = useSimpleStudioStore((s) => s.savedPrompts);
+  const publicPrompts = useSimpleStudioStore((s) => s.publicPrompts);
+  const loadSavedPrompts = useSimpleStudioStore((s) => s.loadSavedPrompts);
+  const loadPublicPrompts = useSimpleStudioStore((s) => s.loadPublicPrompts);
+  const applyPrompt = useSimpleStudioStore((s) => s.applyPrompt);
+
+  useEffect(() => {
+    void loadSavedPrompts();
+    void loadPublicPrompts();
+  }, [loadSavedPrompts, loadPublicPrompts]);
+
+  const handleUse = (prompt: SavedPrompt) => {
+    applyPrompt(prompt);
+    router.push(`/simple-studio/${MODE_TO_URL_SEGMENT[prompt.mode]}`);
+  };
+
+  return (
+    <div className="p-6">
+      <Tabs value={tab} onValueChange={(v) => setTab(v as "templates" | "saved")}>
+        <TabsList>
+          <TabsTrigger value="templates">Templates</TabsTrigger>
+          <TabsTrigger value="saved">Saved</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="templates">
+          {publicPrompts.length === 0 ? (
+            <div className="rounded-lg border p-12 text-center text-sm text-muted-foreground">
+              No templates yet.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {publicPrompts.map((p) => (
+                <PromptCard key={p.id} prompt={p} onUse={handleUse} />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="saved">
+          {savedPrompts.length === 0 ? (
+            <div className="rounded-lg border p-12 text-center text-sm text-muted-foreground">
+              No saved prompts yet. Save one from any creation page.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {savedPrompts.map((p) => (
+                <PromptCard key={p.id} prompt={p} onUse={handleUse} />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/components/simple-studio-shell/__tests__/PromptLibraryTabs.test.tsx`
+Expected: PASS, all 5 tests green.
+
+- [ ] **Step 5: Wire PromptLibraryTabs into the page**
+
+Replace `src/app/simple-studio/prompt-library/page.tsx` with:
+
+```tsx
+import { PromptLibraryTabs } from "@/components/simple-studio-shell/PromptLibraryTabs";
+
+export default function PromptLibraryPage() {
+  return <PromptLibraryTabs />;
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/simple-studio-shell/PromptLibraryTabs.tsx src/components/simple-studio-shell/__tests__/PromptLibraryTabs.test.tsx src/app/simple-studio/prompt-library/page.tsx
+git commit -m "feat(simple-studio): add PromptLibraryTabs with templates + saved"
+```
+
+---
+
+## Task 15: Full verification pass
+
+**Files:** none modified — this task runs the verification checklist from the spec.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test:run`
+Expected: all tests pass, including every new test from Tasks 1-14 plus all pre-existing tests.
+
+If any pre-existing test fails, compare against the baseline recorded in Prerequisites step 4. If the failure is new, investigate before proceeding.
+
+- [ ] **Step 2: Run lint**
+
+Run: `pnpm lint`
+Expected: no errors. Fix any lint errors in-place before proceeding (do not bypass).
+
+- [ ] **Step 3: Run a production build**
+
+Run: `pnpm build`
+Expected: build succeeds with no TypeScript errors.
+
+- [ ] **Step 4: Manual verification against spec checklist**
+
+Run: `pnpm dev`, then walk through every item in the spec's "Verification checklist (manual QA before merging PR 1)" section (items 1-14). For each item:
+- If the item passes, mark it off mentally.
+- If it fails, record the exact failure. Stop the verification pass and open a follow-up task before continuing.
+
+Key items to pay attention to:
+- Item 4: navigating between form routes updates `useSimpleStudioStore.mode` (verifiable in React DevTools — expand the store and watch `mode` change as you click nav items).
+- Item 6: generating an image/video/copy from a form route causes it to appear in `/simple-studio/library` under the right filter.
+- Item 8: if the `saved_prompts` table has any rows with `isPublic: true`, they show in the Templates tab. If not, empty state is visible.
+- Item 13: visiting `/studio/simple` still renders the legacy UI unchanged.
+
+- [ ] **Step 5: Commit verification notes (if needed)**
+
+If the verification pass reveals anything that needs documentation (e.g., a known issue to flag in the PR description), add a short note to a local file — don't touch committed code.
+
+- [ ] **Step 6: Push the branch**
+
+```bash
+git push -u origin feature/simple-studio-dashboard-shell
+```
+
+Do NOT open the PR yet. Tell the user the branch is pushed and the verification checklist has been walked. They will open the PR after confirming.
+
+---
+
+## Appendix A: PR 2 — Old code deletion (separate PR, NOT part of this plan)
+
+Per the spec, PR 2 is a separate follow-up that happens AFTER PR 1 has been merged and the verification window has passed. It is listed here for context only — do NOT execute it as part of this plan.
+
+PR 2 scope:
+1. Delete `src/app/studio/simple/page.tsx`, `src/app/studio/simple/SimpleStudioClient.tsx`, and `src/app/studio/simple/__tests__/`.
+2. Delete the entire `src/components/simple-studio/` directory after `grep -rn "from.*simple-studio/"` confirms no new files reference it.
+3. Recreate `src/app/studio/simple/page.tsx` with a redirect stub:
+   ```tsx
+   import { redirect } from "next/navigation";
+   export default function Page() {
+     redirect("/simple-studio/images");
+   }
+   ```
+4. Re-run the full verification checklist excluding item 13 (which tests the old UI).
+5. Commit and open PR 2 against `develop`.
+
+---
+
+## Appendix B: Known follow-ups
+
+These are out of scope for PR 1 and PR 2 but worth tracking as separate issues:
+
+- **Seed public prompt templates.** The Templates tab is empty until rows with `isPublic: true` exist in `saved_prompts`. Options: (a) SQL seed script in `scripts/db-seed.mjs`, (b) a one-off admin POST, (c) a dedicated seed route. Recommend option (a).
+- **Extract shared form primitives.** After PR 2 deletes the old `Sidebar.tsx`, extracting truly shared primitives (PromptTextarea, ModelPicker, ReferenceImageUpload) from the three new form components becomes safe. Not worth doing until then.
+- **Cost estimation.** `FormInfoPanel` currently shows a hardcoded batch count string as "Estimated cost". A real estimate would read from a pricing table keyed by `selectedModelId` + `batchCount` + `videoDuration`. Non-blocking — the current text is honest ("N images/videos/variants").
+- **Reference image upload in ImageForm/VideoForm.** The existing store supports `referenceImages` and `sourceImage`; wiring them into the new forms requires porting the drop-zone UI from the old `Sidebar.tsx` or writing fresh. Defer to a follow-up.
+- **Edit and delete saved prompts from PromptLibraryTabs.** The existing PATCH and DELETE endpoints exist; only the UI affordances are missing. Add in a follow-up once there's real user demand.
+- **Library preview modal, regenerate, delete actions.** LibraryGallery currently renders cards without click handlers. A detail modal with full resolution + actions is a natural follow-up.

--- a/docs/superpowers/specs/2026-04-06-simple-studio-dashboard-shell-design.md
+++ b/docs/superpowers/specs/2026-04-06-simple-studio-dashboard-shell-design.md
@@ -23,6 +23,8 @@ This spec describes a full rebuild of the simple-studio shell, mirroring the soc
   - `/simple-studio/prompt-library` — prompt templates + user-saved prompts.
 - **Form-first inline layout.** Each `/images`, `/videos`, `/copy` page renders the generation form as its main content (not in a drawer). The form occupies a center column and a right-side info panel shows aspect ratio picker, estimated cost, output example, and tips — matching the pattern used by tools like revid.ai. There is no drawer anywhere in the design.
 - **Library separation.** Past generations live on a dedicated `/simple-studio/library` route, not below or beside the form. This keeps the creation pages clean and single-purpose, and gives the library enough space to support mode filters and batch management.
+- **Reuse existing backend.** The project already has a `saved_prompts` table in Drizzle (`src/lib/db/schema.ts:1151`), a full CRUD API under `/api/studio/prompts` (list, create, update, delete, plus a `/public` variant for templates), and store actions on `useSimpleStudioStore` (`saveCurrentPrompt`, `loadSavedPrompts`, `loadPublicPrompts`, `applyPrompt`). The redesign reuses all of this unchanged — no new tables, no new routes, no duplication. "Templates" are simply saved prompts with `isPublic: true`, served by the existing public endpoint.
+- **URL-to-mode mapping.** The URL uses friendly English plurals — `/simple-studio/images`, `/videos`, `/copy` — while the internal mode enum stays `"photo" | "video" | "copy"` to match the existing store and DB enum. A small mapping in `SimpleStudioLayout` sets the correct mode on route change.
 - `AppSwitcher` gains a dedicated "Simple Studio" pillar entry alongside a renamed "Advanced Workflow" entry (formerly "AI Studio").
 
 ## Routing
@@ -71,13 +73,15 @@ src/components/simple-studio-shell/
   SimpleStudioAppSidebar.tsx
   SimpleStudioSiteHeader.tsx
   LibraryGallery.tsx
+  PromptLibraryTabs.tsx        templates + saved tabs for /prompt-library page
   SavePromptDialog.tsx
+  urlToMode.ts                 URL segment ↔ SimpleStudioMode mapping
   forms/
     FormPageLayout.tsx         shared 2-column shell (form body left, info panel right)
+    FormInfoPanel.tsx          aspect ratio + cost estimate + output example + tips
     ImageForm.tsx
     VideoForm.tsx
     CopyForm.tsx
-    FormInfoPanel.tsx          aspect ratio + cost estimate + output example + tips
 ```
 
 ### `SimpleStudioLayout.tsx` (client)
@@ -100,7 +104,8 @@ Thin wrapper over `SidebarProvider` + `SidebarInset`. Mirrors `SocialLayout.tsx`
 ```
 
 Also:
-- Hydrates prompt templates + saved prompts via `useSimpleStudioShellStore` on first mount (mirrors the `SocialLayout` `fetchAccounts` pattern using a `useRef` flag to avoid `useEffect`).
+- Watches `usePathname()` and calls `useSimpleStudioStore.setMode(modeFromPathname(pathname))` whenever the active route changes, so the store's internal mode stays in sync with the URL.
+- Triggers initial load of recent results via `useSimpleStudioStore.loadRecentResults()` on first mount (mirrors the `SocialLayout` `fetchAccounts` pattern using a `useRef` flag to avoid `useEffect`).
 - No keyboard shortcut for opening a drawer — forms are always visible inline, so there is nothing to toggle.
 
 ### `SimpleStudioAppSidebar.tsx` (client)
@@ -146,10 +151,10 @@ Mirrors `SocialSiteHeader.tsx`:
 
 A small shadcn `Dialog` used in two places:
 
-- Opened from the "Save prompt" ghost button on a form page — prefilled with the current form's prompt text and defaults. User confirms title and clicks Save. On success, dialog closes and a toast confirms.
-- Opened from the "New Saved Prompt" header button on `/simple-studio/prompt-library` — empty, user fills in title + prompt + kind. On success, dialog closes and the Saved tab refreshes (optimistically).
+- Opened from the "Save prompt" ghost button on a form page — the user enters a name and clicks Save. The dialog reads the current form state straight from `useSimpleStudioStore` and calls `saveCurrentPrompt(name)`, which posts to `/api/studio/prompts` and prepends the new row to `savedPrompts`.
+- Opened from the "New Saved Prompt" header button on `/simple-studio/prompt-library` — empty, user fills in name + prompt text. It sets the store's `prompt` and `mode` first, then calls `saveCurrentPrompt(name)` and refreshes the Saved tab.
 
-Calls `useSimpleStudioShellStore.saveSavedPrompt(input)`.
+The dialog's open state lives in `useSimpleStudioShellStore` (`savePromptDialogOpen`). All data operations go through the existing `useSimpleStudioStore` — this component does not talk to the API directly.
 
 ## Form components
 
@@ -215,134 +220,127 @@ New dedicated gallery route. Renders `LibraryGallery` as the main content:
 
 Renders a shadcn `Tabs` component with two tabs:
 
-- **Templates** (default) — grid of `PromptTemplate` cards. Each card shows title, description, prompt preview (first ~120 chars), kind badge, optional thumbnail, and a "Use" button. A kind filter (`All` / `Images` / `Videos` / `Copy`) filters the grid.
-- **Saved** — grid of the current user's saved prompts with edit and delete actions. Empty state: "No saved prompts yet" with a CTA to go generate and save one.
+- **Templates** (default) — grid of `SavedPrompt` cards where `isPublic === true`, loaded via `useSimpleStudioStore.loadPublicPrompts()`. Each card shows name, prompt text preview (first ~120 chars), mode badge, and a "Use" button. A mode filter (`All` / `Photo` / `Video` / `Copy`) filters the grid client-side. Empty state: "No templates yet" explaining that templates are coming soon (or seeded separately).
+- **Saved** — grid of the workspace's private saved prompts (`isPublic === false`), loaded via `useSimpleStudioStore.loadSavedPrompts()`. Each card has edit and delete actions. Empty state: "No saved prompts yet" with a CTA to go to a form page and save one.
 
-Clicking "Use" on a template or saved prompt calls `useSimpleStudioShellStore.applyTemplate(template)`, which:
-1. Writes the template's `prompt` and `defaults` into `useSimpleStudioStore` (matching the `kind`).
-2. Calls `router.push('/simple-studio/images' | '/videos' | '/copy')` based on `kind`.
+Clicking "Use" on any prompt (template or saved) calls:
+1. `useSimpleStudioStore.applyPrompt(prompt)` — writes the prompt's `mode`, `promptText`, and `formConfig` into the store.
+2. `router.push('/simple-studio/' + MODE_TO_URL_SEGMENT[prompt.mode])` — navigates to the corresponding form page.
 
-The target page already renders the form inline, so the prefilled fields are visible immediately on landing — no drawer to open, no extra click.
+The target form page already renders inline, so the prefilled fields are visible immediately on landing — no drawer to open, no extra click.
 
-## Data model & API
+Loading strategy: the prompt-library page calls `loadPublicPrompts()` and `loadSavedPrompts()` on mount. These are already throttled by the existing store (they don't refetch on every mount cycle in practice; plans can add a simple guard if needed).
 
-### Prompt templates (hardcoded, DB-shaped)
+## Data model & API — REUSE EXISTING
 
-```ts
-// src/lib/simple-studio/prompt-templates.ts
-export type PromptTemplateKind = 'image' | 'video' | 'copy';
+This redesign does NOT introduce any new database tables, API routes, or repository functions. Everything needed already exists and is reused unchanged.
 
-export interface PromptTemplate {
-  id: string;
-  kind: PromptTemplateKind;
-  title: string;
-  description: string;
-  prompt: string;
-  thumbnailUrl?: string;
-  defaults?: {
-    model?: string;
-    aspectRatio?: string;
-    tone?: string;
-    platform?: string;
-  };
-  tags?: string[];
-}
-
-export const PROMPT_TEMPLATES: PromptTemplate[] = [ /* ~15 curated entries */ ];
-```
-
-Served via `GET /api/simple-studio/templates`, which returns the in-memory array. Putting this behind an API boundary means migrating to a DB-backed store later only changes `route.ts`, not client code.
-
-Starter content: roughly 5 image templates, 5 video templates, 5 copy templates. Exact content TBD by whoever writes them; selection does not affect the architecture.
-
-### Saved prompts (Postgres via Drizzle)
-
-New table added to `src/lib/db/schema.ts`, referencing the existing Better Auth `user` table (exported as `user`, singular — not `users`):
+### Existing table: `saved_prompts` (`src/lib/db/schema.ts:1151`)
 
 ```ts
-export const simpleStudioSavedPrompts = pgTable('simple_studio_saved_prompts', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
-  kind: text('kind', { enum: ['image', 'video', 'copy'] }).notNull(),
-  title: text('title').notNull(),
-  prompt: text('prompt').notNull(),
-  defaults: jsonb('defaults').$type<PromptTemplate['defaults']>(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
-}, (t) => ({
-  userIdIdx: index('simple_studio_saved_prompts_user_id_idx').on(t.userId),
-}));
+export const savedPrompts = pgTable("saved_prompts", {
+  id: text("id").primaryKey(),
+  workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+  mode: savedPromptModeEnum("mode").notNull(), // "photo" | "video" | "copy"
+  name: text("name").notNull(),
+  promptText: text("prompt_text").notNull(),
+  formConfig: jsonb("form_config").$type<Record<string, unknown>>().default({}).notNull(),
+  isPublic: boolean("is_public").default(false).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at", { withTimezone: true }),
+}, (table) => ({ /* indexes */ }));
 ```
 
-Migration generated via Drizzle's standard `drizzle-kit generate` flow and committed to the project's Drizzle migrations directory. Cascade-on-user-delete because saved prompts are personal data that should follow the user.
+Key characteristics:
+- **Workspace-scoped, not user-scoped.** Matches the project's authz model — all prompts belong to a workspace, and access is gated by workspace membership via `authorizeStudioRequest`.
+- **Mode enum is `"photo" | "video" | "copy"`.** The spec's URL scheme uses `/images` for friendly English plural, but the internal mode is `"photo"`. A single constant in `SimpleStudioLayout` maps between the two.
+- **`isPublic` flag is the template mechanism.** A prompt with `isPublic: true` shows up in the Templates tab (via the public endpoint). A prompt with `isPublic: false` is private to the workspace and shows up in the Saved tab.
+- **Soft delete via `deletedAt`.** Existing routes and repository already handle this.
 
-Explicitly excluded from v1:
-- `tags` column.
-- `referenceImageUrl` column (reference image capture on save).
-- Sharing, folders, or categories.
-- Pagination.
+### Existing API routes
 
-### API routes
+All already implemented, tested, and wired into the old store. No changes needed:
 
 ```
-GET    /api/simple-studio/templates                 → PromptTemplate[]
-GET    /api/simple-studio/saved-prompts             → SavedPrompt[]
-POST   /api/simple-studio/saved-prompts             → SavedPrompt
-PATCH  /api/simple-studio/saved-prompts/[id]        → SavedPrompt
-DELETE /api/simple-studio/saved-prompts/[id]        → { ok: true }
+GET    /api/studio/prompts?mode=<photo|video|copy>   → workspace's saved prompts (src/app/api/studio/prompts/route.ts)
+POST   /api/studio/prompts                           → create (accepts isPublic)
+GET    /api/studio/prompts/public?mode=<mode>        → public prompts (templates) for Templates tab
+PATCH  /api/studio/prompts/[promptId]                → update
+DELETE /api/studio/prompts/[promptId]                → soft-delete
 ```
 
-All routes:
-- Use `getServerAuthSession` for auth. Return `401` with `{ error: 'Unauthorized' }` if no session.
-- On `PATCH` / `DELETE`, the `WHERE` clause includes `AND userId = :session.user.id`. If zero rows are affected, return `404` — do not leak existence of other users' rows.
-- Validate request bodies with Zod schemas (project already uses Zod in other routes; confirm and match style during planning).
-- `POST` body: `{ kind, title, prompt, defaults? }`. `PATCH` body: any subset of `{ title, prompt, defaults }` — `kind` is immutable.
+Authz lives in `src/lib/studio/authz.ts` (`authorizeStudioRequest`). Repository layer is `src/lib/studio/repository.ts` (`createPrompt`, `listPrompts`, etc.). Existing tests in `src/app/api/studio/prompts/__tests__/` and `src/app/api/studio/prompts/public/__tests__/` cover the routes.
+
+### Existing store actions (in `useSimpleStudioStore`)
+
+Also already wired — the new shell components call these directly:
+
+- `saveCurrentPrompt(name)` — POSTs `/api/studio/prompts` with the current form state as `formConfig`, prepends the result to `savedPrompts`.
+- `loadSavedPrompts()` — GETs `/api/studio/prompts?mode=<current mode>`.
+- `loadPublicPrompts()` — GETs `/api/studio/prompts/public?mode=<current mode>`.
+- `applyPrompt(prompt)` — writes `mode`, `prompt`, and all form fields from the given `SavedPrompt` into the store (used by the "Use" button on both tabs).
+
+### Templates seed content — out of scope
+
+The Templates tab will be empty on first load until public prompts exist in the database. Seeding the curated starter set of public prompts is explicitly out of scope for PR 1 and is tracked as a follow-up — either a SQL seed script, a one-off admin POST with `isPublic: true`, or a dedicated seed route. The Templates tab shows a clear empty state ("No templates yet") when there are none.
 
 ## State management
 
-### New `useSimpleStudioShellStore`
+### New `useSimpleStudioShellStore` — UI state only
 
-Separate from the existing `useSimpleStudioStore` because the shell's concerns (templates, saved prompts, save-dialog state, use-template navigation) are independent of the form/generation state:
+Because all data operations (templates, saved prompts, generations) already live in `useSimpleStudioStore`, the new shell store is drastically thinner than earlier spec drafts. It owns only UI state that the existing store does not need to know about:
 
 ```ts
 interface SimpleStudioShellState {
-  // Save prompt dialog
+  // SavePromptDialog open state (shared between form pages and prompt-library page)
   savePromptDialogOpen: boolean;
-  savePromptDialogSeed: Partial<SavedPromptInput> | null;
-  openSavePromptDialog: (seed?: Partial<SavedPromptInput>) => void;
+  openSavePromptDialog: () => void;
   closeSavePromptDialog: () => void;
 
-  // Library filter (syncs with URL ?mode=...)
-  libraryModeFilter: 'all' | 'image' | 'video' | 'copy';
-  setLibraryModeFilter: (mode: 'all' | 'image' | 'video' | 'copy') => void;
+  // Library mode filter (syncs with URL ?mode=... on /simple-studio/library)
+  libraryModeFilter: 'all' | 'photo' | 'video' | 'copy';
+  setLibraryModeFilter: (mode: 'all' | 'photo' | 'video' | 'copy') => void;
 
-  // Templates
-  templates: PromptTemplate[];
-  templatesLoaded: boolean;
-  hydrateTemplates: () => Promise<void>;
-
-  // Saved prompts
-  savedPrompts: SavedPrompt[];
-  savedPromptsLoaded: boolean;
-  hydrateSavedPrompts: () => Promise<void>;
-  saveSavedPrompt: (input: SavedPromptInput) => Promise<void>;   // optimistic
-  updateSavedPrompt: (id: string, patch: Partial<SavedPromptInput>) => Promise<void>;
-  deleteSavedPrompt: (id: string) => Promise<void>;              // optimistic
-
-  // Apply-template flow
-  applyTemplate: (template: PromptTemplate | SavedPrompt) => void; // writes to simpleStudioStore + router.push
+  // Prompt Library active tab
+  promptLibraryTab: 'templates' | 'saved';
+  setPromptLibraryTab: (tab: 'templates' | 'saved') => void;
 }
 ```
 
-Optimistic updates on `saveSavedPrompt` and `deleteSavedPrompt`: apply the change locally immediately, call the API, rollback on failure with a toast.
+That's the entire store. No API calls, no templates, no saved-prompts array, no optimistic update logic. All of that already exists in `useSimpleStudioStore`.
 
-Note: no `createDrawerOpen` state — the design has no drawer. The `savePromptDialog*` state is the only UI-overlay state in this store.
+### `useSimpleStudioStore` — reused directly, NOT touched
 
-### `useSimpleStudioStore` — untouched for PR 1
+The existing store continues to power both the old `/studio/simple` page AND the new shell's forms, galleries, and prompt library. The new shell components call its existing actions (`generate`, `saveCurrentPrompt`, `loadSavedPrompts`, `loadPublicPrompts`, `applyPrompt`, etc.) directly — no wrapper, no proxy, no parallel state.
 
-No changes. The old store continues to power both the old `/studio/simple` page AND the new per-mode forms. This is intentional: keeping the generation state machine exactly as-is minimizes regression risk.
+The store's `mode` field is still authoritative. On route change within the simple studio shell, `SimpleStudioLayout` calls `setMode()` with the mapped mode (see URL-to-mode mapping below).
 
-Under the new shell, the old store's `mode` field becomes vestigial (the route implies the mode). It stays in the store for PR 1 so the old page keeps working and can be removed or repurposed in PR 2 or a later follow-up.
+### URL-to-mode mapping
+
+```ts
+// src/components/simple-studio-shell/urlToMode.ts
+import type { SimpleStudioMode } from '@/store/simpleStudioStore';
+
+export const URL_SEGMENT_TO_MODE: Record<string, SimpleStudioMode> = {
+  images: 'photo',
+  videos: 'video',
+  copy: 'copy',
+};
+
+export const MODE_TO_URL_SEGMENT: Record<SimpleStudioMode, string> = {
+  photo: 'images',
+  video: 'videos',
+  copy: 'copy',
+};
+
+export function modeFromPathname(pathname: string): SimpleStudioMode | null {
+  const match = pathname.match(/^\/simple-studio\/(images|videos|copy)(\/|$)/);
+  return match ? URL_SEGMENT_TO_MODE[match[1]] ?? null : null;
+}
+```
+
+`SimpleStudioLayout` watches the pathname and calls `useSimpleStudioStore.setMode(...)` whenever the route mode changes. `applyPrompt` continues to set the mode internally when a template is applied, so navigation after apply uses `MODE_TO_URL_SEGMENT[prompt.mode]`.
 
 ## AppSwitcher updates
 
@@ -392,21 +390,18 @@ The existing `pathname?.startsWith(item.href + "/")` active-state logic already 
 ### Store tests
 
 - `src/store/__tests__/simpleStudioShellStore.test.ts`:
-  - `openSavePromptDialog` / `closeSavePromptDialog` toggle state and seed data.
-  - `setLibraryModeFilter` updates state.
-  - `hydrateTemplates` populates from a mocked `fetch`.
-  - `saveSavedPrompt` applies optimistically and rolls back on API failure.
-  - `applyTemplate` writes to `simpleStudioStore` and navigates via mocked `router.push`.
+  - `openSavePromptDialog` / `closeSavePromptDialog` toggle `savePromptDialogOpen`.
+  - `setLibraryModeFilter` updates state correctly for all four values.
+  - `setPromptLibraryTab` updates state between `templates` and `saved`.
+
+- `src/components/simple-studio-shell/__tests__/urlToMode.test.ts`:
+  - `modeFromPathname` returns the correct mode for each route.
+  - `modeFromPathname` returns `null` for non-form routes (library, prompt-library, root).
+  - `URL_SEGMENT_TO_MODE` and `MODE_TO_URL_SEGMENT` are inverses of each other for all three modes.
 
 ### API route tests
 
-- `src/app/api/simple-studio/templates/__tests__/route.test.ts` — returns array shape and length > 0.
-- `src/app/api/simple-studio/saved-prompts/__tests__/route.test.ts`:
-  - `401` without session on every verb.
-  - `POST` creates a row with `userId` from the session.
-  - `GET` returns only the session user's rows.
-  - `PATCH` and `DELETE` enforce ownership (`user A` gets `404` when targeting `user B`'s row).
-  - `POST` with invalid body returns `400`.
+No new API route tests. The existing tests under `src/app/api/studio/prompts/__tests__/` and `src/app/api/studio/prompts/public/__tests__/` already cover the routes this redesign uses, and those routes are not being modified.
 
 ### Explicitly untested
 
@@ -423,17 +418,17 @@ All tests under `src/app/studio/simple/__tests__/` stay untouched for PR 1 and a
 
 1. `/simple-studio` redirects to `/simple-studio/images`.
 2. All 5 sidebar nav items (Images, Videos, Copy, Library, Prompt Library) load and highlight correctly, grouped as Create / Browse.
-3. AppSwitcher dropdown shows "Simple Studio" and "Advanced Workflow" as separate entries; current route lights up.
-4. Each of `/images`, `/videos`, `/copy` renders the form inline with the info panel on the right (desktop) or stacked (mobile).
-5. Generate an image / video / copy from each respective form — progress appears in the info panel's "Output Example" area, and the result appears inline once complete.
-6. Clicking "View all in Library" from an inline result navigates to `/simple-studio/library` with the correct mode filter active.
-7. Library page shows all past generations with the correct filter; filter pills in the site header match.
-8. Prompt Library Templates tab: click a template → navigates to the correct form route (images/videos/copy), form fields are prefilled on arrival, no extra click required.
-9. "Save prompt" button on a form page opens `SavePromptDialog` prefilled with the current prompt text; saving adds it to the Saved tab.
-10. "New Saved Prompt" button on `/simple-studio/prompt-library` opens `SavePromptDialog` with empty fields; saving adds it to the Saved tab.
-11. Delete a saved prompt → removed from list (optimistic) and persists on reload.
-12. Sign out, sign in as a different user → previous user's saved prompts are not visible (ownership enforced).
-13. Old `/studio/simple` route still loads, renders the legacy UI, and is functionally untouched.
+3. AppSwitcher dropdown shows "Simple Studio" and "Advanced Workflow" as separate entries; current route lights up for any `/simple-studio/*` sub-route.
+4. Navigating between `/images`, `/videos`, `/copy` sets the correct internal mode in `useSimpleStudioStore` (verifiable via React DevTools or by observing model picker contents change).
+5. Each form route renders the form inline with the info panel on the right (desktop) or stacked (mobile).
+6. Generate an image / video / copy from each respective form — progress appears in the info panel's "Output Example" area, and the result appears inline once complete. Confirm the same generation appears in `/simple-studio/library`.
+7. Library page shows all past generations with the correct mode filter; filter pills in the site header match and URL query param updates.
+8. Prompt Library Templates tab: if the `saved_prompts` table contains rows with `isPublic: true` for the current mode, they appear. If not, the empty state is visible. Clicking "Use" on a template navigates to the correct form route (via `MODE_TO_URL_SEGMENT[prompt.mode]`) and prefills the form.
+9. "Save prompt" button on a form page opens `SavePromptDialog`. Entering a name and clicking Save calls `saveCurrentPrompt`, which POSTs to `/api/studio/prompts`, and the new prompt appears in the Saved tab immediately.
+10. "New Saved Prompt" button on `/simple-studio/prompt-library` opens `SavePromptDialog` with empty fields. Filling in name + prompt + mode and saving calls `saveCurrentPrompt` after seeding the store, and the prompt appears in the Saved tab.
+11. Delete a saved prompt → removed from list and persists on reload (the existing DELETE endpoint handles this).
+12. Switching workspaces (if applicable) shows that workspace's saved prompts only (existing workspace scoping verified to still work through the new UI).
+13. Old `/studio/simple` route still loads, renders the legacy UI, and is functionally untouched — the existing integration tests in `src/app/studio/simple/__tests__/` still pass.
 14. `pnpm test:run` passes, `pnpm lint` passes, `pnpm build` succeeds.
 
 ## Delivery plan
@@ -441,8 +436,10 @@ All tests under `src/app/studio/simple/__tests__/` stay untouched for PR 1 and a
 Two PRs against `develop`:
 
 **PR 1 — Build new shell in parallel.**
-- All new files and the `AppSwitcher` update.
-- Drizzle schema + generated migration for `simple_studio_saved_prompts`.
+- All new files (shell components, forms, pages, shell store, URL-to-mode mapping).
+- `AppSwitcher` update.
+- NO new DB schema, NO new API routes, NO new migrations — existing `/api/studio/prompts` infrastructure is reused unchanged.
+- `useSimpleStudioStore` is NOT modified.
 - All tests listed in the Testing strategy section.
 - Old `/studio/simple` tree is NOT touched.
 - Merged after the full verification checklist passes.
@@ -460,11 +457,13 @@ Two PRs keep rollback cheap: if PR 1 is in production and a regression surfaces,
 
 - Refactoring the old `Sidebar.tsx` to extract shared primitives before deletion.
 - Admin UI for managing prompt templates.
+- Seeding public prompt templates into the database (tracked as follow-up — templates tab shows empty state until seeded).
+- Any modification to the `saved_prompts` schema, existing API routes, or `useSimpleStudioStore`.
+- New DB tables or migrations of any kind.
 - Tags, folders, or categories on saved prompts.
-- Reference image capture in saved prompts.
-- Sharing saved prompts between users or organizations.
+- Sharing saved prompts across workspaces.
 - Import / export of prompt libraries.
-- Pagination of saved prompts endpoint.
+- Pagination on saved prompts endpoint (the existing endpoint does not paginate; v1 inherits this limitation).
 - A `/simple-studio` landing page beyond the redirect.
 - Touching the advanced workflow editor at `/studio/[[...projectId]]`.
 - Porting the mobile `MobileProgress` floating bar (replaced by inline info-panel progress).

--- a/docs/superpowers/specs/2026-04-06-simple-studio-dashboard-shell-design.md
+++ b/docs/superpowers/specs/2026-04-06-simple-studio-dashboard-shell-design.md
@@ -1,0 +1,473 @@
+# Simple Studio — Dashboard Shell Redesign
+
+**Date:** 2026-04-06
+**Status:** Design approved, pending implementation plan
+**Scope:** Replace the bespoke `/studio/simple` shell with a sidebar+header dashboard shell that matches the pattern used by `/social/*`, and split the single-page simple studio into five dedicated routes (Images, Videos, Copy, Library, Prompt Library) under a new top-level `/simple-studio` path. Forms render inline as the main content on each creation route — no drawer pattern.
+
+## Motivation
+
+The current `/studio/simple` page uses a bespoke two-panel layout (a 380 px left `<aside>` containing the generation form and a right-side results gallery wrapped in a custom `<Header />`). It does not share the dashboard shell pattern used elsewhere in the app, does not integrate with `AppSwitcher` from a sidebar, and conflates three distinct generation modes (photo/video/copy) into one page via internal tabs. This makes navigation and discoverability worse than the equivalent `/social` pillar, which already uses `SidebarProvider` + `SidebarInset` + `SocialAppSidebar` + `SocialSiteHeader`.
+
+This spec describes a full rebuild of the simple-studio shell, mirroring the social pattern, with the old route preserved in parallel during development and deleted in a second follow-up PR after verification.
+
+## High-level architecture
+
+- New top-level URL: `/simple-studio/*` (kebab-case, matching existing route conventions).
+- `/studio` becomes strictly the advanced node editor. Simple-studio no longer lives under `/studio`.
+- New shell mirrors `SocialLayout` + `SocialAppSidebar` + `SocialSiteHeader` (`SidebarProvider` + `SidebarInset`, same CSS vars for `--sidebar-width` and `--header-height`).
+- Five child routes:
+  - `/simple-studio/images` — image generation (form-first page).
+  - `/simple-studio/videos` — video generation (form-first page).
+  - `/simple-studio/copy` — text/copy generation (form-first page).
+  - `/simple-studio/library` — gallery of all past generations across all modes, with mode filter.
+  - `/simple-studio/prompt-library` — prompt templates + user-saved prompts.
+- **Form-first inline layout.** Each `/images`, `/videos`, `/copy` page renders the generation form as its main content (not in a drawer). The form occupies a center column and a right-side info panel shows aspect ratio picker, estimated cost, output example, and tips — matching the pattern used by tools like revid.ai. There is no drawer anywhere in the design.
+- **Library separation.** Past generations live on a dedicated `/simple-studio/library` route, not below or beside the form. This keeps the creation pages clean and single-purpose, and gives the library enough space to support mode filters and batch management.
+- `AppSwitcher` gains a dedicated "Simple Studio" pillar entry alongside a renamed "Advanced Workflow" entry (formerly "AI Studio").
+
+## Routing
+
+### New routes
+
+```
+src/app/simple-studio/
+  layout.tsx                  server: auth gate + <SimpleStudioLayout> shell wrapper
+  page.tsx                    redirect('/simple-studio/images')
+  images/page.tsx
+  videos/page.tsx
+  copy/page.tsx
+  library/page.tsx
+  prompt-library/page.tsx
+```
+
+The `layout.tsx` server component:
+- Calls `getServerAuthSession(await headers())` and redirects unauthenticated users to `/sign-in?next=%2Fsimple-studio%2Fimages` (same pattern as `src/app/social/layout.tsx`).
+- Renders `<SimpleStudioLayout>{children}</SimpleStudioLayout>` on success.
+
+No route groups are needed — because the new routes live at a different top-level path (`/simple-studio` not `/studio/simple`), they naturally do not interact with the old code.
+
+### Old `/studio/simple` route lifecycle
+
+1. **During development (PR 1):** `src/app/studio/simple/` is 100% untouched. `/studio/simple` continues to render the existing `SimpleStudioClient.tsx`. New routes at `/simple-studio/*` are built in parallel.
+2. **Verification window:** Both UIs live in production simultaneously. Users can reach the old UI only by direct URL; nothing in the new shell links to it.
+3. **Cleanup (PR 2, after verification):**
+   - Delete `src/app/studio/simple/page.tsx`, `src/app/studio/simple/SimpleStudioClient.tsx`, and `src/app/studio/simple/__tests__/`.
+   - Delete the entire `src/components/simple-studio/` directory (`Sidebar.tsx`, `ResultsGallery.tsx`, `GenerationCard.tsx`, `PromptLibrary.tsx`) — grep-check first for unexpected consumers.
+   - Replace `src/app/studio/simple/page.tsx` with a minimal redirect stub:
+     ```ts
+     import { redirect } from 'next/navigation';
+     export default function Page() { redirect('/simple-studio/images'); }
+     ```
+   - Keeps old bookmarks working.
+   - Update any `docs/` or `README.md` references.
+
+## Shell components
+
+All new components live in `src/components/simple-studio-shell/`, named after their social counterparts for consistency:
+
+```
+src/components/simple-studio-shell/
+  SimpleStudioLayout.tsx
+  SimpleStudioAppSidebar.tsx
+  SimpleStudioSiteHeader.tsx
+  LibraryGallery.tsx
+  SavePromptDialog.tsx
+  forms/
+    FormPageLayout.tsx         shared 2-column shell (form body left, info panel right)
+    ImageForm.tsx
+    VideoForm.tsx
+    CopyForm.tsx
+    FormInfoPanel.tsx          aspect ratio + cost estimate + output example + tips
+```
+
+### `SimpleStudioLayout.tsx` (client)
+
+Thin wrapper over `SidebarProvider` + `SidebarInset`. Mirrors `SocialLayout.tsx`:
+
+```tsx
+<SidebarProvider
+  style={{
+    "--sidebar-width": "calc(var(--spacing) * 64)",
+    "--header-height": "calc(var(--spacing) * 12)",
+  } as React.CSSProperties}
+>
+  <SimpleStudioAppSidebar variant="inset" />
+  <SidebarInset>
+    <SimpleStudioSiteHeader />
+    <div className="flex flex-1 flex-col">{children}</div>
+  </SidebarInset>
+</SidebarProvider>
+```
+
+Also:
+- Hydrates prompt templates + saved prompts via `useSimpleStudioShellStore` on first mount (mirrors the `SocialLayout` `fetchAccounts` pattern using a `useRef` flag to avoid `useEffect`).
+- No keyboard shortcut for opening a drawer — forms are always visible inline, so there is nothing to toggle.
+
+### `SimpleStudioAppSidebar.tsx` (client)
+
+Mirrors `SocialAppSidebar.tsx`:
+
+- **Header:** `AppSwitcher` trigger showing a `PaletteIcon` + "Simple Studio".
+- **Navigation group — Create (`SidebarGroupLabel="Create"`):**
+  - Images → `/simple-studio/images` (`ImageIcon`)
+  - Videos → `/simple-studio/videos` (`VideoIcon`)
+  - Copy → `/simple-studio/copy` (`FileTextIcon`)
+- **Separator**
+- **Navigation group — Browse (`SidebarGroupLabel="Browse"`):**
+  - Library → `/simple-studio/library` (`GalleryThumbnailsIcon` or `ImagesIcon`)
+  - Prompt Library → `/simple-studio/prompt-library` (`BookmarkIcon`)
+- **Footer:** `<NavUser user={...} />` with `authClient.useSession()`.
+- `collapsible="offcanvas"`, `variant="inset"`, same active-state detection (`pathname === item.href || pathname?.startsWith(item.href + "/")`).
+- No "Advanced Workflow" sidebar item — that link lives exclusively in the `AppSwitcher` dropdown.
+
+Grouping Create/Browse visually separates "making new things" from "browsing what exists" and keeps related items clustered.
+
+### `SimpleStudioSiteHeader.tsx` (client)
+
+Mirrors `SocialSiteHeader.tsx`:
+
+- `SidebarTrigger` on the left, vertical separator, page title.
+- Title sourced from a `PAGE_TITLES` record mapped by pathname:
+  ```ts
+  const PAGE_TITLES: Record<string, string> = {
+    "/simple-studio/images": "Images",
+    "/simple-studio/videos": "Videos",
+    "/simple-studio/copy": "Copy",
+    "/simple-studio/library": "Library",
+    "/simple-studio/prompt-library": "Prompt Library",
+  };
+  ```
+- Right-aligned action area (varies by route):
+  - `/simple-studio/images`, `/videos`, `/copy`: no primary action button. The Generate button lives inside the form itself, which is always visible on these pages. A secondary ghost "Save prompt" button may appear when the form has prompt text — it opens `SavePromptDialog` prefilled with the current form state.
+  - `/simple-studio/library`: a `BatchFilter` pill group (All / Images / Videos / Copy).
+  - `/simple-studio/prompt-library`: "New Saved Prompt" button that opens `SavePromptDialog` with empty fields.
+
+### `SavePromptDialog.tsx` (client)
+
+A small shadcn `Dialog` used in two places:
+
+- Opened from the "Save prompt" ghost button on a form page — prefilled with the current form's prompt text and defaults. User confirms title and clicks Save. On success, dialog closes and a toast confirms.
+- Opened from the "New Saved Prompt" header button on `/simple-studio/prompt-library` — empty, user fills in title + prompt + kind. On success, dialog closes and the Saved tab refreshes (optimistically).
+
+Calls `useSimpleStudioShellStore.saveSavedPrompt(input)`.
+
+## Form components
+
+Three fresh per-mode forms under `src/components/simple-studio-shell/forms/`, rendered inline as the main content of their respective route pages. The existing `src/components/simple-studio/Sidebar.tsx` (the old monolithic form) is NOT touched during PR 1 — it is deleted wholesale in PR 2 after the new forms are verified.
+
+All three forms read/write the existing `useSimpleStudioStore` (not the new shell store). This keeps form state, generation state, and batch tracking exactly as they are today, which minimizes the risk surface.
+
+### Shared layout: `FormPageLayout.tsx`
+
+A reusable 2-column layout used by all three form pages:
+
+```tsx
+<FormPageLayout infoPanel={<FormInfoPanel ... />}>
+  {/* form body */}
+</FormPageLayout>
+```
+
+- **Left column (main):** `max-w-2xl` centered, contains the form body and the prominent Generate button.
+- **Right column (`w-80` fixed):** `FormInfoPanel` with aspect ratio picker, batch count, estimated cost, output example, model-specific tips.
+- On viewports below the `lg` breakpoint, the info panel stacks above the form body instead of sitting beside it.
+- When generation is in flight, the info panel's "Output Example" area flips to an in-progress state showing per-item progress cards (replaces the old page's `MobileProgress` floating bar with something that always lives in the same spot).
+
+### Per-form concerns
+
+- **`ImageForm.tsx`** — prompt textarea, model picker (filtered to image-capable models), optional reference image upload. Sends aspect ratio and batch count from the info panel via the shared store.
+- **`VideoForm.tsx`** — prompt textarea, model picker (video-capable), duration picker, optional reference image upload. Aspect ratio + batch count from info panel.
+- **`CopyForm.tsx`** — prompt textarea, LLM model picker, tone, platform. Batch count from info panel (aspect ratio hidden — not meaningful for text).
+
+`FormInfoPanel.tsx` accepts props for which controls to show (`{ aspectRatios, batchPresets, outputExample, tips }`) so the three forms can customize without duplicating the panel shell.
+
+Some visual duplication between the three form bodies is acceptable beyond `FormPageLayout` and `FormInfoPanel`; further extraction of shared primitives is explicitly deferred to a follow-up PR after PR 2's cleanup.
+
+Each form's submit handler calls the existing `useSimpleStudioStore.generate()` action. After successful submit, the form does NOT navigate — the info panel flips to a progress view and, when complete, shows the latest results inline with a "View all in Library" link to `/simple-studio/library`.
+
+## Page content
+
+### `/simple-studio/images`, `/videos`, `/copy`
+
+Each route's `page.tsx` is a thin client component that renders the corresponding form inside the shared layout:
+
+```tsx
+// /simple-studio/images/page.tsx
+export default function ImagesPage() {
+  return <ImageForm />;
+}
+```
+
+`ImageForm` internally wraps its body in `FormPageLayout` and passes the appropriate `FormInfoPanel` config. The form is the entire page content below the `SimpleStudioSiteHeader` — there is no separate gallery section on these pages.
+
+### `/simple-studio/library`
+
+New dedicated gallery route. Renders `LibraryGallery` as the main content:
+
+- Filter pills: All / Images / Videos / Copy (syncs with the `BatchFilter` in the site header for this route).
+- Grid of past generations from `useSimpleStudioStore.generations`, sorted newest-first, grouped visually by batch.
+- Click a card to open a preview modal with full resolution, prompt text, regenerate button, and delete button.
+- Empty state: "No generations yet" with buttons linking to `/simple-studio/images`, `/videos`, `/copy`.
+- Image and video results render as media thumbnails; copy results render as text cards with truncated content.
+
+`LibraryGallery.tsx` reads from `useSimpleStudioStore.generations` and applies `useSimpleStudioShellStore.libraryModeFilter`. The old `src/components/simple-studio/ResultsGallery.tsx` is not reused — it stays untouched for PR 1 and is deleted in PR 2.
+
+### `/simple-studio/prompt-library`
+
+Renders a shadcn `Tabs` component with two tabs:
+
+- **Templates** (default) — grid of `PromptTemplate` cards. Each card shows title, description, prompt preview (first ~120 chars), kind badge, optional thumbnail, and a "Use" button. A kind filter (`All` / `Images` / `Videos` / `Copy`) filters the grid.
+- **Saved** — grid of the current user's saved prompts with edit and delete actions. Empty state: "No saved prompts yet" with a CTA to go generate and save one.
+
+Clicking "Use" on a template or saved prompt calls `useSimpleStudioShellStore.applyTemplate(template)`, which:
+1. Writes the template's `prompt` and `defaults` into `useSimpleStudioStore` (matching the `kind`).
+2. Calls `router.push('/simple-studio/images' | '/videos' | '/copy')` based on `kind`.
+
+The target page already renders the form inline, so the prefilled fields are visible immediately on landing — no drawer to open, no extra click.
+
+## Data model & API
+
+### Prompt templates (hardcoded, DB-shaped)
+
+```ts
+// src/lib/simple-studio/prompt-templates.ts
+export type PromptTemplateKind = 'image' | 'video' | 'copy';
+
+export interface PromptTemplate {
+  id: string;
+  kind: PromptTemplateKind;
+  title: string;
+  description: string;
+  prompt: string;
+  thumbnailUrl?: string;
+  defaults?: {
+    model?: string;
+    aspectRatio?: string;
+    tone?: string;
+    platform?: string;
+  };
+  tags?: string[];
+}
+
+export const PROMPT_TEMPLATES: PromptTemplate[] = [ /* ~15 curated entries */ ];
+```
+
+Served via `GET /api/simple-studio/templates`, which returns the in-memory array. Putting this behind an API boundary means migrating to a DB-backed store later only changes `route.ts`, not client code.
+
+Starter content: roughly 5 image templates, 5 video templates, 5 copy templates. Exact content TBD by whoever writes them; selection does not affect the architecture.
+
+### Saved prompts (Postgres via Drizzle)
+
+New table added to `src/lib/db/schema.ts`, referencing the existing Better Auth `user` table (exported as `user`, singular — not `users`):
+
+```ts
+export const simpleStudioSavedPrompts = pgTable('simple_studio_saved_prompts', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+  kind: text('kind', { enum: ['image', 'video', 'copy'] }).notNull(),
+  title: text('title').notNull(),
+  prompt: text('prompt').notNull(),
+  defaults: jsonb('defaults').$type<PromptTemplate['defaults']>(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+}, (t) => ({
+  userIdIdx: index('simple_studio_saved_prompts_user_id_idx').on(t.userId),
+}));
+```
+
+Migration generated via Drizzle's standard `drizzle-kit generate` flow and committed to the project's Drizzle migrations directory. Cascade-on-user-delete because saved prompts are personal data that should follow the user.
+
+Explicitly excluded from v1:
+- `tags` column.
+- `referenceImageUrl` column (reference image capture on save).
+- Sharing, folders, or categories.
+- Pagination.
+
+### API routes
+
+```
+GET    /api/simple-studio/templates                 → PromptTemplate[]
+GET    /api/simple-studio/saved-prompts             → SavedPrompt[]
+POST   /api/simple-studio/saved-prompts             → SavedPrompt
+PATCH  /api/simple-studio/saved-prompts/[id]        → SavedPrompt
+DELETE /api/simple-studio/saved-prompts/[id]        → { ok: true }
+```
+
+All routes:
+- Use `getServerAuthSession` for auth. Return `401` with `{ error: 'Unauthorized' }` if no session.
+- On `PATCH` / `DELETE`, the `WHERE` clause includes `AND userId = :session.user.id`. If zero rows are affected, return `404` — do not leak existence of other users' rows.
+- Validate request bodies with Zod schemas (project already uses Zod in other routes; confirm and match style during planning).
+- `POST` body: `{ kind, title, prompt, defaults? }`. `PATCH` body: any subset of `{ title, prompt, defaults }` — `kind` is immutable.
+
+## State management
+
+### New `useSimpleStudioShellStore`
+
+Separate from the existing `useSimpleStudioStore` because the shell's concerns (templates, saved prompts, save-dialog state, use-template navigation) are independent of the form/generation state:
+
+```ts
+interface SimpleStudioShellState {
+  // Save prompt dialog
+  savePromptDialogOpen: boolean;
+  savePromptDialogSeed: Partial<SavedPromptInput> | null;
+  openSavePromptDialog: (seed?: Partial<SavedPromptInput>) => void;
+  closeSavePromptDialog: () => void;
+
+  // Library filter (syncs with URL ?mode=...)
+  libraryModeFilter: 'all' | 'image' | 'video' | 'copy';
+  setLibraryModeFilter: (mode: 'all' | 'image' | 'video' | 'copy') => void;
+
+  // Templates
+  templates: PromptTemplate[];
+  templatesLoaded: boolean;
+  hydrateTemplates: () => Promise<void>;
+
+  // Saved prompts
+  savedPrompts: SavedPrompt[];
+  savedPromptsLoaded: boolean;
+  hydrateSavedPrompts: () => Promise<void>;
+  saveSavedPrompt: (input: SavedPromptInput) => Promise<void>;   // optimistic
+  updateSavedPrompt: (id: string, patch: Partial<SavedPromptInput>) => Promise<void>;
+  deleteSavedPrompt: (id: string) => Promise<void>;              // optimistic
+
+  // Apply-template flow
+  applyTemplate: (template: PromptTemplate | SavedPrompt) => void; // writes to simpleStudioStore + router.push
+}
+```
+
+Optimistic updates on `saveSavedPrompt` and `deleteSavedPrompt`: apply the change locally immediately, call the API, rollback on failure with a toast.
+
+Note: no `createDrawerOpen` state — the design has no drawer. The `savePromptDialog*` state is the only UI-overlay state in this store.
+
+### `useSimpleStudioStore` — untouched for PR 1
+
+No changes. The old store continues to power both the old `/studio/simple` page AND the new per-mode forms. This is intentional: keeping the generation state machine exactly as-is minimizes regression risk.
+
+Under the new shell, the old store's `mode` field becomes vestigial (the route implies the mode). It stays in the store for PR 1 so the old page keeps working and can be removed or repurposed in PR 2 or a later follow-up.
+
+## AppSwitcher updates
+
+Current `src/components/AppSwitcher.tsx` pillar list:
+
+```tsx
+const PILLAR_ITEMS = [
+  { href: "/studio",          label: "AI Studio",    icon: PaletteIcon },
+  { href: "/editor/projects", label: "Video Editor", icon: VideoIcon },
+  { href: "/social",          label: "Social Hub",   icon: ActivityIcon },
+  { href: "/analytics",       label: "Analytics",    icon: BarChart3Icon },
+]
+```
+
+New pillar list:
+
+```tsx
+const PILLAR_ITEMS = [
+  { href: "/simple-studio/images", label: "Simple Studio",     icon: PaletteIcon },
+  { href: "/studio",               label: "Advanced Workflow", icon: WorkflowIcon },
+  { href: "/editor/projects",      label: "Video Editor",      icon: VideoIcon },
+  { href: "/social",               label: "Social Hub",        icon: ActivityIcon },
+  { href: "/analytics",            label: "Analytics",         icon: BarChart3Icon },
+]
+```
+
+The existing `pathname?.startsWith(item.href + "/")` active-state logic already handles `/simple-studio/*` sub-routes. No other logic changes.
+
+## Mobile behavior
+
+- Nav sidebar uses `collapsible="offcanvas"` (same as social) — collapses to a hamburger on mobile via `SidebarTrigger`.
+- `FormPageLayout` stacks its two columns vertically below the `lg` breakpoint: info panel first (aspect ratio, cost estimate, output example), form body below. This keeps the most-scanned content at the top of the viewport where users look first, and lets the prompt textarea sit just above the keyboard when focused.
+- `LibraryGallery` uses a responsive grid (2 columns on mobile, 3-4 on desktop).
+- `BatchFilter` in the site header collapses to a single dropdown on mobile to save horizontal space.
+- The old page's bespoke `MobileProgress` floating bar is NOT ported — progress feedback lives inside `FormInfoPanel`'s "Output Example" area, which is always visible on mobile (since it stacks above the form body) and naturally replaces itself with live generation progress while the user waits.
+
+## Testing strategy
+
+### Unit / component tests
+
+- `src/components/simple-studio-shell/__tests__/SimpleStudioAppSidebar.test.tsx` — renders 5 nav items grouped as Create / Browse, active state matches mocked `usePathname`, AppSwitcher trigger present.
+- `src/components/simple-studio-shell/__tests__/SimpleStudioSiteHeader.test.tsx` — title derives from pathname, library route shows `BatchFilter`, prompt-library route shows "New Saved Prompt" button, form routes show no primary action button.
+- `src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx`, `VideoForm.test.tsx`, `CopyForm.test.tsx` — one happy-path test each: required fields render inline, Generate button triggers the store action with expected payload.
+- `src/components/simple-studio-shell/forms/__tests__/FormPageLayout.test.tsx` — renders form body + info panel side-by-side above the `lg` breakpoint, stacks vertically below.
+- `src/components/simple-studio-shell/__tests__/LibraryGallery.test.tsx` — renders all generations when filter is `all`, filters correctly when set to `image`/`video`/`copy`, empty state when no generations.
+
+### Store tests
+
+- `src/store/__tests__/simpleStudioShellStore.test.ts`:
+  - `openSavePromptDialog` / `closeSavePromptDialog` toggle state and seed data.
+  - `setLibraryModeFilter` updates state.
+  - `hydrateTemplates` populates from a mocked `fetch`.
+  - `saveSavedPrompt` applies optimistically and rolls back on API failure.
+  - `applyTemplate` writes to `simpleStudioStore` and navigates via mocked `router.push`.
+
+### API route tests
+
+- `src/app/api/simple-studio/templates/__tests__/route.test.ts` — returns array shape and length > 0.
+- `src/app/api/simple-studio/saved-prompts/__tests__/route.test.ts`:
+  - `401` without session on every verb.
+  - `POST` creates a row with `userId` from the session.
+  - `GET` returns only the session user's rows.
+  - `PATCH` and `DELETE` enforce ownership (`user A` gets `404` when targeting `user B`'s row).
+  - `POST` with invalid body returns `400`.
+
+### Explicitly untested
+
+- Hardcoded template content.
+- Visual snapshots (not used elsewhere in the repo).
+- Drag-and-drop reference image upload inside the forms (matches the coverage level of the old `Sidebar.tsx`).
+- The responsive breakpoint crossover in `FormPageLayout` (CSS-only, tested manually in browser dev tools).
+
+### Existing tests
+
+All tests under `src/app/studio/simple/__tests__/` stay untouched for PR 1 and are deleted in PR 2 alongside the old code.
+
+## Verification checklist (manual QA before merging PR 1)
+
+1. `/simple-studio` redirects to `/simple-studio/images`.
+2. All 5 sidebar nav items (Images, Videos, Copy, Library, Prompt Library) load and highlight correctly, grouped as Create / Browse.
+3. AppSwitcher dropdown shows "Simple Studio" and "Advanced Workflow" as separate entries; current route lights up.
+4. Each of `/images`, `/videos`, `/copy` renders the form inline with the info panel on the right (desktop) or stacked (mobile).
+5. Generate an image / video / copy from each respective form — progress appears in the info panel's "Output Example" area, and the result appears inline once complete.
+6. Clicking "View all in Library" from an inline result navigates to `/simple-studio/library` with the correct mode filter active.
+7. Library page shows all past generations with the correct filter; filter pills in the site header match.
+8. Prompt Library Templates tab: click a template → navigates to the correct form route (images/videos/copy), form fields are prefilled on arrival, no extra click required.
+9. "Save prompt" button on a form page opens `SavePromptDialog` prefilled with the current prompt text; saving adds it to the Saved tab.
+10. "New Saved Prompt" button on `/simple-studio/prompt-library` opens `SavePromptDialog` with empty fields; saving adds it to the Saved tab.
+11. Delete a saved prompt → removed from list (optimistic) and persists on reload.
+12. Sign out, sign in as a different user → previous user's saved prompts are not visible (ownership enforced).
+13. Old `/studio/simple` route still loads, renders the legacy UI, and is functionally untouched.
+14. `pnpm test:run` passes, `pnpm lint` passes, `pnpm build` succeeds.
+
+## Delivery plan
+
+Two PRs against `develop`:
+
+**PR 1 — Build new shell in parallel.**
+- All new files and the `AppSwitcher` update.
+- Drizzle schema + generated migration for `simple_studio_saved_prompts`.
+- All tests listed in the Testing strategy section.
+- Old `/studio/simple` tree is NOT touched.
+- Merged after the full verification checklist passes.
+
+**PR 2 — Delete old simple studio.**
+- Delete `src/app/studio/simple/page.tsx`, `SimpleStudioClient.tsx`, `__tests__/`.
+- Delete entire `src/components/simple-studio/` directory after a grep confirms no external consumers.
+- Add redirect stub at `src/app/studio/simple/page.tsx` pointing to `/simple-studio/images` for bookmark compatibility.
+- Update any `docs/` or `README.md` references to the old path.
+- Re-run the verification checklist (excluding item 11).
+
+Two PRs keep rollback cheap: if PR 1 is in production and a regression surfaces, PR 2 has not yet removed the fallback UI, so reverting PR 1 restores the prior behavior without resurrecting deleted files.
+
+## Out of scope
+
+- Refactoring the old `Sidebar.tsx` to extract shared primitives before deletion.
+- Admin UI for managing prompt templates.
+- Tags, folders, or categories on saved prompts.
+- Reference image capture in saved prompts.
+- Sharing saved prompts between users or organizations.
+- Import / export of prompt libraries.
+- Pagination of saved prompts endpoint.
+- A `/simple-studio` landing page beyond the redirect.
+- Touching the advanced workflow editor at `/studio/[[...projectId]]`.
+- Porting the mobile `MobileProgress` floating bar (replaced by inline info-panel progress).
+- Extracting shared form primitives beyond `FormPageLayout` + `FormInfoPanel` (deferred until after PR 2).
+- Multi-step wizard-style forms — the design uses single-page inline forms, not a numbered stepper.
+- Batch management actions inside Library (bulk delete, bulk download) — v1 supports per-card actions only.

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jszip": "^3.4.0",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^24.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.1
         version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/jszip':
         specifier: ^3.4.0
         version: 3.4.0
@@ -2829,6 +2832,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -9905,6 +9914,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tokenizer/inflate@0.2.7':
     dependencies:

--- a/src/app/simple-studio/copy/page.tsx
+++ b/src/app/simple-studio/copy/page.tsx
@@ -1,5 +1,5 @@
+import { CopyForm } from "@/components/simple-studio-shell/forms/CopyForm";
+
 export default function CopyPage() {
-  return (
-    <div className="p-6 text-sm text-muted-foreground">Copy page — coming soon.</div>
-  );
+  return <CopyForm />;
 }

--- a/src/app/simple-studio/copy/page.tsx
+++ b/src/app/simple-studio/copy/page.tsx
@@ -1,0 +1,5 @@
+export default function CopyPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">Copy page — coming soon.</div>
+  );
+}

--- a/src/app/simple-studio/images/page.tsx
+++ b/src/app/simple-studio/images/page.tsx
@@ -1,0 +1,5 @@
+export default function ImagesPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">Images page — coming soon.</div>
+  );
+}

--- a/src/app/simple-studio/images/page.tsx
+++ b/src/app/simple-studio/images/page.tsx
@@ -1,5 +1,5 @@
+import { ImageForm } from "@/components/simple-studio-shell/forms/ImageForm";
+
 export default function ImagesPage() {
-  return (
-    <div className="p-6 text-sm text-muted-foreground">Images page — coming soon.</div>
-  );
+  return <ImageForm />;
 }

--- a/src/app/simple-studio/layout.tsx
+++ b/src/app/simple-studio/layout.tsx
@@ -1,0 +1,18 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { getServerAuthSession } from "@/lib/auth/session";
+import { SimpleStudioLayout } from "@/components/simple-studio-shell/SimpleStudioLayout";
+
+export default async function SimpleStudioRootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const session = await getServerAuthSession(await headers());
+
+  if (!session?.user) {
+    redirect("/sign-in?next=%2Fsimple-studio%2Fimages");
+  }
+
+  return <SimpleStudioLayout>{children}</SimpleStudioLayout>;
+}

--- a/src/app/simple-studio/library/page.tsx
+++ b/src/app/simple-studio/library/page.tsx
@@ -1,5 +1,5 @@
+import { LibraryGallery } from "@/components/simple-studio-shell/LibraryGallery";
+
 export default function LibraryPage() {
-  return (
-    <div className="p-6 text-sm text-muted-foreground">Library page — coming soon.</div>
-  );
+  return <LibraryGallery />;
 }

--- a/src/app/simple-studio/library/page.tsx
+++ b/src/app/simple-studio/library/page.tsx
@@ -1,0 +1,5 @@
+export default function LibraryPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">Library page — coming soon.</div>
+  );
+}

--- a/src/app/simple-studio/page.tsx
+++ b/src/app/simple-studio/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SimpleStudioRootPage() {
+  redirect("/simple-studio/images");
+}

--- a/src/app/simple-studio/prompt-library/page.tsx
+++ b/src/app/simple-studio/prompt-library/page.tsx
@@ -1,7 +1,5 @@
+import { PromptLibraryTabs } from "@/components/simple-studio-shell/PromptLibraryTabs";
+
 export default function PromptLibraryPage() {
-  return (
-    <div className="p-6 text-sm text-muted-foreground">
-      Prompt Library page — coming soon.
-    </div>
-  );
+  return <PromptLibraryTabs />;
 }

--- a/src/app/simple-studio/prompt-library/page.tsx
+++ b/src/app/simple-studio/prompt-library/page.tsx
@@ -1,0 +1,7 @@
+export default function PromptLibraryPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">
+      Prompt Library page — coming soon.
+    </div>
+  );
+}

--- a/src/app/simple-studio/videos/page.tsx
+++ b/src/app/simple-studio/videos/page.tsx
@@ -1,5 +1,5 @@
+import { VideoForm } from "@/components/simple-studio-shell/forms/VideoForm";
+
 export default function VideosPage() {
-  return (
-    <div className="p-6 text-sm text-muted-foreground">Videos page — coming soon.</div>
-  );
+  return <VideoForm />;
 }

--- a/src/app/simple-studio/videos/page.tsx
+++ b/src/app/simple-studio/videos/page.tsx
@@ -1,0 +1,5 @@
+export default function VideosPage() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">Videos page — coming soon.</div>
+  );
+}

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -6,6 +6,7 @@ import {
   VideoIcon,
   ActivityIcon,
   BarChart3Icon,
+  WorkflowIcon,
 } from "lucide-react"
 import {
   DropdownMenu,
@@ -16,7 +17,8 @@ import {
 } from "@/components/ui/dropdown-menu"
 
 const PILLAR_ITEMS = [
-  { href: "/studio", label: "AI Studio", icon: PaletteIcon },
+  { href: "/simple-studio/images", label: "Simple Studio", icon: PaletteIcon },
+  { href: "/studio", label: "Advanced Workflow", icon: WorkflowIcon },
   { href: "/editor/projects", label: "Video Editor", icon: VideoIcon },
   { href: "/social", label: "Social Hub", icon: ActivityIcon },
   { href: "/analytics", label: "Analytics", icon: BarChart3Icon },

--- a/src/components/simple-studio-shell/LibraryGallery.tsx
+++ b/src/components/simple-studio-shell/LibraryGallery.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { useSimpleStudioStore, type Generation } from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+function GenerationCard({ gen }: { gen: Generation }) {
+  if (gen.mode === "copy") {
+    return (
+      <div className="rounded-lg border p-4">
+        <div className="mb-2 text-xs text-muted-foreground">
+          copy · {new Date(gen.createdAt).toLocaleDateString()}
+        </div>
+        <div className="mb-2 text-sm font-medium line-clamp-2">{gen.prompt}</div>
+        <div className="text-sm line-clamp-4 whitespace-pre-wrap">
+          {gen.result ?? "(no output)"}
+        </div>
+      </div>
+    );
+  }
+
+  if (gen.mode === "video") {
+    return (
+      <div className="rounded-lg border overflow-hidden">
+        <div className="aspect-video bg-muted">
+          {gen.result && (
+            <video
+              src={gen.result}
+              className="h-full w-full object-cover"
+              muted
+              playsInline
+            />
+          )}
+        </div>
+        <div className="p-3">
+          <div className="mb-1 text-xs text-muted-foreground">
+            video · {new Date(gen.createdAt).toLocaleDateString()}
+          </div>
+          <div className="text-sm line-clamp-2">{gen.prompt}</div>
+        </div>
+      </div>
+    );
+  }
+
+  // photo
+  return (
+    <div className="rounded-lg border overflow-hidden">
+      <div className="aspect-square bg-muted">
+        {gen.result && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={gen.result} alt={gen.prompt} className="h-full w-full object-cover" />
+        )}
+      </div>
+      <div className="p-3">
+        <div className="mb-1 text-xs text-muted-foreground">
+          photo · {new Date(gen.createdAt).toLocaleDateString()}
+        </div>
+        <div className="text-sm line-clamp-2">{gen.prompt}</div>
+      </div>
+    </div>
+  );
+}
+
+export function LibraryGallery() {
+  const generationsByMode = useSimpleStudioStore((s) => s.generationsByMode);
+  const filter = useSimpleStudioShellStore((s) => s.libraryModeFilter);
+
+  const visible = useMemo(() => {
+    const all = [
+      ...generationsByMode.photo,
+      ...generationsByMode.video,
+      ...generationsByMode.copy,
+    ].sort((a, b) => b.createdAt - a.createdAt);
+    if (filter === "all") return all;
+    return all.filter((g) => g.mode === filter);
+  }, [generationsByMode, filter]);
+
+  if (visible.length === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 p-12 text-center">
+        <div className="text-sm text-muted-foreground">No generations yet.</div>
+        <div className="flex gap-2">
+          <Link
+            href="/simple-studio/images"
+            className="rounded-md border px-3 py-1 text-sm hover:bg-muted"
+          >
+            Create images
+          </Link>
+          <Link
+            href="/simple-studio/videos"
+            className="rounded-md border px-3 py-1 text-sm hover:bg-muted"
+          >
+            Create videos
+          </Link>
+          <Link
+            href="/simple-studio/copy"
+            className="rounded-md border px-3 py-1 text-sm hover:bg-muted"
+          >
+            Write copy
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 p-6 md:grid-cols-3 lg:grid-cols-4">
+      {visible.map((gen) => (
+        <GenerationCard key={gen.id} gen={gen} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/simple-studio-shell/PromptLibraryTabs.tsx
+++ b/src/components/simple-studio-shell/PromptLibraryTabs.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import {
+  useSimpleStudioStore,
+  type SavedPrompt,
+} from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+import { MODE_TO_URL_SEGMENT } from "./urlToMode";
+
+function PromptCard({
+  prompt,
+  onUse,
+}: {
+  prompt: SavedPrompt;
+  onUse: (p: SavedPrompt) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="font-medium text-sm">{prompt.name}</div>
+        <span className="text-xs rounded-full border px-2 py-0.5 text-muted-foreground">
+          {prompt.mode}
+        </span>
+      </div>
+      <div className="text-xs text-muted-foreground line-clamp-3">
+        {prompt.promptText}
+      </div>
+      <div className="pt-2">
+        <Button size="sm" onClick={() => onUse(prompt)}>
+          Use
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function PromptLibraryTabs() {
+  const router = useRouter();
+  const tab = useSimpleStudioShellStore((s) => s.promptLibraryTab);
+  const setTab = useSimpleStudioShellStore((s) => s.setPromptLibraryTab);
+
+  const savedPrompts = useSimpleStudioStore((s) => s.savedPrompts);
+  const publicPrompts = useSimpleStudioStore((s) => s.publicPrompts);
+  const loadSavedPrompts = useSimpleStudioStore((s) => s.loadSavedPrompts);
+  const loadPublicPrompts = useSimpleStudioStore((s) => s.loadPublicPrompts);
+  const applyPrompt = useSimpleStudioStore((s) => s.applyPrompt);
+
+  useEffect(() => {
+    void loadSavedPrompts();
+    void loadPublicPrompts();
+  }, [loadSavedPrompts, loadPublicPrompts]);
+
+  const handleUse = (prompt: SavedPrompt) => {
+    applyPrompt(prompt);
+    router.push(`/simple-studio/${MODE_TO_URL_SEGMENT[prompt.mode]}`);
+  };
+
+  return (
+    <div className="p-6">
+      <Tabs value={tab} onValueChange={(v) => setTab(v as "templates" | "saved")}>
+        <TabsList>
+          <TabsTrigger value="templates">Templates</TabsTrigger>
+          <TabsTrigger value="saved">Saved</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="templates">
+          {publicPrompts.length === 0 ? (
+            <div className="rounded-lg border p-12 text-center text-sm text-muted-foreground">
+              No templates yet.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {publicPrompts.map((p) => (
+                <PromptCard key={p.id} prompt={p} onUse={handleUse} />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="saved">
+          {savedPrompts.length === 0 ? (
+            <div className="rounded-lg border p-12 text-center text-sm text-muted-foreground">
+              No saved prompts yet. Save one from any creation page.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {savedPrompts.map((p) => (
+                <PromptCard key={p.id} prompt={p} onUse={handleUse} />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/components/simple-studio-shell/SavePromptDialog.tsx
+++ b/src/components/simple-studio-shell/SavePromptDialog.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+export function SavePromptDialog() {
+  const open = useSimpleStudioShellStore((s) => s.savePromptDialogOpen);
+  const closeDialog = useSimpleStudioShellStore((s) => s.closeSavePromptDialog);
+  const storePrompt = useSimpleStudioStore((s) => s.prompt);
+  const mode = useSimpleStudioStore((s) => s.mode);
+  const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
+  const saveCurrentPrompt = useSimpleStudioStore((s) => s.saveCurrentPrompt);
+
+  const [name, setName] = useState("");
+  const [promptText, setPromptText] = useState(storePrompt);
+  const [saving, setSaving] = useState(false);
+
+  // Re-seed the dialog's local prompt from the store whenever the dialog opens
+  useEffect(() => {
+    if (open) {
+      setPromptText(storePrompt);
+      setName("");
+    }
+  }, [open, storePrompt]);
+
+  const disabled =
+    saving || name.trim().length === 0 || promptText.trim().length === 0;
+
+  const handleSave = async () => {
+    if (disabled) return;
+    setSaving(true);
+    try {
+      // If the user edited the prompt in the dialog, push it to the store
+      // so saveCurrentPrompt picks it up.
+      if (promptText !== storePrompt) {
+        setPrompt(promptText);
+      }
+      await saveCurrentPrompt(name.trim());
+      closeDialog();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) closeDialog();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Save prompt</DialogTitle>
+          <DialogDescription>
+            Save a {mode} prompt to your library for later use.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="save-prompt-name" className="mb-1 block text-sm font-medium">
+              Name
+            </label>
+            <input
+              id="save-prompt-name"
+              type="text"
+              className="w-full rounded-md border bg-background p-2 text-sm"
+              placeholder="e.g. Cinematic sunset"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="save-prompt-text"
+              className="mb-1 block text-sm font-medium"
+            >
+              Prompt text
+            </label>
+            <textarea
+              id="save-prompt-text"
+              className="max-h-48 min-h-24 w-full resize-y rounded-md border bg-background p-2 text-sm"
+              placeholder="Describe the prompt…"
+              value={promptText}
+              onChange={(e) => setPromptText(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={disabled}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/simple-studio-shell/SimpleStudioAppSidebar.tsx
+++ b/src/components/simple-studio-shell/SimpleStudioAppSidebar.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  ImageIcon,
+  VideoIcon,
+  FileTextIcon,
+  GalleryThumbnailsIcon,
+  BookmarkIcon,
+  PaletteIcon,
+} from "lucide-react";
+import { NavUser } from "@/components/nav-user";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarSeparator,
+} from "@/components/ui/sidebar";
+import { AppSwitcher } from "@/components/AppSwitcher";
+import { authClient } from "@/lib/auth/client";
+
+const CREATE_ITEMS = [
+  { href: "/simple-studio/images", label: "Images", icon: ImageIcon },
+  { href: "/simple-studio/videos", label: "Videos", icon: VideoIcon },
+  { href: "/simple-studio/copy", label: "Copy", icon: FileTextIcon },
+];
+
+const BROWSE_ITEMS = [
+  { href: "/simple-studio/library", label: "Library", icon: GalleryThumbnailsIcon },
+  { href: "/simple-studio/prompt-library", label: "Prompt Library", icon: BookmarkIcon },
+];
+
+export function SimpleStudioAppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const pathname = usePathname();
+  const session = authClient.useSession();
+
+  const user = {
+    name: session.data?.user?.name || "User",
+    email: session.data?.user?.email || "",
+    avatar: session.data?.user?.image || "",
+  };
+
+  const isActive = (href: string) =>
+    pathname === href || pathname?.startsWith(href + "/");
+
+  return (
+    <Sidebar collapsible="offcanvas" {...props}>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <AppSwitcher>
+              <div className="flex w-full items-center gap-2 rounded-md p-1.5 text-start text-sm font-semibold hover:bg-sidebar-accent cursor-pointer">
+                <PaletteIcon className="size-5" />
+                <span className="text-base font-semibold">Simple Studio</span>
+              </div>
+            </AppSwitcher>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Create</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {CREATE_ITEMS.map((item) => (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton
+                    isActive={isActive(item.href)}
+                    render={<Link href={item.href} />}
+                  >
+                    <item.icon />
+                    <span>{item.label}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarSeparator />
+
+        <SidebarGroup>
+          <SidebarGroupLabel>Browse</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {BROWSE_ITEMS.map((item) => (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton
+                    isActive={isActive(item.href)}
+                    render={<Link href={item.href} />}
+                  >
+                    <item.icon />
+                    <span>{item.label}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarFooter>
+        <NavUser user={user} />
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/src/components/simple-studio-shell/SimpleStudioLayout.tsx
+++ b/src/components/simple-studio-shell/SimpleStudioLayout.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useSimpleStudioStore } from "@/store/simpleStudioStore";
 import { SimpleStudioAppSidebar } from "./SimpleStudioAppSidebar";
 import { SimpleStudioSiteHeader } from "./SimpleStudioSiteHeader";
+import { SavePromptDialog } from "./SavePromptDialog";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { modeFromPathname } from "./urlToMode";
 
@@ -45,6 +46,7 @@ export function SimpleStudioLayout({ children }: SimpleStudioLayoutProps) {
       <SidebarInset>
         <SimpleStudioSiteHeader />
         <div className="flex flex-1 flex-col">{children}</div>
+        <SavePromptDialog />
       </SidebarInset>
     </SidebarProvider>
   );

--- a/src/components/simple-studio-shell/SimpleStudioLayout.tsx
+++ b/src/components/simple-studio-shell/SimpleStudioLayout.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { SimpleStudioAppSidebar } from "./SimpleStudioAppSidebar";
+import { SimpleStudioSiteHeader } from "./SimpleStudioSiteHeader";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { modeFromPathname } from "./urlToMode";
+
+interface SimpleStudioLayoutProps {
+  children: React.ReactNode;
+}
+
+export function SimpleStudioLayout({ children }: SimpleStudioLayoutProps) {
+  const pathname = usePathname();
+  const setMode = useSimpleStudioStore((s) => s.setMode);
+  const loadRecentResults = useSimpleStudioStore((s) => s.loadRecentResults);
+  const initialized = useRef(false);
+
+  // Sync store mode with URL on every pathname change
+  useEffect(() => {
+    const mode = modeFromPathname(pathname ?? "");
+    if (mode) {
+      setMode(mode);
+    }
+  }, [pathname, setMode]);
+
+  // Load recent results once on first mount
+  if (!initialized.current) {
+    initialized.current = true;
+    loadRecentResults();
+  }
+
+  return (
+    <SidebarProvider
+      style={
+        {
+          "--sidebar-width": "calc(var(--spacing) * 64)",
+          "--header-height": "calc(var(--spacing) * 12)",
+        } as React.CSSProperties
+      }
+    >
+      <SimpleStudioAppSidebar variant="inset" />
+      <SidebarInset>
+        <SimpleStudioSiteHeader />
+        <div className="flex flex-1 flex-col">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/src/components/simple-studio-shell/SimpleStudioSiteHeader.tsx
+++ b/src/components/simple-studio-shell/SimpleStudioSiteHeader.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { PlusIcon, BookmarkIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import {
+  useSimpleStudioShellStore,
+  type LibraryModeFilter,
+} from "@/store/simpleStudioShellStore";
+
+const PAGE_TITLES: Record<string, string> = {
+  "/simple-studio/images": "Images",
+  "/simple-studio/videos": "Videos",
+  "/simple-studio/copy": "Copy",
+  "/simple-studio/library": "Library",
+  "/simple-studio/prompt-library": "Prompt Library",
+};
+
+const FILTER_VALUES: { value: LibraryModeFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "photo", label: "Photo" },
+  { value: "video", label: "Video" },
+  { value: "copy", label: "Copy" },
+];
+
+function resolveTitle(pathname: string | null): string {
+  if (!pathname) return "Simple Studio";
+  const exact = PAGE_TITLES[pathname];
+  if (exact) return exact;
+  const prefixMatch = Object.entries(PAGE_TITLES).find(([path]) =>
+    pathname.startsWith(path + "/"),
+  );
+  return prefixMatch ? prefixMatch[1] : "Simple Studio";
+}
+
+function isFormRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return (
+    pathname === "/simple-studio/images" ||
+    pathname === "/simple-studio/videos" ||
+    pathname === "/simple-studio/copy" ||
+    pathname.startsWith("/simple-studio/images/") ||
+    pathname.startsWith("/simple-studio/videos/") ||
+    pathname.startsWith("/simple-studio/copy/")
+  );
+}
+
+export function SimpleStudioSiteHeader() {
+  const pathname = usePathname();
+  const title = resolveTitle(pathname);
+  const openSavePromptDialog = useSimpleStudioShellStore(
+    (s) => s.openSavePromptDialog,
+  );
+  const libraryModeFilter = useSimpleStudioShellStore((s) => s.libraryModeFilter);
+  const setLibraryModeFilter = useSimpleStudioShellStore(
+    (s) => s.setLibraryModeFilter,
+  );
+
+  const isLibrary = pathname === "/simple-studio/library";
+  const isPromptLibrary = pathname === "/simple-studio/prompt-library";
+  const isForm = isFormRoute(pathname);
+
+  return (
+    <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
+      <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+        <SidebarTrigger className="-ms-1" />
+        <Separator
+          orientation="vertical"
+          className="mx-2 h-4 data-vertical:self-auto"
+        />
+        <h1 className="text-base font-medium">{title}</h1>
+
+        <div className="ms-auto flex items-center gap-2">
+          {isLibrary &&
+            FILTER_VALUES.map((f) => (
+              <Button
+                key={f.value}
+                size="sm"
+                variant={libraryModeFilter === f.value ? "default" : "ghost"}
+                onClick={() => setLibraryModeFilter(f.value)}
+              >
+                {f.label}
+              </Button>
+            ))}
+
+          {isForm && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => openSavePromptDialog()}
+            >
+              <BookmarkIcon className="size-4" />
+              Save prompt
+            </Button>
+          )}
+
+          {isPromptLibrary && (
+            <Button size="sm" onClick={() => openSavePromptDialog()}>
+              <PlusIcon className="size-4" />
+              New Saved Prompt
+            </Button>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/simple-studio-shell/__tests__/LibraryGallery.test.tsx
+++ b/src/components/simple-studio-shell/__tests__/LibraryGallery.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, beforeEach } from "vitest";
+import { LibraryGallery } from "../LibraryGallery";
+import { useSimpleStudioStore, type Generation } from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+function makeGen(overrides: Partial<Generation>): Generation {
+  return {
+    id: "g1",
+    batchId: "b1",
+    status: "complete",
+    result: "data:image/png;base64,xxx",
+    assetId: null,
+    error: null,
+    mode: "photo",
+    aspectRatio: "1:1",
+    prompt: "A cat",
+    createdAt: Date.now(),
+    modelName: "Auto",
+    ...overrides,
+  };
+}
+
+describe("LibraryGallery", () => {
+  beforeEach(() => {
+    useSimpleStudioStore.setState({
+      generationsByMode: {
+        photo: [makeGen({ id: "p1", mode: "photo", prompt: "Photo one" })],
+        video: [makeGen({ id: "v1", mode: "video", prompt: "Video one", result: "data:video/mp4;base64,xxx" })],
+        copy: [makeGen({ id: "c1", mode: "copy", prompt: "Copy one", result: "Text output" })],
+      },
+      generations: [],
+      mode: "photo",
+    });
+    useSimpleStudioShellStore.setState({ libraryModeFilter: "all" });
+  });
+
+  it("renders all generations when filter is 'all'", () => {
+    render(<LibraryGallery />);
+    expect(screen.getByText("Photo one")).toBeInTheDocument();
+    expect(screen.getByText("Video one")).toBeInTheDocument();
+    expect(screen.getByText("Copy one")).toBeInTheDocument();
+  });
+
+  it("renders only photo generations when filter is 'photo'", () => {
+    useSimpleStudioShellStore.setState({ libraryModeFilter: "photo" });
+    render(<LibraryGallery />);
+    expect(screen.getByText("Photo one")).toBeInTheDocument();
+    expect(screen.queryByText("Video one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Copy one")).not.toBeInTheDocument();
+  });
+
+  it("renders only video generations when filter is 'video'", () => {
+    useSimpleStudioShellStore.setState({ libraryModeFilter: "video" });
+    render(<LibraryGallery />);
+    expect(screen.queryByText("Photo one")).not.toBeInTheDocument();
+    expect(screen.getByText("Video one")).toBeInTheDocument();
+    expect(screen.queryByText("Copy one")).not.toBeInTheDocument();
+  });
+
+  it("renders only copy generations when filter is 'copy'", () => {
+    useSimpleStudioShellStore.setState({ libraryModeFilter: "copy" });
+    render(<LibraryGallery />);
+    expect(screen.queryByText("Photo one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Video one")).not.toBeInTheDocument();
+    expect(screen.getByText("Copy one")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no generations", () => {
+    useSimpleStudioStore.setState({
+      generationsByMode: { photo: [], video: [], copy: [] },
+      generations: [],
+    });
+    render(<LibraryGallery />);
+    expect(screen.getByText(/no generations yet/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/simple-studio-shell/__tests__/PromptLibraryTabs.test.tsx
+++ b/src/components/simple-studio-shell/__tests__/PromptLibraryTabs.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { PromptLibraryTabs } from "../PromptLibraryTabs";
+import {
+  useSimpleStudioStore,
+  type SavedPrompt,
+} from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+const routerPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+}));
+
+function makePrompt(overrides: Partial<SavedPrompt>): SavedPrompt {
+  return {
+    id: "p1",
+    mode: "photo",
+    name: "Demo",
+    promptText: "Demo prompt",
+    formConfig: {},
+    isPublic: false,
+    ...overrides,
+  };
+}
+
+describe("PromptLibraryTabs", () => {
+  beforeEach(() => {
+    routerPush.mockClear();
+    useSimpleStudioShellStore.setState({ promptLibraryTab: "templates" });
+    useSimpleStudioStore.setState({
+      savedPrompts: [
+        makePrompt({ id: "s1", name: "Saved one", promptText: "Saved text" }),
+      ],
+      publicPrompts: [
+        makePrompt({
+          id: "t1",
+          name: "Template one",
+          promptText: "Template text",
+          isPublic: true,
+        }),
+      ],
+      applyPrompt: vi.fn(),
+      loadSavedPrompts: vi.fn().mockResolvedValue(undefined),
+      loadPublicPrompts: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it("shows templates by default", () => {
+    render(<PromptLibraryTabs />);
+    expect(screen.getByText("Template one")).toBeInTheDocument();
+  });
+
+  it("switches to Saved tab on click", async () => {
+    render(<PromptLibraryTabs />);
+    await userEvent.click(screen.getByRole("tab", { name: /saved/i }));
+    expect(screen.getByText("Saved one")).toBeInTheDocument();
+    expect(useSimpleStudioShellStore.getState().promptLibraryTab).toBe("saved");
+  });
+
+  it("clicking Use on a template applies and navigates", async () => {
+    const applySpy = vi.fn();
+    useSimpleStudioStore.setState({ applyPrompt: applySpy });
+    render(<PromptLibraryTabs />);
+    await userEvent.click(screen.getByRole("button", { name: /use/i }));
+    expect(applySpy).toHaveBeenCalled();
+    expect(routerPush).toHaveBeenCalledWith("/simple-studio/images");
+  });
+
+  it("shows empty state when no templates", () => {
+    useSimpleStudioStore.setState({ publicPrompts: [] });
+    render(<PromptLibraryTabs />);
+    expect(screen.getByText(/no templates yet/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no saved prompts", async () => {
+    useSimpleStudioStore.setState({ savedPrompts: [] });
+    render(<PromptLibraryTabs />);
+    await userEvent.click(screen.getByRole("tab", { name: /saved/i }));
+    expect(screen.getByText(/no saved prompts yet/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/simple-studio-shell/__tests__/SavePromptDialog.test.tsx
+++ b/src/components/simple-studio-shell/__tests__/SavePromptDialog.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { SavePromptDialog } from "../SavePromptDialog";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+describe("SavePromptDialog", () => {
+  beforeEach(() => {
+    useSimpleStudioShellStore.setState({ savePromptDialogOpen: true });
+    useSimpleStudioStore.setState({ prompt: "A cat", mode: "photo" });
+  });
+
+  it("renders the dialog when open is true", () => {
+    render(<SavePromptDialog />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("shows a name input", () => {
+    render(<SavePromptDialog />);
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+  });
+
+  it("shows an editable prompt textarea seeded with the current store prompt", () => {
+    render(<SavePromptDialog />);
+    const textarea = screen.getByLabelText(/prompt text/i) as HTMLTextAreaElement;
+    expect(textarea).toBeInTheDocument();
+    expect(textarea.value).toBe("A cat");
+  });
+
+  it("calls setPrompt then saveCurrentPrompt with the edited prompt on Save", async () => {
+    const setPromptSpy = vi.fn();
+    const saveSpy = vi.fn().mockResolvedValue(undefined);
+    useSimpleStudioStore.setState({ setPrompt: setPromptSpy, saveCurrentPrompt: saveSpy });
+    render(<SavePromptDialog />);
+    const textarea = screen.getByLabelText(/prompt text/i);
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, "A fluffy cat");
+    await userEvent.type(screen.getByLabelText(/name/i), "Cat v2");
+    await userEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    expect(setPromptSpy).toHaveBeenCalledWith("A fluffy cat");
+    expect(saveSpy).toHaveBeenCalledWith("Cat v2");
+    expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(false);
+  });
+
+  it("Save button is disabled when name is empty", () => {
+    render(<SavePromptDialog />);
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("Save button is disabled when prompt text is empty", async () => {
+    useSimpleStudioStore.setState({ prompt: "" });
+    render(<SavePromptDialog />);
+    await userEvent.type(screen.getByLabelText(/name/i), "Empty");
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("does not render when open is false", () => {
+    useSimpleStudioShellStore.setState({ savePromptDialogOpen: false });
+    render(<SavePromptDialog />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/simple-studio-shell/__tests__/SimpleStudioAppSidebar.test.tsx
+++ b/src/components/simple-studio-shell/__tests__/SimpleStudioAppSidebar.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SimpleStudioAppSidebar } from "../SimpleStudioAppSidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+// Mock next/navigation to control pathname
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/simple-studio/images",
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+// Mock authClient.useSession to provide a stable user
+vi.mock("@/lib/auth/client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { name: "Test User", email: "test@example.com", image: "" } },
+    }),
+  },
+}));
+
+function renderSidebar() {
+  return render(
+    <SidebarProvider>
+      <SimpleStudioAppSidebar />
+    </SidebarProvider>,
+  );
+}
+
+describe("SimpleStudioAppSidebar", () => {
+  it("renders all five nav items", () => {
+    renderSidebar();
+    expect(screen.getByText("Images")).toBeInTheDocument();
+    expect(screen.getByText("Videos")).toBeInTheDocument();
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+    expect(screen.getByText("Library")).toBeInTheDocument();
+    expect(screen.getByText("Prompt Library")).toBeInTheDocument();
+  });
+
+  it("renders Create and Browse group labels", () => {
+    renderSidebar();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Browse")).toBeInTheDocument();
+  });
+
+  it("renders the AppSwitcher trigger with Simple Studio label", () => {
+    renderSidebar();
+    expect(screen.getByText("Simple Studio")).toBeInTheDocument();
+  });
+
+  it("renders the user's name in the footer", () => {
+    renderSidebar();
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+  });
+});

--- a/src/components/simple-studio-shell/__tests__/SimpleStudioSiteHeader.test.tsx
+++ b/src/components/simple-studio-shell/__tests__/SimpleStudioSiteHeader.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { SimpleStudioSiteHeader } from "../SimpleStudioSiteHeader";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { useSimpleStudioShellStore } from "@/store/simpleStudioShellStore";
+
+const pathnameMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathnameMock(),
+}));
+
+function renderHeader() {
+  return render(
+    <SidebarProvider>
+      <SimpleStudioSiteHeader />
+    </SidebarProvider>,
+  );
+}
+
+describe("SimpleStudioSiteHeader", () => {
+  beforeEach(() => {
+    useSimpleStudioShellStore.setState({
+      savePromptDialogOpen: false,
+      libraryModeFilter: "all",
+      promptLibraryTab: "templates",
+    });
+  });
+
+  it("shows 'Images' title on /simple-studio/images", () => {
+    pathnameMock.mockReturnValue("/simple-studio/images");
+    renderHeader();
+    expect(screen.getByRole("heading", { name: "Images" })).toBeInTheDocument();
+  });
+
+  it("shows 'Library' title on /simple-studio/library", () => {
+    pathnameMock.mockReturnValue("/simple-studio/library");
+    renderHeader();
+    expect(screen.getByRole("heading", { name: "Library" })).toBeInTheDocument();
+  });
+
+  it("shows 'Prompt Library' title on /simple-studio/prompt-library", () => {
+    pathnameMock.mockReturnValue("/simple-studio/prompt-library");
+    renderHeader();
+    expect(screen.getByRole("heading", { name: "Prompt Library" })).toBeInTheDocument();
+  });
+
+  it("shows a Save prompt button on a form route", () => {
+    pathnameMock.mockReturnValue("/simple-studio/images");
+    renderHeader();
+    expect(screen.getByRole("button", { name: /save prompt/i })).toBeInTheDocument();
+  });
+
+  it("Save prompt button opens the dialog via the store", async () => {
+    pathnameMock.mockReturnValue("/simple-studio/images");
+    renderHeader();
+    await userEvent.click(screen.getByRole("button", { name: /save prompt/i }));
+    expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(true);
+  });
+
+  it("shows a New Saved Prompt button on the prompt-library route", () => {
+    pathnameMock.mockReturnValue("/simple-studio/prompt-library");
+    renderHeader();
+    expect(screen.getByRole("button", { name: /new saved prompt/i })).toBeInTheDocument();
+  });
+
+  it("shows filter pills on the library route", () => {
+    pathnameMock.mockReturnValue("/simple-studio/library");
+    renderHeader();
+    expect(screen.getByRole("button", { name: /^all$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^photo$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^video$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeInTheDocument();
+  });
+
+  it("clicking a filter pill updates the store", async () => {
+    pathnameMock.mockReturnValue("/simple-studio/library");
+    renderHeader();
+    await userEvent.click(screen.getByRole("button", { name: /^photo$/i }));
+    expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("photo");
+  });
+});

--- a/src/components/simple-studio-shell/__tests__/urlToMode.test.ts
+++ b/src/components/simple-studio-shell/__tests__/urlToMode.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  URL_SEGMENT_TO_MODE,
+  MODE_TO_URL_SEGMENT,
+  modeFromPathname,
+} from "../urlToMode";
+
+describe("urlToMode", () => {
+  describe("URL_SEGMENT_TO_MODE", () => {
+    it("maps images → photo", () => {
+      expect(URL_SEGMENT_TO_MODE.images).toBe("photo");
+    });
+    it("maps videos → video", () => {
+      expect(URL_SEGMENT_TO_MODE.videos).toBe("video");
+    });
+    it("maps copy → copy", () => {
+      expect(URL_SEGMENT_TO_MODE.copy).toBe("copy");
+    });
+  });
+
+  describe("MODE_TO_URL_SEGMENT", () => {
+    it("is the inverse of URL_SEGMENT_TO_MODE", () => {
+      expect(MODE_TO_URL_SEGMENT.photo).toBe("images");
+      expect(MODE_TO_URL_SEGMENT.video).toBe("videos");
+      expect(MODE_TO_URL_SEGMENT.copy).toBe("copy");
+    });
+  });
+
+  describe("modeFromPathname", () => {
+    it("returns photo for /simple-studio/images", () => {
+      expect(modeFromPathname("/simple-studio/images")).toBe("photo");
+    });
+    it("returns video for /simple-studio/videos", () => {
+      expect(modeFromPathname("/simple-studio/videos")).toBe("video");
+    });
+    it("returns copy for /simple-studio/copy", () => {
+      expect(modeFromPathname("/simple-studio/copy")).toBe("copy");
+    });
+    it("handles trailing segments", () => {
+      expect(modeFromPathname("/simple-studio/images/")).toBe("photo");
+    });
+    it("returns null for /simple-studio/library", () => {
+      expect(modeFromPathname("/simple-studio/library")).toBeNull();
+    });
+    it("returns null for /simple-studio/prompt-library", () => {
+      expect(modeFromPathname("/simple-studio/prompt-library")).toBeNull();
+    });
+    it("returns null for /simple-studio", () => {
+      expect(modeFromPathname("/simple-studio")).toBeNull();
+    });
+    it("returns null for unrelated paths", () => {
+      expect(modeFromPathname("/studio/simple")).toBeNull();
+      expect(modeFromPathname("/social/calendar")).toBeNull();
+    });
+  });
+});

--- a/src/components/simple-studio-shell/forms/CopyForm.tsx
+++ b/src/components/simple-studio-shell/forms/CopyForm.tsx
@@ -9,6 +9,16 @@ const TONES = ["professional", "casual", "creative", "persuasive"];
 const PLATFORMS = ["general", "instagram", "x", "linkedin"];
 const BATCH_PRESETS = [1, 4, 8];
 
+const LLM_MODELS: { id: string; name: string; provider: string }[] = [
+  { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", provider: "Google" },
+  { id: "gemini-3-flash-preview", name: "Gemini 3 Flash", provider: "Google" },
+  { id: "gemini-3-pro-preview", name: "Gemini 3 Pro", provider: "Google" },
+  { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "OpenAI" },
+  { id: "gpt-4.1-nano", name: "GPT-4.1 Nano", provider: "OpenAI" },
+  { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5", provider: "Anthropic" },
+  { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", provider: "Anthropic" },
+];
+
 export function CopyForm() {
   const prompt = useSimpleStudioStore((s) => s.prompt);
   const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
@@ -21,6 +31,7 @@ export function CopyForm() {
   const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
   const generate = useSimpleStudioStore((s) => s.generate);
   const copyModelId = useSimpleStudioStore((s) => s.copyModelId);
+  const setCopyModelId = useSimpleStudioStore((s) => s.setCopyModelId);
 
   const disabled = isGenerating || prompt.trim().length === 0;
 
@@ -88,8 +99,22 @@ export function CopyForm() {
           </div>
         </div>
 
-        <div className="text-xs text-muted-foreground">
-          Model: {copyModelId}
+        <div>
+          <label htmlFor="copy-model" className="mb-2 block text-sm font-medium">
+            Model
+          </label>
+          <select
+            id="copy-model"
+            className="w-full rounded-md border bg-background p-2 text-sm"
+            value={copyModelId}
+            onChange={(e) => setCopyModelId(e.target.value)}
+          >
+            {LLM_MODELS.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name} ({m.provider})
+              </option>
+            ))}
+          </select>
         </div>
 
         <Button

--- a/src/components/simple-studio-shell/forms/CopyForm.tsx
+++ b/src/components/simple-studio-shell/forms/CopyForm.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { Button } from "@/components/ui/button";
+import { FormPageLayout } from "./FormPageLayout";
+import { FormInfoPanel } from "./FormInfoPanel";
+
+const TONES = ["professional", "casual", "creative", "persuasive"];
+const PLATFORMS = ["general", "instagram", "x", "linkedin"];
+const BATCH_PRESETS = [1, 4, 8];
+
+export function CopyForm() {
+  const prompt = useSimpleStudioStore((s) => s.prompt);
+  const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
+  const tone = useSimpleStudioStore((s) => s.tone);
+  const setTone = useSimpleStudioStore((s) => s.setTone);
+  const platform = useSimpleStudioStore((s) => s.platform);
+  const setPlatform = useSimpleStudioStore((s) => s.setPlatform);
+  const batchCount = useSimpleStudioStore((s) => s.batchCount);
+  const setBatchCount = useSimpleStudioStore((s) => s.setBatchCount);
+  const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
+  const generate = useSimpleStudioStore((s) => s.generate);
+  const copyModelId = useSimpleStudioStore((s) => s.copyModelId);
+
+  const disabled = isGenerating || prompt.trim().length === 0;
+
+  return (
+    <FormPageLayout
+      infoPanel={
+        <FormInfoPanel
+          batchPresets={BATCH_PRESETS}
+          currentBatchCount={batchCount}
+          onBatchCountChange={setBatchCount}
+          estimatedCost={<span>{batchCount} variant{batchCount > 1 ? "s" : ""}</span>}
+          tips={<p>Give the model context: audience, product, and desired action.</p>}
+        />
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="copy-prompt" className="mb-2 block text-sm font-medium">
+            Prompt
+          </label>
+          <textarea
+            id="copy-prompt"
+            className="min-h-32 w-full resize-y rounded-md border bg-background p-3 text-sm"
+            placeholder="What should the copy be about?"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="copy-tone" className="mb-2 block text-sm font-medium">
+              Tone
+            </label>
+            <select
+              id="copy-tone"
+              className="w-full rounded-md border bg-background p-2 text-sm"
+              value={tone}
+              onChange={(e) => setTone(e.target.value)}
+            >
+              {TONES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="copy-platform" className="mb-2 block text-sm font-medium">
+              Platform
+            </label>
+            <select
+              id="copy-platform"
+              className="w-full rounded-md border bg-background p-2 text-sm"
+              value={platform}
+              onChange={(e) => setPlatform(e.target.value)}
+            >
+              {PLATFORMS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Model: {copyModelId}
+        </div>
+
+        <Button
+          type="button"
+          size="lg"
+          disabled={disabled}
+          onClick={() => {
+            void generate();
+          }}
+        >
+          {isGenerating ? "Generating…" : "Generate"}
+        </Button>
+      </div>
+    </FormPageLayout>
+  );
+}

--- a/src/components/simple-studio-shell/forms/CopyForm.tsx
+++ b/src/components/simple-studio-shell/forms/CopyForm.tsx
@@ -4,6 +4,7 @@ import { useSimpleStudioStore } from "@/store/simpleStudioStore";
 import { Button } from "@/components/ui/button";
 import { FormPageLayout } from "./FormPageLayout";
 import { FormInfoPanel } from "./FormInfoPanel";
+import { LatestResultsInline } from "./LatestResultsInline";
 
 const TONES = ["professional", "casual", "creative", "persuasive"];
 const PLATFORMS = ["general", "instagram", "x", "linkedin"];
@@ -127,6 +128,8 @@ export function CopyForm() {
         >
           {isGenerating ? "Generating…" : "Generate"}
         </Button>
+
+        <LatestResultsInline mode="copy" />
       </div>
     </FormPageLayout>
   );

--- a/src/components/simple-studio-shell/forms/FormInfoPanel.tsx
+++ b/src/components/simple-studio-shell/forms/FormInfoPanel.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+interface FormInfoPanelProps {
+  aspectRatios?: { value: string; label: string }[];
+  batchPresets?: number[];
+  outputExample?: ReactNode;
+  tips?: ReactNode;
+  currentAspectRatio?: string;
+  onAspectRatioChange?: (value: string) => void;
+  currentBatchCount?: number;
+  onBatchCountChange?: (value: number) => void;
+  estimatedCost?: ReactNode;
+}
+
+export function FormInfoPanel({
+  aspectRatios,
+  batchPresets,
+  outputExample,
+  tips,
+  currentAspectRatio,
+  onAspectRatioChange,
+  currentBatchCount,
+  onBatchCountChange,
+  estimatedCost,
+}: FormInfoPanelProps) {
+  return (
+    <div className="space-y-4 rounded-lg border bg-card p-4 text-sm">
+      {aspectRatios && aspectRatios.length > 0 && (
+        <section>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Aspect ratio
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {aspectRatios.map((r) => (
+              <button
+                key={r.value}
+                type="button"
+                className={`rounded-md border px-3 py-1 text-xs ${
+                  currentAspectRatio === r.value
+                    ? "border-primary bg-primary/10"
+                    : "border-border hover:bg-muted"
+                }`}
+                onClick={() => onAspectRatioChange?.(r.value)}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {batchPresets && batchPresets.length > 0 && (
+        <section>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Batch count
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {batchPresets.map((n) => (
+              <button
+                key={n}
+                type="button"
+                className={`rounded-md border px-3 py-1 text-xs ${
+                  currentBatchCount === n
+                    ? "border-primary bg-primary/10"
+                    : "border-border hover:bg-muted"
+                }`}
+                onClick={() => onBatchCountChange?.(n)}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {estimatedCost && (
+        <section>
+          <div className="mb-1 text-xs font-medium text-muted-foreground">
+            Estimated cost
+          </div>
+          <div>{estimatedCost}</div>
+        </section>
+      )}
+
+      {outputExample && (
+        <section>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Output example
+          </div>
+          {outputExample}
+        </section>
+      )}
+
+      {tips && (
+        <section className="text-xs text-muted-foreground">{tips}</section>
+      )}
+    </div>
+  );
+}

--- a/src/components/simple-studio-shell/forms/FormPageLayout.tsx
+++ b/src/components/simple-studio-shell/forms/FormPageLayout.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+interface FormPageLayoutProps {
+  children: ReactNode;
+  infoPanel: ReactNode;
+}
+
+export function FormPageLayout({ children, infoPanel }: FormPageLayoutProps) {
+  return (
+    <div className="flex flex-1 flex-col-reverse gap-6 overflow-y-auto p-6 lg:flex-row">
+      <div className="flex-1">
+        <div className="mx-auto w-full max-w-2xl">{children}</div>
+      </div>
+      <aside className="lg:w-80 lg:shrink-0">{infoPanel}</aside>
+    </div>
+  );
+}

--- a/src/components/simple-studio-shell/forms/ImageForm.tsx
+++ b/src/components/simple-studio-shell/forms/ImageForm.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { Button } from "@/components/ui/button";
+import { FormPageLayout } from "./FormPageLayout";
+import { FormInfoPanel } from "./FormInfoPanel";
+
+const ASPECT_RATIOS = [
+  { value: "1:1", label: "1:1" },
+  { value: "16:9", label: "16:9" },
+  { value: "9:16", label: "9:16" },
+  { value: "4:5", label: "4:5" },
+];
+
+const BATCH_PRESETS = [1, 4, 8, 12];
+
+export function ImageForm() {
+  const prompt = useSimpleStudioStore((s) => s.prompt);
+  const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
+  const aspectRatio = useSimpleStudioStore((s) => s.aspectRatio);
+  const setAspectRatio = useSimpleStudioStore((s) => s.setAspectRatio);
+  const batchCount = useSimpleStudioStore((s) => s.batchCount);
+  const setBatchCount = useSimpleStudioStore((s) => s.setBatchCount);
+  const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
+  const generate = useSimpleStudioStore((s) => s.generate);
+  const selectedModelName = useSimpleStudioStore((s) => s.selectedModelName);
+
+  const disabled = isGenerating || prompt.trim().length === 0;
+
+  return (
+    <FormPageLayout
+      infoPanel={
+        <FormInfoPanel
+          aspectRatios={ASPECT_RATIOS}
+          batchPresets={BATCH_PRESETS}
+          currentAspectRatio={aspectRatio}
+          onAspectRatioChange={setAspectRatio}
+          currentBatchCount={batchCount}
+          onBatchCountChange={setBatchCount}
+          estimatedCost={<span>{batchCount} image{batchCount > 1 ? "s" : ""}</span>}
+          outputExample={
+            <div className="aspect-square w-full rounded-md border bg-muted" />
+          }
+          tips={<p>Describe the scene, style, and subject for best results.</p>}
+        />
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="image-prompt" className="mb-2 block text-sm font-medium">
+            Prompt
+          </label>
+          <textarea
+            id="image-prompt"
+            className="min-h-32 w-full resize-y rounded-md border bg-background p-3 text-sm"
+            placeholder="Describe the image you want to generate…"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Model: {selectedModelName || "Auto"}
+        </div>
+
+        <Button
+          type="button"
+          size="lg"
+          disabled={disabled}
+          onClick={() => {
+            void generate();
+          }}
+        >
+          {isGenerating ? "Generating…" : "Generate"}
+        </Button>
+      </div>
+    </FormPageLayout>
+  );
+}

--- a/src/components/simple-studio-shell/forms/ImageForm.tsx
+++ b/src/components/simple-studio-shell/forms/ImageForm.tsx
@@ -4,6 +4,8 @@ import { useSimpleStudioStore } from "@/store/simpleStudioStore";
 import { Button } from "@/components/ui/button";
 import { FormPageLayout } from "./FormPageLayout";
 import { FormInfoPanel } from "./FormInfoPanel";
+import { ModelSelect } from "./ModelSelect";
+import { LatestResultsInline } from "./LatestResultsInline";
 
 const ASPECT_RATIOS = [
   { value: "1:1", label: "1:1" },
@@ -23,7 +25,6 @@ export function ImageForm() {
   const setBatchCount = useSimpleStudioStore((s) => s.setBatchCount);
   const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
   const generate = useSimpleStudioStore((s) => s.generate);
-  const selectedModelName = useSimpleStudioStore((s) => s.selectedModelName);
 
   const disabled = isGenerating || prompt.trim().length === 0;
 
@@ -59,8 +60,11 @@ export function ImageForm() {
           />
         </div>
 
-        <div className="text-xs text-muted-foreground">
-          Model: {selectedModelName || "Auto"}
+        <div>
+          <label htmlFor="image-model" className="mb-2 block text-sm font-medium">
+            Model
+          </label>
+          <ModelSelect mode="photo" id="image-model" />
         </div>
 
         <Button
@@ -73,6 +77,8 @@ export function ImageForm() {
         >
           {isGenerating ? "Generating…" : "Generate"}
         </Button>
+
+        <LatestResultsInline mode="photo" />
       </div>
     </FormPageLayout>
   );

--- a/src/components/simple-studio-shell/forms/LatestResultsInline.tsx
+++ b/src/components/simple-studio-shell/forms/LatestResultsInline.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useSimpleStudioStore,
+  type Generation,
+  type SimpleStudioMode,
+} from "@/store/simpleStudioStore";
+
+interface LatestResultsInlineProps {
+  mode: SimpleStudioMode;
+}
+
+function ResultCard({ gen }: { gen: Generation }) {
+  if (gen.status === "pending" || gen.status === "generating") {
+    return (
+      <div className="rounded-md border bg-muted p-3 text-xs text-muted-foreground animate-pulse">
+        Generating…
+      </div>
+    );
+  }
+
+  if (gen.status === "failed") {
+    return (
+      <div className="rounded-md border border-destructive p-3 text-xs text-destructive">
+        Failed: {gen.error ?? "unknown error"}
+      </div>
+    );
+  }
+
+  if (gen.mode === "copy") {
+    return (
+      <div className="rounded-md border p-3 text-sm whitespace-pre-wrap">
+        {gen.result ?? "(no output)"}
+      </div>
+    );
+  }
+
+  if (gen.mode === "video") {
+    return (
+      <div className="rounded-md border overflow-hidden">
+        {gen.result && (
+          <video
+            src={gen.result}
+            className="w-full aspect-video object-cover"
+            muted
+            playsInline
+            controls
+          />
+        )}
+      </div>
+    );
+  }
+
+  // photo
+  return (
+    <div className="rounded-md border overflow-hidden">
+      {gen.result && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={gen.result}
+          alt={gen.prompt}
+          className="w-full aspect-square object-cover"
+        />
+      )}
+    </div>
+  );
+}
+
+export function LatestResultsInline({ mode }: LatestResultsInlineProps) {
+  const modeGens = useSimpleStudioStore((s) => s.generationsByMode[mode]);
+
+  if (modeGens.length === 0) return null;
+
+  const latestBatchId = modeGens[0].batchId;
+  const latestBatch = modeGens.filter((g) => g.batchId === latestBatchId);
+
+  return (
+    <div className="space-y-2 border-t pt-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium">Latest results</div>
+        <Link
+          href="/simple-studio/library"
+          className="text-xs text-muted-foreground hover:underline"
+        >
+          View all →
+        </Link>
+      </div>
+      <div className="space-y-2">
+        {latestBatch.map((gen) => (
+          <ResultCard key={gen.id} gen={gen} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/simple-studio-shell/forms/ModelSelect.tsx
+++ b/src/components/simple-studio-shell/forms/ModelSelect.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+
+interface ProviderModel {
+  id: string;
+  name: string;
+  provider: string;
+  capabilities?: string[];
+}
+
+const RECOMMENDED_IMAGE_MODELS = new Set([
+  "nano-banana",
+  "nano-banana-pro",
+  "nano-banana-2",
+  "flux-2/pro-text-to-image",
+  "seedream/4.5-text-to-image",
+  "gpt-image/1.5-text-to-image",
+]);
+
+const RECOMMENDED_VIDEO_MODELS = new Set([
+  "veo-3.1/text-to-video",
+  "veo-3.1-fast/text-to-video",
+  "kling-2.6/text-to-video",
+  "veo3/text-to-video",
+  "wan/2-6-text-to-video",
+]);
+
+interface ModelSelectProps {
+  mode: "photo" | "video";
+  id: string;
+}
+
+export function ModelSelect({ mode, id }: ModelSelectProps) {
+  const selectedModelId = useSimpleStudioStore((s) => s.selectedModelId);
+  const setSelectedModel = useSimpleStudioStore((s) => s.setSelectedModel);
+
+  const [models, setModels] = useState<ProviderModel[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setIsLoading(true);
+    setHasError(false);
+
+    const capabilities =
+      mode === "video"
+        ? "text-to-video,image-to-video"
+        : "text-to-image,image-to-image";
+
+    fetch(`/api/models?capabilities=${capabilities}`, {
+      signal: controller.signal,
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        if (data.success) {
+          const seen = new Set<string>();
+          const unique = (data.models || []).filter((m: ProviderModel) => {
+            if (seen.has(m.id)) return false;
+            seen.add(m.id);
+            return true;
+          });
+          setModels(unique);
+        } else {
+          setHasError(true);
+        }
+      })
+      .catch((err) => {
+        if (controller.signal.aborted || err?.name === "AbortError") return;
+        setHasError(true);
+      })
+      .finally(() => {
+        if (controller.signal.aborted) return;
+        setIsLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [mode]);
+
+  const recommendedSet =
+    mode === "video" ? RECOMMENDED_VIDEO_MODELS : RECOMMENDED_IMAGE_MODELS;
+
+  // Sort: recommended first (alphabetical within group), then others (alphabetical)
+  const sorted = [...models].sort((a, b) => {
+    const aRec = recommendedSet.has(a.id);
+    const bRec = recommendedSet.has(b.id);
+    if (aRec && !bRec) return -1;
+    if (!aRec && bRec) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    if (value === "") {
+      setSelectedModel(null, null, null);
+      return;
+    }
+    const model = models.find((m) => m.id === value);
+    if (model) {
+      setSelectedModel(model.id, model.provider, model.name);
+    }
+  };
+
+  return (
+    <select
+      id={id}
+      className="w-full rounded-md border bg-background p-2 text-sm"
+      value={selectedModelId ?? ""}
+      onChange={handleChange}
+      disabled={isLoading && models.length === 0}
+    >
+      <option value="">Auto (default)</option>
+      {isLoading && models.length === 0 && (
+        <option disabled>Loading models…</option>
+      )}
+      {hasError && !isLoading && (
+        <option disabled>Failed to load models</option>
+      )}
+      {sorted.map((m) => (
+        <option key={m.id} value={m.id}>
+          {m.name} ({m.provider})
+          {recommendedSet.has(m.id) ? " — recommended" : ""}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/simple-studio-shell/forms/VideoForm.tsx
+++ b/src/components/simple-studio-shell/forms/VideoForm.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+import { Button } from "@/components/ui/button";
+import { FormPageLayout } from "./FormPageLayout";
+import { FormInfoPanel } from "./FormInfoPanel";
+
+const ASPECT_RATIOS = [
+  { value: "16:9", label: "16:9" },
+  { value: "9:16", label: "9:16" },
+];
+
+const BATCH_PRESETS = [1, 2, 4];
+const DURATIONS = [5, 8, 10];
+
+export function VideoForm() {
+  const prompt = useSimpleStudioStore((s) => s.prompt);
+  const setPrompt = useSimpleStudioStore((s) => s.setPrompt);
+  const aspectRatio = useSimpleStudioStore((s) => s.aspectRatio);
+  const setAspectRatio = useSimpleStudioStore((s) => s.setAspectRatio);
+  const batchCount = useSimpleStudioStore((s) => s.batchCount);
+  const setBatchCount = useSimpleStudioStore((s) => s.setBatchCount);
+  const videoDuration = useSimpleStudioStore((s) => s.videoDuration);
+  const setVideoDuration = useSimpleStudioStore((s) => s.setVideoDuration);
+  const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
+  const generate = useSimpleStudioStore((s) => s.generate);
+  const selectedModelName = useSimpleStudioStore((s) => s.selectedModelName);
+
+  const disabled = isGenerating || prompt.trim().length === 0;
+
+  return (
+    <FormPageLayout
+      infoPanel={
+        <FormInfoPanel
+          aspectRatios={ASPECT_RATIOS}
+          batchPresets={BATCH_PRESETS}
+          currentAspectRatio={aspectRatio}
+          onAspectRatioChange={setAspectRatio}
+          currentBatchCount={batchCount}
+          onBatchCountChange={setBatchCount}
+          estimatedCost={<span>{batchCount} video{batchCount > 1 ? "s" : ""}</span>}
+          outputExample={
+            <div className="aspect-video w-full rounded-md border bg-muted" />
+          }
+          tips={<p>Describe the motion and scene. Videos take longer to generate.</p>}
+        />
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="video-prompt" className="mb-2 block text-sm font-medium">
+            Prompt
+          </label>
+          <textarea
+            id="video-prompt"
+            className="min-h-32 w-full resize-y rounded-md border bg-background p-3 text-sm"
+            placeholder="Describe the video you want to generate…"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">Duration</label>
+          <div className="flex gap-2">
+            {DURATIONS.map((d) => (
+              <button
+                key={d}
+                type="button"
+                className={`rounded-md border px-3 py-1 text-xs ${
+                  videoDuration === d
+                    ? "border-primary bg-primary/10"
+                    : "border-border hover:bg-muted"
+                }`}
+                onClick={() => setVideoDuration(d)}
+              >
+                {d}s
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Model: {selectedModelName || "Auto (Veo 3.1)"}
+        </div>
+
+        <Button
+          type="button"
+          size="lg"
+          disabled={disabled}
+          onClick={() => {
+            void generate();
+          }}
+        >
+          {isGenerating ? "Generating…" : "Generate"}
+        </Button>
+      </div>
+    </FormPageLayout>
+  );
+}

--- a/src/components/simple-studio-shell/forms/VideoForm.tsx
+++ b/src/components/simple-studio-shell/forms/VideoForm.tsx
@@ -4,6 +4,8 @@ import { useSimpleStudioStore } from "@/store/simpleStudioStore";
 import { Button } from "@/components/ui/button";
 import { FormPageLayout } from "./FormPageLayout";
 import { FormInfoPanel } from "./FormInfoPanel";
+import { ModelSelect } from "./ModelSelect";
+import { LatestResultsInline } from "./LatestResultsInline";
 
 const ASPECT_RATIOS = [
   { value: "16:9", label: "16:9" },
@@ -24,7 +26,6 @@ export function VideoForm() {
   const setVideoDuration = useSimpleStudioStore((s) => s.setVideoDuration);
   const isGenerating = useSimpleStudioStore((s) => s.isGenerating);
   const generate = useSimpleStudioStore((s) => s.generate);
-  const selectedModelName = useSimpleStudioStore((s) => s.selectedModelName);
 
   const disabled = isGenerating || prompt.trim().length === 0;
 
@@ -80,8 +81,11 @@ export function VideoForm() {
           </div>
         </div>
 
-        <div className="text-xs text-muted-foreground">
-          Model: {selectedModelName || "Auto (Veo 3.1)"}
+        <div>
+          <label htmlFor="video-model" className="mb-2 block text-sm font-medium">
+            Model
+          </label>
+          <ModelSelect mode="video" id="video-model" />
         </div>
 
         <Button
@@ -94,6 +98,8 @@ export function VideoForm() {
         >
           {isGenerating ? "Generating…" : "Generate"}
         </Button>
+
+        <LatestResultsInline mode="video" />
       </div>
     </FormPageLayout>
   );

--- a/src/components/simple-studio-shell/forms/__tests__/CopyForm.test.tsx
+++ b/src/components/simple-studio-shell/forms/__tests__/CopyForm.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { CopyForm } from "../CopyForm";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+
+describe("CopyForm", () => {
+  beforeEach(() => {
+    useSimpleStudioStore.setState({
+      mode: "copy",
+      prompt: "",
+      tone: "professional",
+      platform: "general",
+      copyModelId: "gemini-2.5-flash",
+      batchCount: 1,
+      isGenerating: false,
+    });
+  });
+
+  it("renders a prompt textarea", () => {
+    render(<CopyForm />);
+    expect(screen.getByLabelText(/prompt/i)).toBeInTheDocument();
+  });
+
+  it("renders tone and platform selectors", () => {
+    render(<CopyForm />);
+    expect(screen.getByLabelText(/tone/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/platform/i)).toBeInTheDocument();
+  });
+
+  it("renders a Generate button", () => {
+    render(<CopyForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeInTheDocument();
+  });
+
+  it("clicking Generate calls generate", async () => {
+    const generateSpy = vi.fn().mockResolvedValue(undefined);
+    useSimpleStudioStore.setState({ prompt: "Ad copy", generate: generateSpy });
+    render(<CopyForm />);
+    await userEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(generateSpy).toHaveBeenCalled();
+  });
+
+  it("Generate is disabled with empty prompt", () => {
+    useSimpleStudioStore.setState({ prompt: "" });
+    render(<CopyForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+  });
+});

--- a/src/components/simple-studio-shell/forms/__tests__/FormPageLayout.test.tsx
+++ b/src/components/simple-studio-shell/forms/__tests__/FormPageLayout.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FormPageLayout } from "../FormPageLayout";
+
+describe("FormPageLayout", () => {
+  it("renders the form body slot", () => {
+    render(
+      <FormPageLayout infoPanel={<div>Info</div>}>
+        <div>Form body</div>
+      </FormPageLayout>,
+    );
+    expect(screen.getByText("Form body")).toBeInTheDocument();
+  });
+
+  it("renders the info panel slot", () => {
+    render(
+      <FormPageLayout infoPanel={<div>Info content</div>}>
+        <div>Form body</div>
+      </FormPageLayout>,
+    );
+    expect(screen.getByText("Info content")).toBeInTheDocument();
+  });
+
+  it("renders both slots in the same document", () => {
+    render(
+      <FormPageLayout infoPanel={<div data-testid="panel">Panel</div>}>
+        <div data-testid="body">Body</div>
+      </FormPageLayout>,
+    );
+    expect(screen.getByTestId("body")).toBeInTheDocument();
+    expect(screen.getByTestId("panel")).toBeInTheDocument();
+  });
+});

--- a/src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx
+++ b/src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx
@@ -13,6 +13,8 @@ describe("ImageForm", () => {
       batchCount: 4,
       isGenerating: false,
     });
+    // Stub fetch so ModelSelect's /api/models call doesn't race with test teardown
+    global.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
   });
 
   it("renders a prompt textarea", () => {

--- a/src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx
+++ b/src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx
@@ -52,6 +52,6 @@ describe("ImageForm", () => {
   it("Generate button is disabled while generating", () => {
     useSimpleStudioStore.setState({ prompt: "A cat", isGenerating: true });
     render(<ImageForm />);
-    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /generat/i })).toBeDisabled();
   });
 });

--- a/src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx
+++ b/src/components/simple-studio-shell/forms/__tests__/ImageForm.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { ImageForm } from "../ImageForm";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+
+describe("ImageForm", () => {
+  beforeEach(() => {
+    useSimpleStudioStore.setState({
+      mode: "photo",
+      prompt: "",
+      aspectRatio: "1:1",
+      batchCount: 4,
+      isGenerating: false,
+    });
+  });
+
+  it("renders a prompt textarea", () => {
+    render(<ImageForm />);
+    expect(screen.getByLabelText(/prompt/i)).toBeInTheDocument();
+  });
+
+  it("renders a Generate button", () => {
+    render(<ImageForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeInTheDocument();
+  });
+
+  it("typing in the prompt textarea updates the store", async () => {
+    render(<ImageForm />);
+    const textarea = screen.getByLabelText(/prompt/i);
+    await userEvent.type(textarea, "A cat");
+    expect(useSimpleStudioStore.getState().prompt).toBe("A cat");
+  });
+
+  it("clicking Generate calls the store's generate action", async () => {
+    const generateSpy = vi.fn().mockResolvedValue(undefined);
+    useSimpleStudioStore.setState({
+      prompt: "A cat",
+      generate: generateSpy,
+    });
+    render(<ImageForm />);
+    await userEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(generateSpy).toHaveBeenCalled();
+  });
+
+  it("Generate button is disabled when prompt is empty", () => {
+    useSimpleStudioStore.setState({ prompt: "" });
+    render(<ImageForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+  });
+
+  it("Generate button is disabled while generating", () => {
+    useSimpleStudioStore.setState({ prompt: "A cat", isGenerating: true });
+    render(<ImageForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+  });
+});

--- a/src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx
+++ b/src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { VideoForm } from "../VideoForm";
+import { useSimpleStudioStore } from "@/store/simpleStudioStore";
+
+describe("VideoForm", () => {
+  beforeEach(() => {
+    useSimpleStudioStore.setState({
+      mode: "video",
+      prompt: "",
+      aspectRatio: "16:9",
+      batchCount: 1,
+      videoDuration: 5,
+      isGenerating: false,
+    });
+  });
+
+  it("renders a prompt textarea", () => {
+    render(<VideoForm />);
+    expect(screen.getByLabelText(/prompt/i)).toBeInTheDocument();
+  });
+
+  it("renders a Generate button", () => {
+    render(<VideoForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeInTheDocument();
+  });
+
+  it("typing updates the store prompt", async () => {
+    render(<VideoForm />);
+    await userEvent.type(screen.getByLabelText(/prompt/i), "Sunset");
+    expect(useSimpleStudioStore.getState().prompt).toBe("Sunset");
+  });
+
+  it("clicking Generate calls the store's generate action", async () => {
+    const generateSpy = vi.fn().mockResolvedValue(undefined);
+    useSimpleStudioStore.setState({ prompt: "Sunset", generate: generateSpy });
+    render(<VideoForm />);
+    await userEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(generateSpy).toHaveBeenCalled();
+  });
+
+  it("Generate button is disabled when prompt is empty", () => {
+    useSimpleStudioStore.setState({ prompt: "" });
+    render(<VideoForm />);
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDisabled();
+  });
+});

--- a/src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx
+++ b/src/components/simple-studio-shell/forms/__tests__/VideoForm.test.tsx
@@ -14,6 +14,8 @@ describe("VideoForm", () => {
       videoDuration: 5,
       isGenerating: false,
     });
+    // Stub fetch so ModelSelect's /api/models call doesn't race with test teardown
+    global.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
   });
 
   it("renders a prompt textarea", () => {

--- a/src/components/simple-studio-shell/urlToMode.ts
+++ b/src/components/simple-studio-shell/urlToMode.ts
@@ -1,0 +1,22 @@
+import type { SimpleStudioMode } from "@/store/simpleStudioStore";
+
+export const URL_SEGMENT_TO_MODE: Record<"images" | "videos" | "copy", SimpleStudioMode> = {
+  images: "photo",
+  videos: "video",
+  copy: "copy",
+};
+
+export const MODE_TO_URL_SEGMENT: Record<SimpleStudioMode, "images" | "videos" | "copy"> = {
+  photo: "images",
+  video: "videos",
+  copy: "copy",
+};
+
+const PATH_REGEX = /^\/simple-studio\/(images|videos|copy)(?:\/|$)/;
+
+export function modeFromPathname(pathname: string): SimpleStudioMode | null {
+  const match = pathname.match(PATH_REGEX);
+  if (!match) return null;
+  const segment = match[1] as "images" | "videos" | "copy";
+  return URL_SEGMENT_TO_MODE[segment] ?? null;
+}

--- a/src/store/__tests__/simpleStudioShellStore.test.ts
+++ b/src/store/__tests__/simpleStudioShellStore.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSimpleStudioShellStore } from "../simpleStudioShellStore";
+
+describe("useSimpleStudioShellStore", () => {
+  beforeEach(() => {
+    // Reset store to initial state between tests
+    useSimpleStudioShellStore.setState({
+      savePromptDialogOpen: false,
+      libraryModeFilter: "all",
+      promptLibraryTab: "templates",
+    });
+  });
+
+  describe("save prompt dialog", () => {
+    it("initializes closed", () => {
+      expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(false);
+    });
+
+    it("openSavePromptDialog sets open to true", () => {
+      useSimpleStudioShellStore.getState().openSavePromptDialog();
+      expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(true);
+    });
+
+    it("closeSavePromptDialog sets open to false", () => {
+      useSimpleStudioShellStore.setState({ savePromptDialogOpen: true });
+      useSimpleStudioShellStore.getState().closeSavePromptDialog();
+      expect(useSimpleStudioShellStore.getState().savePromptDialogOpen).toBe(false);
+    });
+  });
+
+  describe("library mode filter", () => {
+    it("defaults to all", () => {
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("all");
+    });
+
+    it("setLibraryModeFilter updates the filter", () => {
+      useSimpleStudioShellStore.getState().setLibraryModeFilter("photo");
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("photo");
+
+      useSimpleStudioShellStore.getState().setLibraryModeFilter("video");
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("video");
+
+      useSimpleStudioShellStore.getState().setLibraryModeFilter("copy");
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("copy");
+
+      useSimpleStudioShellStore.getState().setLibraryModeFilter("all");
+      expect(useSimpleStudioShellStore.getState().libraryModeFilter).toBe("all");
+    });
+  });
+
+  describe("prompt library tab", () => {
+    it("defaults to templates", () => {
+      expect(useSimpleStudioShellStore.getState().promptLibraryTab).toBe("templates");
+    });
+
+    it("setPromptLibraryTab switches between templates and saved", () => {
+      useSimpleStudioShellStore.getState().setPromptLibraryTab("saved");
+      expect(useSimpleStudioShellStore.getState().promptLibraryTab).toBe("saved");
+
+      useSimpleStudioShellStore.getState().setPromptLibraryTab("templates");
+      expect(useSimpleStudioShellStore.getState().promptLibraryTab).toBe("templates");
+    });
+  });
+});

--- a/src/store/simpleStudioShellStore.ts
+++ b/src/store/simpleStudioShellStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+export type LibraryModeFilter = "all" | "photo" | "video" | "copy";
+export type PromptLibraryTab = "templates" | "saved";
+
+interface SimpleStudioShellState {
+  // Save prompt dialog
+  savePromptDialogOpen: boolean;
+  openSavePromptDialog: () => void;
+  closeSavePromptDialog: () => void;
+
+  // Library filter
+  libraryModeFilter: LibraryModeFilter;
+  setLibraryModeFilter: (mode: LibraryModeFilter) => void;
+
+  // Prompt library active tab
+  promptLibraryTab: PromptLibraryTab;
+  setPromptLibraryTab: (tab: PromptLibraryTab) => void;
+}
+
+export const useSimpleStudioShellStore = create<SimpleStudioShellState>((set) => ({
+  savePromptDialogOpen: false,
+  openSavePromptDialog: () => set({ savePromptDialogOpen: true }),
+  closeSavePromptDialog: () => set({ savePromptDialogOpen: false }),
+
+  libraryModeFilter: "all",
+  setLibraryModeFilter: (mode) => set({ libraryModeFilter: mode }),
+
+  promptLibraryTab: "templates",
+  setPromptLibraryTab: (tab) => set({ promptLibraryTab: tab }),
+}));


### PR DESCRIPTION
## Summary

- Builds a new top-level `/simple-studio` pillar with a sidebar+header dashboard shell mirroring the `/social` pattern (`SidebarProvider` + `SidebarInset` + AppSidebar + SiteHeader)
- Five routes: `/simple-studio/images`, `/videos`, `/copy`, `/library`, `/prompt-library`
- Form-first inline layout on each creation route: prompt textarea, model picker (dynamic from `/api/models`), aspect ratio, batch count, duration (video), tone/platform (copy) — all wired to the existing `useSimpleStudioStore`
- `LibraryGallery` on `/library` shows all past generations across modes with filter pills (All/Photo/Video/Copy)
- `PromptLibraryTabs` on `/prompt-library` shows Templates (public prompts) and Saved (private prompts) tabs, reusing existing `/api/studio/prompts` backend
- `SavePromptDialog` with editable prompt text, accessible from form pages and prompt library
- `AppSwitcher` updated: "AI Studio" split into "Simple Studio" + "Advanced Workflow" pillars
- Inline latest-results feedback below Generate button so users see output without navigating to Library
- **No new DB tables, no new API routes, no modifications to `useSimpleStudioStore`** — all backend reused from existing `/api/studio/prompts` infrastructure
- Old `/studio/simple` route is 100% untouched — deletion planned for a separate PR 2 after verification

## New files

- `src/app/simple-studio/` — 7 route files (layout, redirect, 5 pages)
- `src/components/simple-studio-shell/` — 12 components + 8 test files
- `src/store/simpleStudioShellStore.ts` — UI-only Zustand store (dialog, filter, tab state)

## Modified files

- `src/components/AppSwitcher.tsx` — split pillar entries
- `.gitignore` — added `.worktrees/`

## Test plan

- [x] 67 new tests, all passing (`pnpm test:run`)
- [x] No regressions — same 2 pre-existing unrelated failures as baseline
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Production build passes (`pnpm build`)
- [x] Manual QA: shell routing, sidebar nav, form submission, model pickers, inline results, Library gallery with filters, Prompt Library tabs, Save prompt dialog, AppSwitcher navigation
- [ ] Verify old `/studio/simple` still renders the legacy UI unchanged
- [ ] Test on mobile viewport (sidebar collapses, form stacks)

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-04-06-simple-studio-dashboard-shell-design.md`
- Plan: `docs/superpowers/plans/2026-04-06-simple-studio-dashboard-shell.md`

## Follow-ups (not in this PR)

- PR 2: delete old `/studio/simple` + `src/components/simple-studio/` + redirect stub
- Seed public prompt templates into DB
- Reference image upload in ImageForm/VideoForm
- Edit/delete actions on saved prompts in PromptLibraryTabs
- Library detail modal with full-res preview + regenerate
- `aria-pressed` on FormInfoPanel pill buttons
- `useShallow` convention alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)