### PR TITLE
Model fetch freshness: SWR + search-miss retry + Gemini discovery

### DIFF
--- a/docs/superpowers/plans/2026-04-14-model-fetch-freshness.md
+++ b/docs/superpowers/plans/2026-04-14-model-fetch-freshness.md
@@ -1,0 +1,1049 @@
+# Model Fetch Freshness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** New models from Replicate/Fal/WaveSpeed surface within minutes of upstream release (instead of up to 48h), and Gemini discovery of new Google models via `v1beta/models` supplements the existing hardcoded list.
+
+**Architecture:** Three isolated changes — (1) client-side SWR in `ModelSearchDialog.tsx`, (2) server-side search-miss retry in `/api/models/route.ts`, (3) server-side Gemini hybrid discovery in `/api/models/route.ts`. Each ships, tests, and reverts independently.
+
+**Tech Stack:** Next.js 16 App Router, TypeScript, Vitest (server tests), Zustand (client store — read-only here), `@xyflow/react` (adjacent but untouched), Google Generative Language REST API (`generativelanguage.googleapis.com/v1beta/models`).
+
+**Spec:** `docs/superpowers/specs/2026-04-14-model-fetch-freshness-design.md`
+
+**Branch:** `feature/model-fetch-freshness` (already created from `develop`).
+
+---
+
+## File Structure
+
+| File | Role | Change |
+|------|------|--------|
+| `src/app/api/models/route.ts` | Server route — aggregates providers, handles caching | Add `humanize()`, `fetchGeminiModels()`, revalidation-throttle map, search-miss retry block; replace hardcoded-only Gemini branch with hybrid discovery |
+| `src/components/modals/ModelSearchDialog.tsx` | Client — model search UI + fetch logic | Modify `fetchModels()` to implement stale-while-revalidate |
+| `src/app/api/models/__tests__/route.test.ts` | Existing vitest test file for the route | Extend with 7 new test cases (Tasks 2, 3, 4) |
+
+No new files created. All changes colocated with the code they modify.
+
+---
+
+## Task 1: Add `humanize()` helper
+
+**Files:**
+- Modify: `src/app/api/models/route.ts` (top-level helper section, near `filterModelsBySearch` at line 648)
+- Test: `src/app/api/models/__tests__/route.test.ts`
+
+Why this task exists: `fetchGeminiModels` (Task 2) needs `humanize` to convert raw model IDs like `gemini-4-pro-image-preview` into display names. TDD-driven, tiny, self-contained.
+
+- [ ] **Step 1.1: Write the failing test**
+
+Append to `src/app/api/models/__tests__/route.test.ts` inside the existing `describe("/api/models route", () => { ... })`:
+
+```ts
+  describe("humanize helper", () => {
+    it("converts kebab-case id to Title Case", async () => {
+      const { humanize } = await import("../route");
+      expect(humanize("gemini-4-pro-image-preview")).toBe("Gemini 4 Pro Image Preview");
+    });
+
+    it("handles snake_case ids", async () => {
+      const { humanize } = await import("../route");
+      expect(humanize("veo_3_fast")).toBe("Veo 3 Fast");
+    });
+
+    it("handles single-word ids", async () => {
+      const { humanize } = await import("../route");
+      expect(humanize("veo")).toBe("Veo");
+    });
+
+    it("preserves numeric segments", async () => {
+      const { humanize } = await import("../route");
+      expect(humanize("gemini-2.5-flash")).toBe("Gemini 2.5 Flash");
+    });
+  });
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts -t "humanize helper"`
+
+Expected: 4 failures with `humanize is not a function` or import error (function not yet exported).
+
+- [ ] **Step 1.3: Implement `humanize` and export it**
+
+In `src/app/api/models/route.ts`, add near the other top-level helpers (after `filterModelsBySearch`, around line 660):
+
+```ts
+/**
+ * Convert a raw model id (kebab-case, snake_case, dot-separated) to a display
+ * name by title-casing each segment.
+ *
+ * humanize("gemini-4-pro-image-preview") → "Gemini 4 Pro Image Preview"
+ * humanize("veo_3_fast")                 → "Veo 3 Fast"
+ * humanize("gemini-2.5-flash")           → "Gemini 2.5 Flash"
+ */
+export function humanize(id: string): string {
+  return id
+    .split(/[-_]/)
+    .map((segment) =>
+      segment.length === 0
+        ? segment
+        : segment[0].toUpperCase() + segment.slice(1)
+    )
+    .join(" ");
+}
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts -t "humanize helper"`
+
+Expected: 4 passed.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/app/api/models/route.ts src/app/api/models/__tests__/route.test.ts
+git commit -m "feat(models): add humanize helper for deriving display names"
+```
+
+---
+
+## Task 2: Add `fetchGeminiModels()` discovery function
+
+**Files:**
+- Modify: `src/app/api/models/route.ts` (add new function + inference helper below the existing WaveSpeed/Fal helpers, around line 935)
+- Test: `src/app/api/models/__tests__/route.test.ts`
+
+Why this task exists: discovery is the core of Gemini hybrid merge. Implementing + testing it in isolation (before wiring into `GET`) makes the failure surface smaller.
+
+- [ ] **Step 2.1: Write the failing test**
+
+Append to the existing test file inside the main `describe("/api/models route", ...)`:
+
+```ts
+  describe("fetchGeminiModels", () => {
+    beforeEach(() => {
+      global.fetch = mockFetch as unknown as typeof global.fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("returns only image/video models from the discovery response", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [
+              { name: "models/gemini-4-pro-image-preview", supportedGenerationMethods: ["generateContent"] },
+              { name: "models/veo-4-ultra", supportedGenerationMethods: ["predictLongRunning"] },
+              { name: "models/gemini-2.5-flash", supportedGenerationMethods: ["generateContent"] },
+              { name: "models/text-embedding-004", supportedGenerationMethods: ["embedContent"] },
+            ],
+          }),
+      });
+
+      const result = await fetchGeminiModels("fake-key");
+
+      expect(result.map((m) => m.id).sort()).toEqual(["gemini-4-pro-image-preview", "veo-4-ultra"]);
+    });
+
+    it("infers image capabilities for ids containing 'image'", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [{ name: "models/gemini-4-pro-image-preview", supportedGenerationMethods: ["generateContent"] }],
+          }),
+      });
+
+      const result = await fetchGeminiModels("fake-key");
+      expect(result[0]).toMatchObject({
+        id: "gemini-4-pro-image-preview",
+        name: "Gemini 4 Pro Image Preview",
+        provider: "gemini",
+        capabilities: ["text-to-image", "image-to-image"],
+      });
+      expect(result[0].pricing).toBeUndefined();
+      expect(result[0].coverImage).toBeUndefined();
+    });
+
+    it("infers video capabilities for veo-* ids", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [{ name: "models/veo-4-ultra", supportedGenerationMethods: ["predictLongRunning"] }],
+          }),
+      });
+
+      const result = await fetchGeminiModels("fake-key");
+      expect(result[0].capabilities).toEqual(["text-to-video", "image-to-video"]);
+    });
+
+    it("returns [] on HTTP error", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      });
+
+      const result = await fetchGeminiModels("bad-key");
+      expect(result).toEqual([]);
+    });
+
+    it("returns [] on network throw", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+      const result = await fetchGeminiModels("fake-key");
+      expect(result).toEqual([]);
+    });
+
+    it("paginates when nextPageToken is present", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              models: [{ name: "models/gemini-5-image", supportedGenerationMethods: ["generateContent"] }],
+              nextPageToken: "page2",
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              models: [{ name: "models/veo-5", supportedGenerationMethods: ["predictLongRunning"] }],
+            }),
+        });
+
+      const result = await fetchGeminiModels("fake-key");
+      expect(result.map((m) => m.id).sort()).toEqual(["gemini-5-image", "veo-5"]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts -t "fetchGeminiModels"`
+
+Expected: 6 failures with `fetchGeminiModels is not a function` or import error.
+
+- [ ] **Step 2.3: Implement `fetchGeminiModels`**
+
+Add the following in `src/app/api/models/route.ts` after the `fetchWaveSpeedModels` function (around line 853). The `humanize` import from the same module is already available since it's in the same file.
+
+```ts
+// ============ Gemini Discovery ============
+
+const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+const GEMINI_DISCOVERY_TIMEOUT_MS = 5000;
+
+interface GeminiDiscoveryModel {
+  name: string; // e.g. "models/gemini-4-pro-image-preview"
+  supportedGenerationMethods?: string[];
+}
+
+interface GeminiDiscoveryResponse {
+  models?: GeminiDiscoveryModel[];
+  nextPageToken?: string;
+}
+
+function inferGeminiCapabilities(id: string): ModelCapability[] | null {
+  const lower = id.toLowerCase();
+  if (lower.includes("image")) {
+    return ["text-to-image", "image-to-image"];
+  }
+  if (lower.startsWith("veo-") || lower.includes("video")) {
+    return ["text-to-video", "image-to-video"];
+  }
+  return null;
+}
+
+/**
+ * Discover Gemini models via the Google Generative Language API.
+ *
+ * Filters to image/video generation models only. Returns [] on any failure
+ * (network, auth, malformed response, timeout) — caller is expected to fall
+ * back to the hardcoded list.
+ *
+ * Timeout: 5s total across all pages (shared AbortSignal).
+ */
+export async function fetchGeminiModels(apiKey: string): Promise<ProviderModel[]> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), GEMINI_DISCOVERY_TIMEOUT_MS);
+
+  try {
+    const discovered: ProviderModel[] = [];
+    let pageToken: string | undefined;
+    let pageCount = 0;
+    const maxPages = 10; // safety bound
+
+    do {
+      const url = new URL(`${GEMINI_API_BASE}/models`);
+      url.searchParams.set("key", apiKey);
+      url.searchParams.set("pageSize", "100");
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+
+      const response = await fetch(url.toString(), { signal: controller.signal });
+      if (!response.ok) {
+        console.warn(`[Models] gemini discovery HTTP ${response.status}`);
+        return [];
+      }
+
+      const data = (await response.json()) as GeminiDiscoveryResponse;
+      const models = data.models ?? [];
+
+      for (const model of models) {
+        const rawId = model.name.replace(/^models\//, "");
+        const capabilities = inferGeminiCapabilities(rawId);
+        if (!capabilities) continue;
+
+        discovered.push({
+          id: rawId,
+          name: humanize(rawId),
+          description: "Newly discovered Gemini model. Metadata may be incomplete.",
+          provider: "gemini",
+          capabilities,
+        });
+      }
+
+      pageToken = data.nextPageToken;
+      pageCount++;
+    } while (pageToken && pageCount < maxPages);
+
+    return discovered;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[Models] gemini discovery failed: ${message}`);
+    return [];
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts -t "fetchGeminiModels"`
+
+Expected: 6 passed.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/app/api/models/route.ts src/app/api/models/__tests__/route.test.ts
+git commit -m "feat(models): add Gemini discovery via v1beta/models endpoint"
+```
+
+---
+
+## Task 3: Wire Gemini hybrid discovery into GET handler
+
+**Files:**
+- Modify: `src/app/api/models/route.ts` (the `includeGemini` branch in the `GET` handler, currently at lines 1040–1053)
+- Test: `src/app/api/models/__tests__/route.test.ts`
+
+Why this task exists: now that `fetchGeminiModels` works in isolation, merge it into the actual request flow with cache + hardcoded-wins-on-collision semantics.
+
+- [ ] **Step 3.1: Write the failing test**
+
+Append to the test file:
+
+```ts
+  describe("Gemini hybrid discovery in GET", () => {
+    beforeEach(() => {
+      global.fetch = mockFetch as unknown as typeof global.fetch;
+      process.env.GEMINI_API_KEY = "test-gemini-key";
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      delete process.env.GEMINI_API_KEY;
+    });
+
+    it("merges discovered models with hardcoded list (hardcoded wins on collision)", async () => {
+      // Discovery returns "nano-banana" (which is already hardcoded) plus a new "gemini-9-image"
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [
+              { name: "models/nano-banana", supportedGenerationMethods: ["generateContent"] },
+              { name: "models/gemini-9-image", supportedGenerationMethods: ["generateContent"] },
+            ],
+          }),
+      });
+
+      const request = createMockGetRequest({ provider: "gemini" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+
+      const geminiModels = data.models.filter((m: { provider: string }) => m.provider === "gemini");
+      const nanoBanana = geminiModels.find((m: { id: string }) => m.id === "nano-banana");
+      const newModel = geminiModels.find((m: { id: string }) => m.id === "gemini-9-image");
+
+      // Hardcoded wins: description/pricing from hardcoded, NOT from discovery stub
+      expect(nanoBanana.description).toContain("Fast image generation");
+      expect(nanoBanana.pricing).toEqual({ type: "per-run", amount: 0.039, currency: "USD" });
+
+      // Discovered-only model has the stub shape
+      expect(newModel).toMatchObject({
+        name: "Gemini 9 Image",
+        description: "Newly discovered Gemini model. Metadata may be incomplete.",
+        capabilities: ["text-to-image", "image-to-image"],
+      });
+      expect(newModel.pricing).toBeUndefined();
+    });
+
+    it("falls back to hardcoded list when discovery fails", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("boom"));
+
+      const request = createMockGetRequest({ provider: "gemini" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      const ids = data.models.map((m: { id: string }) => m.id);
+      expect(ids).toContain("nano-banana");
+      expect(ids).toContain("nano-banana-2");
+      // No discovered-only models present
+      expect(ids.every((id: string) => !id.startsWith("gemini-9"))).toBe(true);
+    });
+
+    it("skips discovery and returns hardcoded only when GEMINI_API_KEY missing", async () => {
+      delete process.env.GEMINI_API_KEY;
+
+      const request = createMockGetRequest({ provider: "gemini" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+      const ids = data.models.map((m: { id: string }) => m.id);
+      expect(ids).toContain("nano-banana");
+    });
+
+    it("uses cached discovery when available", async () => {
+      // Prime cache with a discovered model
+      mockGetCachedModels.mockImplementation((key: string) => {
+        if (key === "gemini:models") {
+          return [
+            {
+              id: "cached-gemini-model",
+              name: "Cached Gemini Model",
+              description: "From cache",
+              provider: "gemini",
+              capabilities: ["text-to-image", "image-to-image"],
+            },
+          ];
+        }
+        return null;
+      });
+
+      const request = createMockGetRequest({ provider: "gemini" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      const ids = data.models.map((m: { id: string }) => m.id);
+      expect(ids).toContain("cached-gemini-model");
+
+      // Reset the cache mock so it doesn't leak to subsequent tests
+      mockGetCachedModels.mockReturnValue(null);
+    });
+  });
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts -t "Gemini hybrid discovery"`
+
+Expected: 4 failures — current code returns only the hardcoded list and does not attempt discovery.
+
+- [ ] **Step 3.3: Replace the `includeGemini` branch in the GET handler**
+
+In `src/app/api/models/route.ts`, locate the block starting at line 1040:
+
+```ts
+  // Add Gemini models first if included (they appear at the top)
+  if (includeGemini) {
+    // Filter by search query if provided
+    let geminiModels = [...GEMINI_IMAGE_MODELS, ...GEMINI_VIDEO_MODELS];
+    if (searchQuery) {
+      geminiModels = filterModelsBySearch(geminiModels, searchQuery);
+    }
+    allModels.push(...geminiModels);
+    providerResults["gemini"] = {
+      success: true,
+      count: geminiModels.length,
+      cached: true, // Hardcoded models are effectively "cached"
+    };
+    anyFromCache = true;
+  }
+```
+
+Replace it with:
+
+```ts
+  // Add Gemini models first if included (they appear at the top)
+  if (includeGemini) {
+    const hardcoded = [...GEMINI_IMAGE_MODELS, ...GEMINI_VIDEO_MODELS];
+
+    // Discovery is additive: try cache first, then fresh fetch, then fall back to empty.
+    let discovered: ProviderModel[] = [];
+    let discoveryFromCache = false;
+    const geminiKey = process.env.GEMINI_API_KEY;
+
+    if (geminiKey) {
+      const cacheKey = getCacheKey("gemini");
+      const cached = refresh ? null : getCachedModels(cacheKey);
+      if (cached) {
+        discovered = cached;
+        discoveryFromCache = true;
+        anyFromCache = true;
+      } else {
+        discovered = await fetchGeminiModels(geminiKey);
+        if (discovered.length > 0) {
+          setCachedModels(cacheKey, discovered);
+        }
+        allFromCache = false;
+      }
+    }
+
+    // Hardcoded wins on ID collision
+    const hardcodedIds = new Set(hardcoded.map((m) => m.id));
+    const additions = discovered.filter((m) => !hardcodedIds.has(m.id));
+    let geminiModels: ProviderModel[] = [...hardcoded, ...additions];
+
+    if (searchQuery) {
+      geminiModels = filterModelsBySearch(geminiModels, searchQuery);
+    }
+
+    allModels.push(...geminiModels);
+    providerResults["gemini"] = {
+      success: true,
+      count: geminiModels.length,
+      cached: discoveryFromCache,
+    };
+    if (discoveryFromCache) {
+      anyFromCache = true;
+    }
+  }
+```
+
+- [ ] **Step 3.4: Run the Gemini tests to verify they pass**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts -t "Gemini hybrid discovery"`
+
+Expected: 4 passed.
+
+- [ ] **Step 3.5: Run the full test file to confirm no regressions**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts`
+
+Expected: all tests pass (new tests + all pre-existing ones). If any pre-existing test asserts a specific hardcoded-only count for the Gemini provider, update it to allow extra discovered models OR add an explicit "no discovery" setup (delete `GEMINI_API_KEY`) to those tests.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add src/app/api/models/route.ts src/app/api/models/__tests__/route.test.ts
+git commit -m "feat(models): hybrid Gemini discovery in GET handler"
+```
+
+---
+
+## Task 4: Server-side search-miss retry with throttle
+
+**Files:**
+- Modify: `src/app/api/models/route.ts` (add throttle map near top; add retry block in `GET` after provider loop, currently around line 1147)
+- Test: `src/app/api/models/__tests__/route.test.ts`
+
+Why this task exists: this is the change that directly fixes the user-visible "I searched for seedance-3 and got nothing" case. Independent of Gemini work.
+
+- [ ] **Step 4.1: Write the failing test**
+
+Append to the test file:
+
+```ts
+  describe("Search-miss retry", () => {
+    beforeEach(() => {
+      global.fetch = mockFetch as unknown as typeof global.fetch;
+      process.env.REPLICATE_API_KEY = "fake-replicate-key";
+      // Ensure Gemini discovery is a no-op (no key, so it won't fire)
+      delete process.env.GEMINI_API_KEY;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      delete process.env.REPLICATE_API_KEY;
+    });
+
+    it("retries with cache bypass when cache-hit returned zero matches for search", async () => {
+      // Cache returns an empty list for the Replicate base key
+      mockGetCachedModels.mockImplementation((key: string) => {
+        if (key === "replicate:models") return [];
+        return null;
+      });
+
+      // First fresh fetch (cache-bypass retry) returns seedance-3
+      mockFetch.mockResolvedValueOnce(
+        createReplicateResponse(
+          [{ owner: "bytedance", name: "seedance-3", description: "new video model" }],
+          null
+        )
+      );
+
+      const request = createMockGetRequest({ search: "seedance-3", provider: "replicate" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(data.models.some((m: { id: string }) => m.id.includes("seedance-3"))).toBe(true);
+      // Confirm the fresh replicate call happened
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // Confirm cache was rewritten
+      expect(mockSetCachedModels).toHaveBeenCalledWith("replicate:models", expect.any(Array));
+
+      // Reset
+      mockGetCachedModels.mockReturnValue(null);
+    });
+
+    it("does NOT retry when refresh=true is already set", async () => {
+      mockGetCachedModels.mockReturnValue(null); // force fresh fetch path anyway
+      mockFetch.mockResolvedValueOnce(createReplicateResponse([], null));
+
+      const request = createMockGetRequest({
+        search: "nonexistent-model",
+        provider: "replicate",
+        refresh: "true",
+      });
+      const response = await GET(request);
+      await response.json();
+
+      // Only ONE fetch call: the initial refresh=true fetch. No retry on top.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry when no providers were cache-hit", async () => {
+      mockGetCachedModels.mockReturnValue(null); // all cache misses
+      mockFetch.mockResolvedValueOnce(createReplicateResponse([], null));
+
+      const request = createMockGetRequest({ search: "nothing", provider: "replicate" });
+      const response = await GET(request);
+      await response.json();
+
+      // Only the initial fetch; no retry since we weren't serving from cache
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry within 60s of a previous retry for the same cache key", async () => {
+      mockGetCachedModels.mockImplementation((key: string) => {
+        if (key === "replicate:models") return [];
+        return null;
+      });
+
+      // First request: retry fires, returns empty
+      mockFetch.mockResolvedValueOnce(createReplicateResponse([], null));
+      const r1 = await GET(createMockGetRequest({ search: "unicorn", provider: "replicate" }));
+      await r1.json();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Second request within throttle window: NO retry, no fetch
+      const r2 = await GET(createMockGetRequest({ search: "unicorn", provider: "replicate" }));
+      const data2 = await r2.json();
+      expect(mockFetch).toHaveBeenCalledTimes(1); // unchanged
+      expect(data2.models).toEqual([]);
+
+      // Reset
+      mockGetCachedModels.mockReturnValue(null);
+    });
+  });
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts -t "Search-miss retry"`
+
+Expected: 4 failures (no retry logic yet — the first test will see zero fetch calls, others will see different mismatches).
+
+- [ ] **Step 4.3: Add the throttle map near the top of `route.ts`**
+
+After the constants block (around line 44, after `WAVESPEED_API_BASE`):
+
+```ts
+// Search-miss retry throttle: per-cache-key timestamp of last cache-bypass retry.
+// Prevents repeated upstream calls for gibberish searches.
+const SEARCH_MISS_RETRY_THROTTLE_MS = 60_000;
+const searchMissRetryThrottle = new Map<string, number>();
+```
+
+- [ ] **Step 4.4: Add the retry block in the GET handler**
+
+In `src/app/api/models/route.ts`, locate the comment at line 1149 (`// Check if we got any models`). Insert the retry block **before** that comment.
+
+Current code (around line 1147):
+
+```ts
+    // Add to results
+    allModels.push(...models);
+    providerResults[provider] = {
+      success: true,
+      count: models.length,
+      cached: fromCache,
+    };
+  }
+
+  // Check if we got any models
+```
+
+Insert the retry block between the closing `}` of the provider loop and the `// Check if we got any models` comment:
+
+```ts
+  }
+
+  // Search-miss retry: if a search yielded zero matches but results came from cache,
+  // bypass cache once for the cache-hit providers and retry upstream.
+  if (
+    searchQuery &&
+    !refresh &&
+    allModels.length === 0 &&
+    anyFromCache
+  ) {
+    const cacheHitProviders = Object.entries(providerResults)
+      .filter(([, result]) => result.success && result.cached)
+      .map(([provider]) => provider as ProviderType)
+      .filter((p) => p === "replicate" || p === "fal" || p === "wavespeed");
+
+    for (const provider of cacheHitProviders) {
+      const cacheKey =
+        provider === "replicate" || provider === "wavespeed"
+          ? getCacheKey(provider)
+          : getCacheKey(provider, searchQuery);
+
+      // Throttle: skip if this cache key was revalidated within the window
+      const lastRetry = searchMissRetryThrottle.get(cacheKey) ?? 0;
+      if (Date.now() - lastRetry < SEARCH_MISS_RETRY_THROTTLE_MS) {
+        continue;
+      }
+      searchMissRetryThrottle.set(cacheKey, Date.now());
+
+      try {
+        let fresh: ProviderModel[] = [];
+        if (provider === "replicate") {
+          const all = await fetchReplicateModels(replicateKey!);
+          setCachedModels(cacheKey, all);
+          fresh = searchQuery ? filterModelsBySearch(all, searchQuery) : all;
+        } else if (provider === "fal") {
+          fresh = await fetchFalModels(falKey, searchQuery);
+          setCachedModels(cacheKey, fresh);
+        } else if (provider === "wavespeed") {
+          const all = await fetchWaveSpeedModels(wavespeedKey!);
+          setCachedModels(cacheKey, all);
+          fresh = searchQuery ? filterModelsBySearch(all, searchQuery) : all;
+        }
+        allModels.push(...fresh);
+        providerResults[provider] = {
+          success: true,
+          count: fresh.length,
+          cached: false,
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        console.warn(`[Models] ${provider} search-miss retry failed: ${errorMessage}`);
+        // Leave the original empty-but-cached result in place
+      }
+    }
+  }
+
+  // Check if we got any models
+```
+
+- [ ] **Step 4.5: Run the search-miss tests to verify they pass**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts -t "Search-miss retry"`
+
+Expected: 4 passed.
+
+- [ ] **Step 4.6: Run the full test file to confirm no regressions**
+
+Run: `pnpm vitest run src/app/api/models/__tests__/route.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add src/app/api/models/route.ts src/app/api/models/__tests__/route.test.ts
+git commit -m "feat(models): server-side search-miss retry with 60s throttle"
+```
+
+---
+
+## Task 5: Client-side stale-while-revalidate
+
+**Files:**
+- Modify: `src/components/modals/ModelSearchDialog.tsx` (the `fetchModels` function at lines 175–272)
+
+Why this task exists: ensures users see fresh data on dialog open without ever seeing a loading spinner for a cache-hit. Per spec, no unit tests — manual QA only.
+
+- [ ] **Step 5.1: Modify `fetchModels` to implement SWR**
+
+In `src/components/modals/ModelSearchDialog.tsx`, locate the `fetchModels` function at line 175. Replace the entire function body (keeping the `useCallback` wrapper and dependencies) with:
+
+```ts
+  // Fetch models with stale-while-revalidate: cache-hit returns immediately, then a
+  // background revalidate silently refreshes state + localStorage if upstream differs.
+  const fetchModels = useCallback(async (bypassCache = false) => {
+    // Increment version to track this request
+    const thisVersion = ++requestVersionRef.current;
+
+    // Build cache key from filters
+    const cacheKey = `${providerFilter}:${capabilityFilter}:${debouncedSearch}`;
+
+    // Helper: build query params + headers for an API call
+    const buildRequest = (forceRefresh: boolean) => {
+      const params = new URLSearchParams();
+      if (debouncedSearch) params.set("search", debouncedSearch);
+      if (providerFilter !== "all") params.set("provider", providerFilter);
+      if (capabilityFilter !== "all") {
+        const capabilities =
+          capabilityFilter === "image"
+            ? "text-to-image,image-to-image"
+            : capabilityFilter === "video"
+            ? "text-to-video,image-to-video"
+            : capabilityFilter === "3d"
+            ? "text-to-3d,image-to-3d"
+            : "text-to-audio";
+        params.set("capabilities", capabilities);
+      }
+      if (forceRefresh) params.set("refresh", "true");
+
+      const headers: Record<string, string> = {};
+      if (replicateApiKey) headers["X-Replicate-Key"] = replicateApiKey;
+      if (falApiKey) headers["X-Fal-Key"] = falApiKey;
+      if (kieApiKey) headers["X-Kie-Key"] = kieApiKey;
+      if (wavespeedApiKey) headers["X-WaveSpeed-Key"] = wavespeedApiKey;
+
+      return { params, headers };
+    };
+
+    // Helper: hash the model list by length + sorted id signature. Used to detect
+    // whether an SWR revalidation response actually changed anything.
+    const signature = (models: ProviderModel[]): string =>
+      `${models.length}:${models
+        .map((m) => m.id)
+        .sort()
+        .join(",")}`;
+
+    // Check localStorage cache first (skip when bypassing)
+    const cached = bypassCache ? null : getCachedModels(cacheKey);
+    if (cached) {
+      // Serve cached immediately, no spinner
+      setModels(cached.models);
+      if (cached.availableProviders) {
+        setServerAvailableProviders(cached.availableProviders);
+      }
+
+      // Background revalidate: fire and forget, only update if response differs
+      (async () => {
+        try {
+          const { params, headers } = buildRequest(false);
+          const response = await deduplicatedFetch(`/api/models?${params.toString()}`, {
+            headers,
+          });
+
+          // Drop if filters changed while we were in flight
+          if (thisVersion !== requestVersionRef.current) return;
+
+          const data: ModelsResponse = await response.json();
+          if (!data.success || !data.models) return;
+
+          const cachedSig = signature(cached.models);
+          const freshSig = signature(data.models);
+          if (cachedSig !== freshSig) {
+            console.debug("[ModelSearch] SWR detected diff, updating", {
+              cachedCount: cached.models.length,
+              freshCount: data.models.length,
+            });
+            setModels(data.models);
+            setCachedModels(cacheKey, data.models, data.availableProviders);
+            if (data.availableProviders) {
+              setServerAvailableProviders(data.availableProviders);
+            }
+          }
+        } catch (err) {
+          // Silent: cached data is still good. Log for devtools.
+          console.warn("[ModelSearch] SWR revalidate failed:", err);
+        }
+      })();
+
+      return;
+    }
+
+    // Cache miss: show spinner and fetch normally
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const { params, headers } = buildRequest(bypassCache);
+      const response = await deduplicatedFetch(`/api/models?${params.toString()}`, {
+        headers,
+      });
+
+      // Check if this request is still current
+      if (thisVersion !== requestVersionRef.current) {
+        return; // Ignore stale response
+      }
+
+      const data: ModelsResponse = await response.json();
+
+      if (data.success && data.models) {
+        setModels(data.models);
+        setCachedModels(cacheKey, data.models, data.availableProviders);
+        if (data.availableProviders) {
+          setServerAvailableProviders(data.availableProviders);
+        }
+      } else {
+        setError(data.error || "Failed to fetch models");
+        setModels([]);
+      }
+    } catch (err) {
+      if (thisVersion !== requestVersionRef.current) {
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Failed to fetch models");
+      setModels([]);
+    } finally {
+      if (thisVersion === requestVersionRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [debouncedSearch, providerFilter, capabilityFilter, replicateApiKey, falApiKey, kieApiKey, wavespeedApiKey]);
+```
+
+- [ ] **Step 5.2: Typecheck + lint**
+
+Run: `pnpm lint`
+
+Expected: no new errors in `ModelSearchDialog.tsx`.
+
+Run: `pnpm build` (optional, slower) — or if the project has a dedicated typecheck script, use that instead.
+
+Expected: build succeeds.
+
+- [ ] **Step 5.3: Manual QA — cold cache path**
+
+```bash
+pnpm dev
+```
+
+Open `http://localhost:3000`, click "All models" in the FloatingActionBar. First open (cold cache) should show a spinner briefly, then the list.
+
+- [ ] **Step 5.4: Manual QA — warm cache with SWR**
+
+Close the dialog. Reopen it. In the browser devtools:
+- **Network tab:** expect a background `GET /api/models` request to fire.
+- **Console tab:** if the response differs from cached, expect `[ModelSearch] SWR detected diff, updating ...`. If identical, no log.
+- **UI:** the list renders instantly; no spinner.
+
+- [ ] **Step 5.5: Manual QA — search-miss surfaces fresh models**
+
+With a warm-but-old cache in localStorage, search for a model that has just been published upstream (if available — otherwise artificially age the cache by editing the `timestamp` in `localStorage` via devtools). Expect the first search to render empty-from-cache, then shortly after the SWR revalidate + server search-miss retry chain, the model appears.
+
+- [ ] **Step 5.6: Manual QA — rapid filter switching**
+
+Open the dialog, type quickly to change the search several times, then switch providers. Expect no stale results to leak into the UI. This verifies the `requestVersionRef` guard.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add src/components/modals/ModelSearchDialog.tsx
+git commit -m "feat(models): client-side stale-while-revalidate for model list"
+```
+
+---
+
+## Task 6: Verification pass
+
+**Files:** none modified, verification only.
+
+- [ ] **Step 6.1: Full test suite**
+
+Run: `pnpm test:run`
+
+Expected: all tests pass. If anything breaks outside of `src/app/api/models/__tests__/route.test.ts`, investigate — SWR should be isolated, but a neighbor test could have assumed a specific Gemini model count.
+
+- [ ] **Step 6.2: Lint**
+
+Run: `pnpm lint`
+
+Expected: no new warnings or errors introduced.
+
+- [ ] **Step 6.3: Build**
+
+Run: `pnpm build`
+
+Expected: build succeeds with no type errors.
+
+- [ ] **Step 6.4: Manual QA final checklist** (from the spec)
+
+- [ ] Cold cache → dialog opens, list loads with spinner.
+- [ ] Warm cache → dialog opens instantly, devtools Network tab shows a background `/api/models` call.
+- [ ] Warm cache + SWR detects diff → UI updates in place (verify via `console.debug` log).
+- [ ] Search for a known-new model with warm-but-stale cache → blocking refetch, model appears.
+- [ ] Revoke `GEMINI_API_KEY` → Gemini tab still shows hardcoded models.
+- [ ] Rapid filter switching during background revalidate → no stale results leak into UI.
+
+- [ ] **Step 6.5: Create PR targeting develop**
+
+```bash
+git push -u origin feature/model-fetch-freshness
+gh pr create --base develop --title "Model fetch freshness: SWR + search-miss retry + Gemini discovery" --body "$(cat <<'EOF'
+## Summary
+- Client-side stale-while-revalidate in `ModelSearchDialog`: cache-hit returns instantly, then a background revalidate silently updates the UI if upstream differs.
+- Server-side search-miss retry in `/api/models/route.ts`: when a searched query returns zero results against a cache-hit provider, bypass cache once and retry upstream (with a 60s per-cache-key throttle).
+- Server-side hybrid Gemini discovery: merges Google's `v1beta/models` response with the hardcoded `GEMINI_IMAGE_MODELS` / `GEMINI_VIDEO_MODELS` arrays; hardcoded wins on ID collision, discovery-only models surface with minimal metadata.
+
+Spec: `docs/superpowers/specs/2026-04-14-model-fetch-freshness-design.md`
+
+## Test plan
+- [x] `pnpm test:run` passes
+- [x] Cold cache: dialog loads list with spinner
+- [x] Warm cache: instant render + background `/api/models` call visible in Network tab
+- [x] SWR diff: `[ModelSearch] SWR detected diff, updating` appears when upstream changed
+- [x] Search-miss retry: searching a new model surfaces it within seconds
+- [x] Gemini discovery fallback: works with `GEMINI_API_KEY` unset
+- [x] Rapid filter switching during revalidate does not leak stale results
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Done
+
+Total commits: 5 feature commits + 1 spec commit already on branch.
+
+Net diff:
+- `src/app/api/models/route.ts`: +~140 lines (humanize, fetchGeminiModels + helpers, hybrid merge block, throttle + retry block)
+- `src/components/modals/ModelSearchDialog.tsx`: ~60 lines modified (fetchModels body)
+- `src/app/api/models/__tests__/route.test.ts`: +~250 lines (18 new assertions across 4 describe blocks)

--- a/docs/superpowers/specs/2026-04-14-model-fetch-freshness-design.md
+++ b/docs/superpowers/specs/2026-04-14-model-fetch-freshness-design.md
@@ -1,0 +1,247 @@
+# Model Fetch Freshness — Design
+
+**Date:** 2026-04-14
+**Branch:** `feature/model-fetch-freshness`
+**Status:** Design (pre-implementation)
+
+## Problem
+
+Users cannot find newly-released models in the model search dialog until caches expire. Two distinct causes:
+
+1. **Stale cached lists** for API-backed providers (Replicate, Fal, WaveSpeed). The client caches `/api/models` responses in localStorage for 48h, and the server caches upstream responses in-memory for 1h. A user who searched yesterday sees yesterday's model list for up to 48h.
+2. **Hardcoded providers** (Gemini, Kie) cannot surface new models at all without a code change. Gemini is the priority here — Google ships new image/video models frequently.
+
+The current manual "refresh" button exists but is not discoverable and puts the burden on the user to notice staleness.
+
+## Goals
+
+- A user searching for a just-released model from Replicate, Fal, WaveSpeed, or Gemini should find it without manual action.
+- Existing cached-list UX (instant open) stays instant.
+- No change to the manual refresh button — it remains as an escape hatch.
+- Kie is out of scope (no discovery API; a remote manifest was considered and deferred).
+
+## Non-goals
+
+- Revamp of the schema cache (`/api/models/[modelId]`). Discovered Gemini models will fall back to generic schemas — acceptable for v1.
+- Remote manifest for Kie. Deferred; ops complexity not yet warranted.
+- Changes to cost tracking, model registry format, or downstream node execution.
+
+## Architecture
+
+Three coordinated, isolated changes:
+
+1. **Client SWR** in `ModelSearchDialog.tsx` — cache hit returns immediately, then a background revalidate updates state if the upstream returned different data.
+2. **Server search-miss retry** in `/api/models/route.ts` — when a searched query returns zero results against a cached provider, transparently bypass cache for just that provider and retry once.
+3. **Gemini hybrid discovery** in `/api/models/route.ts` — call Google's `v1beta/models` endpoint at request time, merge with hardcoded `GEMINI_IMAGE_MODELS` / `GEMINI_VIDEO_MODELS` (hardcoded wins on ID collision).
+
+Each change is independent and can ship, be reverted, or tested separately.
+
+## Change 1 — Client SWR
+
+**File:** `src/components/modals/ModelSearchDialog.tsx`
+
+Current `fetchModels` (lines 175–272):
+
+```
+cache hit  → setModels(cached), return
+cache miss → setLoading(true) → fetch → setModels → cache
+```
+
+New flow:
+
+```
+cache hit  → setModels(cached) immediately
+          → fire background revalidate (no loading state)
+          → on response: if models changed, update state + localStorage
+cache miss → setLoading(true) → fetch → setModels → cache  [unchanged]
+```
+
+**"Different from cached" comparison** — compute `models.length + hash of sorted model.id list`. Cheap, detects adds/removes. Equal → skip state update. Not comparing full model shape (capabilities, descriptions can vary and would churn state without material UX change).
+
+**Race guard** — the background revalidate bumps the same `requestVersionRef` (`ModelSearchDialog.tsx:149`). If the user changes filters mid-flight, the stale response is discarded.
+
+**Loading indicator** — no spinner during revalidate. Optional future addition: a subtle pulsing dot on the refresh icon. Deferred.
+
+**Failure handling** — background revalidate throws → `console.warn` + keep cached data. Never surfaces as an error state.
+
+**Interaction with `deduplicatedFetch`** — the revalidate call passes through `deduplicatedFetch`, so rapid dialog open/close with identical filters collapses to one request.
+
+## Change 2 — Server search-miss retry
+
+**File:** `src/app/api/models/route.ts`
+
+Triggered in the `GET` handler, after the provider aggregation loop (current line 1147) and before the capability filter (current line 1163).
+
+**Trigger conditions (all must be true):**
+
+1. `searchQuery` is non-empty
+2. `allModels.length === 0` before capability filtering
+3. At least one provider returned with `providerResults[p].cached === true`
+4. The request does NOT have `refresh=true`
+5. The `(cacheKey)` has not been revalidated in the last 60 seconds (gibberish-search throttle)
+
+**Behavior when triggered:**
+
+- For each cache-hit provider:
+  - Re-run its fetch function (`fetchReplicateModels`, `fetchFalModels`, `fetchWaveSpeedModels`) with cache bypass
+  - Write the fresh result to `setCachedModels(cacheKey, fresh)`
+  - Mark the cacheKey in an in-memory revalidation-throttle map (`Map<string, timestamp>`) with 60s TTL
+  - Merge fresh results into `allModels`
+- Proceed to capability filter + sort as normal.
+
+**Providers NOT retried:**
+
+- Gemini and Kie use hardcoded lists — a second read of a static array would return identical results.
+- Providers that already failed this request (`providerResults[p].success === false`) — retrying a failed upstream fetch isn't the job of search-miss logic.
+
+**Response shape:**
+
+No changes to `ModelsSuccessResponse`. Internal only. The existing `providerResults[p].cached` field already indicates cache state.
+
+**Cost bound:**
+
+Per cache-key, at most one cache-bypass refetch per 60s window. If 100 users search the same gibberish query simultaneously, only one upstream call is issued.
+
+## Change 3 — Gemini hybrid discovery
+
+**File:** `src/app/api/models/route.ts`
+
+**New function:** `fetchGeminiModels(apiKey: string): Promise<ProviderModel[]>`
+
+**Endpoint:** `GET https://generativelanguage.googleapis.com/v1beta/models?key=<key>&pageSize=100`, paginated via `pageToken`. Total timeout: 5s across all pages (enforced via `AbortController` with a shared signal; on timeout, abort and return whatever pages succeeded, or `[]` if none). Discovery must not block a user-facing request for longer than this budget.
+
+**Response filtering:** the Gemini list returns all models (text, embedding, image, video). Keep only models whose `name` (after stripping the `models/` prefix) matches one of:
+
+- Contains `image` (→ image model)
+- Matches `veo-*` or contains `video` (→ video model)
+
+Everything else dropped.
+
+**Capability inference from ID:**
+
+| ID pattern | Capabilities |
+|------------|--------------|
+| contains `image` | `text-to-image`, `image-to-image` |
+| matches `veo-*` OR contains `video` | `text-to-video`, `image-to-video` |
+| other | — (skipped by the filter above) |
+
+**Hybrid merge (inside the `includeGemini` branch, around current line 1040):**
+
+```ts
+const hardcoded = [...GEMINI_IMAGE_MODELS, ...GEMINI_VIDEO_MODELS];
+const cached = getCachedModels(getCacheKey("gemini"));
+const discovered = cached ?? await fetchGeminiModels(GEMINI_API_KEY).catch(err => {
+  console.warn(`[Models] gemini discovery failed: ${err.message}`);
+  return [];
+});
+if (!cached && discovered.length > 0) {
+  setCachedModels(getCacheKey("gemini"), discovered);
+}
+
+const hardcodedIds = new Set(hardcoded.map(m => m.id));
+const additions = discovered.filter(m => !hardcodedIds.has(m.id));
+const geminiModels = [...hardcoded, ...additions];
+```
+
+**Metadata for discovered-only models:**
+
+```ts
+{
+  id: "<raw model id>",          // e.g. "gemini-4-pro-image-preview"
+  name: humanize(id),            // "Gemini 4 Pro Image Preview"
+  description: "Newly discovered Gemini model. Metadata may be incomplete.",
+  provider: "gemini",
+  capabilities: [...inferred],
+  // coverImage omitted
+  // pricing omitted
+}
+```
+
+`humanize(id)`: split on `-` and `_`, title-case each segment. Small helper colocated with the fetch function.
+
+**API key source:**
+
+`process.env.GEMINI_API_KEY` (already required per `CLAUDE.md`). No client-header override — discovery is server-only. Missing key → skip discovery, return hardcoded.
+
+**Caching:**
+
+Reuses existing `getCachedModels` / `setCachedModels` / `getCacheKey("gemini")` with the default 1h TTL. Interacts correctly with Change 2: a search-miss against Gemini alone wouldn't trigger retry (Gemini is hardcoded-list from the retry's perspective), but a search-miss against a Gemini+Replicate result would retry Replicate and rebuild the merged Gemini list on the next cache-miss.
+
+**Failure modes:**
+
+| Failure | Behavior |
+|---------|----------|
+| `GEMINI_API_KEY` missing | Hardcoded list only, no error |
+| Network / HTTP 5xx | Log warning, return hardcoded list |
+| 401/403 (bad key) | Log warning, return hardcoded list |
+| 429 (rate limit) | Cache still serves previous discovery; if no cache, hardcoded |
+| Malformed response | Log warning, return hardcoded list |
+
+## Data flow (end-to-end)
+
+User types "seedance-3" → dialog debounces 300ms → `fetchModels()`:
+
+1. Check localStorage for `all:all:seedance-3`. Hit on a 3-day-old cache (48h TTL means cache-hit if <48h). Render cached list (empty because seedance-3 didn't exist 3 days ago).
+2. Fire background revalidate against `/api/models?search=seedance-3`.
+3. Server:
+   - Checks in-memory cache for `replicate` key. Hit. Runs client-side filter for "seedance-3" on cached list. Empty.
+   - Search-miss retry triggers: bypass cache, call Replicate `/v1/models` fresh. seedance-3 is in the fresh list. Cache rewritten.
+   - Merged response includes seedance-3.
+4. Client SWR compares new response to cached. Length + ID hash differs → update state + localStorage.
+5. UI refreshes in place, user sees seedance-3 appear within ~2s of the initial empty render.
+
+## Error handling
+
+| Failure | User-visible effect |
+|---------|--------------------|
+| SWR background revalidate fails (network, timeout) | None. Cached list stays. Warning logged. |
+| Server search-miss retry: all providers fail | Empty result (same as today). |
+| Server search-miss retry: one provider fails, others succeed | Partial merged results shown. Failures in `errors[]`. |
+| Gemini discovery fails | Hardcoded list served. Warning logged. Not visible to user. |
+| Client localStorage quota exceeded during revalidate write | Caught and ignored (existing `setCachedModels` try/catch at line 39). |
+
+## Testing
+
+**Server (`tests/api/models/route.test.ts`):**
+
+1. Search-miss retry triggers when: `searchQuery` non-empty, `allModels` empty, cache-hit provider exists, no `refresh=true`.
+2. Search-miss retry does NOT trigger when `refresh=true` already set.
+3. Search-miss retry respects the 60s throttle (second request within 60s returns empty without bypass).
+4. Gemini discovery merges with hardcoded, hardcoded wins on ID collision.
+5. Gemini discovery failure falls back to hardcoded list.
+6. Gemini discovery with no API key returns hardcoded list.
+7. Discovered-only Gemini models have expected shape (id, name via `humanize`, description, capabilities, no pricing).
+
+**Mocks:** `vi.fn()` against `global.fetch` per existing patterns. Use fixture objects for Replicate / Fal / Google response shapes.
+
+**Client (`ModelSearchDialog.tsx`):**
+
+No unit tests. Rationale: no existing modal test infrastructure, and the SWR logic is straightforward enough to verify via manual QA. The comparison logic is kept dead simple (length + sorted ID hash) to reduce subtle bug risk. Add `console.debug` when SWR detects a diff so it is observable in devtools.
+
+**Manual QA checklist:**
+
+- [ ] Cold cache → dialog opens, list loads with spinner.
+- [ ] Warm cache → dialog opens instantly, devtools Network tab shows a background `/api/models` call.
+- [ ] Warm cache + SWR detects diff → UI updates in place (verify via `console.debug` log).
+- [ ] Search for a known-new model with warm-but-stale cache → blocking refetch, model appears.
+- [ ] Revoke `GEMINI_API_KEY` → Gemini tab still shows hardcoded models.
+- [ ] Rapid filter switching during background revalidate → no stale results leak into UI.
+
+## Risk & rollback
+
+Each change is isolated in its own file region and can be reverted independently:
+
+- Revert Change 1: replace `fetchModels` body with pre-SWR version.
+- Revert Change 2: remove the retry block after the provider loop.
+- Revert Change 3: remove `fetchGeminiModels` call, restore the direct hardcoded spread.
+
+No data migrations, no schema changes, no breaking API contract changes.
+
+## Open questions
+
+None. Decisions made during brainstorming:
+
+- Scope: API-backed providers + Gemini discovery (Kie deferred).
+- Search-miss: blocking refetch, server-side, scoped to cache-hit providers.
+- Freshness for existing cached lists: SWR (stale-while-revalidate).
+- Gemini strategy: hybrid with hardcoded-wins-on-collision.

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -797,4 +797,119 @@ describe("/api/models route", () => {
       expect(humanize("gemini-2.5-flash")).toBe("Gemini 2.5 Flash");
     });
   });
+
+  describe("fetchGeminiModels", () => {
+    beforeEach(() => {
+      global.fetch = mockFetch as unknown as typeof global.fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("returns only image/video models from the discovery response", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [
+              { name: "models/gemini-4-pro-image-preview", supportedGenerationMethods: ["generateContent"] },
+              { name: "models/veo-4-ultra", supportedGenerationMethods: ["predictLongRunning"] },
+              { name: "models/gemini-2.5-flash", supportedGenerationMethods: ["generateContent"] },
+              { name: "models/text-embedding-004", supportedGenerationMethods: ["embedContent"] },
+            ],
+          }),
+      });
+
+      const result = await fetchGeminiModels("fake-key");
+
+      expect(result.map((m) => m.id).sort()).toEqual(["gemini-4-pro-image-preview", "veo-4-ultra"]);
+    });
+
+    it("infers image capabilities for ids containing 'image'", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [{ name: "models/gemini-4-pro-image-preview", supportedGenerationMethods: ["generateContent"] }],
+          }),
+      });
+
+      const result = await fetchGeminiModels("fake-key");
+      expect(result[0]).toMatchObject({
+        id: "gemini-4-pro-image-preview",
+        name: "Gemini 4 Pro Image Preview",
+        provider: "gemini",
+        capabilities: ["text-to-image", "image-to-image"],
+      });
+      expect(result[0].pricing).toBeUndefined();
+      expect(result[0].coverImage).toBeUndefined();
+    });
+
+    it("infers video capabilities for veo-* ids", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [{ name: "models/veo-4-ultra", supportedGenerationMethods: ["predictLongRunning"] }],
+          }),
+      });
+
+      const result = await fetchGeminiModels("fake-key");
+      expect(result[0].capabilities).toEqual(["text-to-video", "image-to-video"]);
+    });
+
+    it("returns [] on HTTP error", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      });
+
+      const result = await fetchGeminiModels("bad-key");
+      expect(result).toEqual([]);
+    });
+
+    it("returns [] on network throw", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+      const result = await fetchGeminiModels("fake-key");
+      expect(result).toEqual([]);
+    });
+
+    it("paginates when nextPageToken is present", async () => {
+      const { fetchGeminiModels } = await import("../route");
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              models: [{ name: "models/gemini-5-image", supportedGenerationMethods: ["generateContent"] }],
+              nextPageToken: "page2",
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              models: [{ name: "models/veo-5", supportedGenerationMethods: ["predictLongRunning"] }],
+            }),
+        });
+
+      const result = await fetchGeminiModels("fake-key");
+      expect(result.map((m) => m.id).sort()).toEqual(["gemini-5-image", "veo-5"]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -1012,5 +1012,44 @@ describe("/api/models route", () => {
       // Reset the cache mock so it doesn't leak to subsequent tests
       mockGetCachedModels.mockReturnValue(null);
     });
+
+    it("bypasses cache when refresh=true", async () => {
+      mockGetCachedModels.mockImplementation((key: string) => {
+        if (key === "gemini:models") {
+          return [
+            {
+              id: "stale-model",
+              name: "Stale Model",
+              description: "Should not appear",
+              provider: "gemini",
+              capabilities: ["text-to-image", "image-to-image"],
+            },
+          ];
+        }
+        return null;
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [
+              { name: "models/gemini-10-image", supportedGenerationMethods: ["generateContent"] },
+            ],
+          }),
+      });
+
+      const request = createMockGetRequest({ provider: "gemini", refresh: "true" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const ids = data.models.map((m: { id: string }) => m.id);
+      expect(ids).not.toContain("stale-model");
+      expect(ids).toContain("gemini-10-image");
+
+      // Reset the cache mock so it doesn't leak to subsequent tests
+      mockGetCachedModels.mockReturnValue(null);
+    });
   });
 });

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/lib/providers/cache", () => ({
   getCacheKey: mockGetCacheKey,
 }));
 
-import { GET } from "../route";
+import { GET, searchMissRetryThrottle } from "../route";
 
 // Store original env and fetch
 const originalEnv = { ...process.env };
@@ -1049,6 +1049,92 @@ describe("/api/models route", () => {
       expect(ids).toContain("gemini-10-image");
 
       // Reset the cache mock so it doesn't leak to subsequent tests
+      mockGetCachedModels.mockReturnValue(null);
+    });
+  });
+
+  describe("Search-miss retry", () => {
+    beforeEach(() => {
+      global.fetch = mockFetch as unknown as typeof global.fetch;
+      process.env.REPLICATE_API_KEY = "fake-replicate-key";
+      delete process.env.GEMINI_API_KEY;
+      // Clear module-level throttle state between cases (tests using the same
+      // cache key — e.g. "replicate:models" — would otherwise leak throttle entries).
+      searchMissRetryThrottle.clear();
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      delete process.env.REPLICATE_API_KEY;
+    });
+
+    it("retries with cache bypass when cache-hit returned zero matches for search", async () => {
+      mockGetCachedModels.mockImplementation((key: string) => {
+        if (key === "replicate:models") return [];
+        return null;
+      });
+
+      mockFetch.mockResolvedValueOnce(
+        createReplicateResponse(
+          [{ owner: "bytedance", name: "seedance-3", description: "new video model" }],
+          null
+        )
+      );
+
+      const request = createMockGetRequest({ search: "seedance-3", provider: "replicate" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(data.models.some((m: { id: string }) => m.id.includes("seedance-3"))).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockSetCachedModels).toHaveBeenCalledWith("replicate:models", expect.any(Array));
+
+      mockGetCachedModels.mockReturnValue(null);
+    });
+
+    it("does NOT retry when refresh=true is already set", async () => {
+      mockGetCachedModels.mockReturnValue(null);
+      mockFetch.mockResolvedValueOnce(createReplicateResponse([], null));
+
+      const request = createMockGetRequest({
+        search: "nonexistent-model",
+        provider: "replicate",
+        refresh: "true",
+      });
+      const response = await GET(request);
+      await response.json();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry when no providers were cache-hit", async () => {
+      mockGetCachedModels.mockReturnValue(null);
+      mockFetch.mockResolvedValueOnce(createReplicateResponse([], null));
+
+      const request = createMockGetRequest({ search: "nothing", provider: "replicate" });
+      const response = await GET(request);
+      await response.json();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry within 60s of a previous retry for the same cache key", async () => {
+      mockGetCachedModels.mockImplementation((key: string) => {
+        if (key === "replicate:models") return [];
+        return null;
+      });
+
+      mockFetch.mockResolvedValueOnce(createReplicateResponse([], null));
+      const r1 = await GET(createMockGetRequest({ search: "unicorn", provider: "replicate" }));
+      await r1.json();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const r2 = await GET(createMockGetRequest({ search: "unicorn", provider: "replicate" }));
+      const data2 = await r2.json();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(data2.models).toEqual([]);
+
       mockGetCachedModels.mockReturnValue(null);
     });
   });

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -97,6 +97,7 @@ describe("/api/models route", () => {
     // Clear API keys
     delete process.env.REPLICATE_API_KEY;
     delete process.env.FAL_API_KEY;
+    delete process.env.GEMINI_API_KEY;
     // Set up mock fetch
     global.fetch = mockFetch;
     // Reset cache mock to default (miss)
@@ -910,6 +911,106 @@ describe("/api/models route", () => {
       const result = await fetchGeminiModels("fake-key");
       expect(result.map((m) => m.id).sort()).toEqual(["gemini-5-image", "veo-5"]);
       expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Gemini hybrid discovery in GET", () => {
+    beforeEach(() => {
+      global.fetch = mockFetch as unknown as typeof global.fetch;
+      process.env.GEMINI_API_KEY = "test-gemini-key";
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      delete process.env.GEMINI_API_KEY;
+    });
+
+    it("merges discovered models with hardcoded list (hardcoded wins on collision)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [
+              { name: "models/nano-banana", supportedGenerationMethods: ["generateContent"] },
+              { name: "models/gemini-9-image", supportedGenerationMethods: ["generateContent"] },
+            ],
+          }),
+      });
+
+      const request = createMockGetRequest({ provider: "gemini" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+
+      const geminiModels = data.models.filter((m: { provider: string }) => m.provider === "gemini");
+      const nanoBanana = geminiModels.find((m: { id: string }) => m.id === "nano-banana");
+      const newModel = geminiModels.find((m: { id: string }) => m.id === "gemini-9-image");
+
+      expect(nanoBanana.description).toContain("Fast image generation");
+      expect(nanoBanana.pricing).toEqual({ type: "per-run", amount: 0.039, currency: "USD" });
+
+      expect(newModel).toMatchObject({
+        name: "Gemini 9 Image",
+        description: "Newly discovered Gemini model. Metadata may be incomplete.",
+        capabilities: ["text-to-image", "image-to-image"],
+      });
+      expect(newModel.pricing).toBeUndefined();
+    });
+
+    it("falls back to hardcoded list when discovery fails", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("boom"));
+
+      const request = createMockGetRequest({ provider: "gemini" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      const ids = data.models.map((m: { id: string }) => m.id);
+      expect(ids).toContain("nano-banana");
+      expect(ids).toContain("nano-banana-2");
+      expect(ids.every((id: string) => !id.startsWith("gemini-9"))).toBe(true);
+    });
+
+    it("skips discovery and returns hardcoded only when GEMINI_API_KEY missing", async () => {
+      delete process.env.GEMINI_API_KEY;
+
+      const request = createMockGetRequest({ provider: "gemini" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+      const ids = data.models.map((m: { id: string }) => m.id);
+      expect(ids).toContain("nano-banana");
+    });
+
+    it("uses cached discovery when available", async () => {
+      mockGetCachedModels.mockImplementation((key: string) => {
+        if (key === "gemini:models") {
+          return [
+            {
+              id: "cached-gemini-model",
+              name: "Cached Gemini Model",
+              description: "From cache",
+              provider: "gemini",
+              capabilities: ["text-to-image", "image-to-image"],
+            },
+          ];
+        }
+        return null;
+      });
+
+      const request = createMockGetRequest({ provider: "gemini" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      const ids = data.models.map((m: { id: string }) => m.id);
+      expect(ids).toContain("cached-gemini-model");
+
+      // Reset the cache mock so it doesn't leak to subsequent tests
+      mockGetCachedModels.mockReturnValue(null);
     });
   });
 });

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -775,4 +775,26 @@ describe("/api/models route", () => {
       expect(data.models[10].name).toBe("zebra");
     });
   });
+
+  describe("humanize helper", () => {
+    it("converts kebab-case id to Title Case", async () => {
+      const { humanize } = await import("../route");
+      expect(humanize("gemini-4-pro-image-preview")).toBe("Gemini 4 Pro Image Preview");
+    });
+
+    it("handles snake_case ids", async () => {
+      const { humanize } = await import("../route");
+      expect(humanize("veo_3_fast")).toBe("Veo 3 Fast");
+    });
+
+    it("handles single-word ids", async () => {
+      const { humanize } = await import("../route");
+      expect(humanize("veo")).toBe("Veo");
+    });
+
+    it("preserves numeric segments", async () => {
+      const { humanize } = await import("../route");
+      expect(humanize("gemini-2.5-flash")).toBe("Gemini 2.5 Flash");
+    });
+  });
 });

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -660,8 +660,8 @@ function filterModelsBySearch(
 }
 
 /**
- * Convert a raw model id (kebab-case, snake_case, dot-separated) to a display
- * name by title-casing each segment.
+ * Convert a raw model id (kebab-case or snake_case; dots are preserved) to a
+ * display name by title-casing each hyphen/underscore-separated segment.
  *
  * humanize("gemini-4-pro-image-preview") → "Gemini 4 Pro Image Preview"
  * humanize("veo_3_fast")                 → "Veo 3 Fast"

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -1317,16 +1317,19 @@ export async function GET(
 
       try {
         let fresh: ProviderModel[] = [];
+        // Don't overwrite cache with an empty list — a transient upstream
+        // failure could otherwise wipe the shared per-provider cache key
+        // (replicate:models / wavespeed:models) for all subsequent searches.
         if (provider === "replicate") {
           const all = await fetchReplicateModels(replicateKey!);
-          setCachedModels(cacheKey, all);
+          if (all.length > 0) setCachedModels(cacheKey, all);
           fresh = searchQuery ? filterModelsBySearch(all, searchQuery) : all;
         } else if (provider === "fal") {
           fresh = await fetchFalModels(falKey, searchQuery);
-          setCachedModels(cacheKey, fresh);
+          if (fresh.length > 0) setCachedModels(cacheKey, fresh);
         } else if (provider === "wavespeed") {
           const all = await fetchWaveSpeedModels(wavespeedKey!);
-          setCachedModels(cacheKey, all);
+          if (all.length > 0) setCachedModels(cacheKey, all);
           fresh = searchQuery ? filterModelsBySearch(all, searchQuery) : all;
         }
         allModels.push(...fresh);
@@ -1335,9 +1338,12 @@ export async function GET(
           count: fresh.length,
           cached: false,
         };
+        // A successful retry means the response now includes fresh upstream data,
+        // so the top-level "cached" envelope must no longer claim full freshness.
+        allFromCache = false;
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        console.warn(`[Models] ${provider} search-miss retry failed: ${errorMessage}`);
+        console.warn(`[Models] ${provider}: search-miss retry failed: ${errorMessage}`);
         // Leave the original empty-but-cached result in place
       }
     }

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -951,6 +951,94 @@ async function fetchFalModels(
   return allModels;
 }
 
+// ============ Gemini Discovery ============
+
+const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+const GEMINI_DISCOVERY_TIMEOUT_MS = 5000;
+
+interface GeminiDiscoveryModel {
+  name: string; // e.g. "models/gemini-4-pro-image-preview"
+  supportedGenerationMethods?: string[];
+}
+
+interface GeminiDiscoveryResponse {
+  models?: GeminiDiscoveryModel[];
+  nextPageToken?: string;
+}
+
+function inferGeminiCapabilities(id: string): ModelCapability[] | null {
+  const lower = id.toLowerCase();
+  if (lower.includes("image")) {
+    return ["text-to-image", "image-to-image"];
+  }
+  if (lower.startsWith("veo-") || lower.includes("video")) {
+    return ["text-to-video", "image-to-video"];
+  }
+  return null;
+}
+
+/**
+ * Discover Gemini models via the Google Generative Language API.
+ *
+ * Filters to image/video generation models only. Returns [] on any failure
+ * (network, auth, malformed response, timeout) — caller is expected to fall
+ * back to the hardcoded list.
+ *
+ * Timeout: 5s total across all pages (shared AbortSignal).
+ */
+export async function fetchGeminiModels(apiKey: string): Promise<ProviderModel[]> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), GEMINI_DISCOVERY_TIMEOUT_MS);
+
+  try {
+    const discovered: ProviderModel[] = [];
+    let pageToken: string | undefined;
+    let pageCount = 0;
+    const maxPages = 10; // safety bound
+
+    do {
+      const url = new URL(`${GEMINI_API_BASE}/models`);
+      url.searchParams.set("key", apiKey);
+      url.searchParams.set("pageSize", "100");
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+
+      const response = await fetch(url.toString(), { signal: controller.signal });
+      if (!response.ok) {
+        console.warn(`[Models] gemini discovery HTTP ${response.status}`);
+        return [];
+      }
+
+      const data = (await response.json()) as GeminiDiscoveryResponse;
+      const models = data.models ?? [];
+
+      for (const model of models) {
+        const rawId = model.name.replace(/^models\//, "");
+        const capabilities = inferGeminiCapabilities(rawId);
+        if (!capabilities) continue;
+
+        discovered.push({
+          id: rawId,
+          name: humanize(rawId),
+          description: "Newly discovered Gemini model. Metadata may be incomplete.",
+          provider: "gemini",
+          capabilities,
+        });
+      }
+
+      pageToken = data.nextPageToken;
+      pageCount++;
+    } while (pageToken && pageCount < maxPages);
+
+    return discovered;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[Models] gemini discovery failed: ${message}`);
+    return [];
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 // ============ Main Handler ============
 
 export async function GET(

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -1156,8 +1156,11 @@ export async function GET(
     const hardcoded = [...GEMINI_IMAGE_MODELS, ...GEMINI_VIDEO_MODELS];
 
     // Discovery is additive: try cache first, then fresh fetch, then fall back to empty.
+    // Start from "hardcoded is cached" to match the Kie branch below — a live fetch
+    // flips this to false below.
     let discovered: ProviderModel[] = [];
-    let discoveryFromCache = false;
+    let geminiCached = true;
+    anyFromCache = true;
     const geminiKey = process.env.GEMINI_API_KEY;
 
     if (geminiKey) {
@@ -1165,8 +1168,6 @@ export async function GET(
       const cached = refresh ? null : getCachedModels(cacheKey);
       if (cached) {
         discovered = cached;
-        discoveryFromCache = true;
-        anyFromCache = true;
       } else {
         discovered = await fetchGeminiModels(geminiKey);
         // Skip caching empty results so a transient upstream failure doesn't
@@ -1174,6 +1175,7 @@ export async function GET(
         if (discovered.length > 0) {
           setCachedModels(cacheKey, discovered);
         }
+        geminiCached = false;
         allFromCache = false;
       }
     }
@@ -1191,7 +1193,7 @@ export async function GET(
     providerResults["gemini"] = {
       success: true,
       count: geminiModels.length,
-      cached: discoveryFromCache,
+      cached: geminiCached,
     };
   }
 

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -659,6 +659,25 @@ function filterModelsBySearch(
   });
 }
 
+/**
+ * Convert a raw model id (kebab-case, snake_case, dot-separated) to a display
+ * name by title-casing each segment.
+ *
+ * humanize("gemini-4-pro-image-preview") → "Gemini 4 Pro Image Preview"
+ * humanize("veo_3_fast")                 → "Veo 3 Fast"
+ * humanize("gemini-2.5-flash")           → "Gemini 2.5 Flash"
+ */
+export function humanize(id: string): string {
+  return id
+    .split(/[-_]/)
+    .map((segment) =>
+      segment.length === 0
+        ? segment
+        : segment[0].toUpperCase() + segment.slice(1)
+    )
+    .join(" ");
+}
+
 // ============ WaveSpeed Types ============
 
 interface WaveSpeedModel {

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -1147,18 +1147,47 @@ export async function GET(
 
   // Add Gemini models first if included (they appear at the top)
   if (includeGemini) {
-    // Filter by search query if provided
-    let geminiModels = [...GEMINI_IMAGE_MODELS, ...GEMINI_VIDEO_MODELS];
+    const hardcoded = [...GEMINI_IMAGE_MODELS, ...GEMINI_VIDEO_MODELS];
+
+    // Discovery is additive: try cache first, then fresh fetch, then fall back to empty.
+    let discovered: ProviderModel[] = [];
+    let discoveryFromCache = false;
+    const geminiKey = process.env.GEMINI_API_KEY;
+
+    if (geminiKey) {
+      const cacheKey = getCacheKey("gemini");
+      const cached = refresh ? null : getCachedModels(cacheKey);
+      if (cached) {
+        discovered = cached;
+        discoveryFromCache = true;
+        anyFromCache = true;
+      } else {
+        discovered = await fetchGeminiModels(geminiKey);
+        if (discovered.length > 0) {
+          setCachedModels(cacheKey, discovered);
+        }
+        allFromCache = false;
+      }
+    }
+
+    // Hardcoded wins on ID collision
+    const hardcodedIds = new Set(hardcoded.map((m) => m.id));
+    const additions = discovered.filter((m) => !hardcodedIds.has(m.id));
+    let geminiModels: ProviderModel[] = [...hardcoded, ...additions];
+
     if (searchQuery) {
       geminiModels = filterModelsBySearch(geminiModels, searchQuery);
     }
+
     allModels.push(...geminiModels);
     providerResults["gemini"] = {
       success: true,
       count: geminiModels.length,
-      cached: true, // Hardcoded models are effectively "cached"
+      cached: discoveryFromCache,
     };
-    anyFromCache = true;
+    if (discoveryFromCache) {
+      anyFromCache = true;
+    }
   }
 
   // Add Kie models if included (hardcoded, no API call needed)

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -1163,6 +1163,8 @@ export async function GET(
         anyFromCache = true;
       } else {
         discovered = await fetchGeminiModels(geminiKey);
+        // Skip caching empty results so a transient upstream failure doesn't
+        // mask real data for the remainder of the TTL window.
         if (discovered.length > 0) {
           setCachedModels(cacheKey, discovered);
         }
@@ -1185,9 +1187,6 @@ export async function GET(
       count: geminiModels.length,
       cached: discoveryFromCache,
     };
-    if (discoveryFromCache) {
-      anyFromCache = true;
-    }
   }
 
   // Add Kie models if included (hardcoded, no API call needed)

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -998,13 +998,15 @@ export async function fetchGeminiModels(apiKey: string): Promise<ProviderModel[]
 
     do {
       const url = new URL(`${GEMINI_API_BASE}/models`);
-      url.searchParams.set("key", apiKey);
       url.searchParams.set("pageSize", "100");
       if (pageToken) url.searchParams.set("pageToken", pageToken);
 
-      const response = await fetch(url.toString(), { signal: controller.signal });
+      const response = await fetch(url.toString(), {
+        signal: controller.signal,
+        headers: { "x-goog-api-key": apiKey },
+      });
       if (!response.ok) {
-        console.warn(`[Models] gemini discovery HTTP ${response.status}`);
+        console.warn(`[Models] gemini: discovery HTTP ${response.status}`);
         return [];
       }
 
@@ -1032,7 +1034,7 @@ export async function fetchGeminiModels(apiKey: string): Promise<ProviderModel[]
     return discovered;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[Models] gemini discovery failed: ${message}`);
+    console.warn(`[Models] gemini: discovery failed: ${message}`);
     return [];
   } finally {
     clearTimeout(timeoutId);

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -43,6 +43,12 @@ const REPLICATE_API_BASE = "https://api.replicate.com/v1";
 const FAL_API_BASE = "https://api.fal.ai/v1";
 const WAVESPEED_API_BASE = "https://api.wavespeed.ai/api/v3";
 
+// Search-miss retry throttle: per-cache-key timestamp of last cache-bypass retry.
+// Prevents repeated upstream calls for gibberish searches.
+const SEARCH_MISS_RETRY_THROTTLE_MS = 60_000;
+// Exported for test isolation — tests can reset this between cases.
+export const searchMissRetryThrottle = new Map<string, number>();
+
 // Categories we care about for image/video/3D/audio generation (fal.ai)
 const RELEVANT_CATEGORIES = [
   "text-to-image",
@@ -1281,6 +1287,60 @@ export async function GET(
       count: models.length,
       cached: fromCache,
     };
+  }
+
+  // Search-miss retry: if a search yielded zero matches but results came from cache,
+  // bypass cache once for the cache-hit providers and retry upstream.
+  if (
+    searchQuery &&
+    !refresh &&
+    allModels.length === 0 &&
+    anyFromCache
+  ) {
+    const cacheHitProviders = Object.entries(providerResults)
+      .filter(([, result]) => result.success && result.cached)
+      .map(([provider]) => provider as ProviderType)
+      .filter((p) => p === "replicate" || p === "fal" || p === "wavespeed");
+
+    for (const provider of cacheHitProviders) {
+      const cacheKey =
+        provider === "replicate" || provider === "wavespeed"
+          ? getCacheKey(provider)
+          : getCacheKey(provider, searchQuery);
+
+      // Throttle: skip if this cache key was revalidated within the window
+      const lastRetry = searchMissRetryThrottle.get(cacheKey) ?? 0;
+      if (Date.now() - lastRetry < SEARCH_MISS_RETRY_THROTTLE_MS) {
+        continue;
+      }
+      searchMissRetryThrottle.set(cacheKey, Date.now());
+
+      try {
+        let fresh: ProviderModel[] = [];
+        if (provider === "replicate") {
+          const all = await fetchReplicateModels(replicateKey!);
+          setCachedModels(cacheKey, all);
+          fresh = searchQuery ? filterModelsBySearch(all, searchQuery) : all;
+        } else if (provider === "fal") {
+          fresh = await fetchFalModels(falKey, searchQuery);
+          setCachedModels(cacheKey, fresh);
+        } else if (provider === "wavespeed") {
+          const all = await fetchWaveSpeedModels(wavespeedKey!);
+          setCachedModels(cacheKey, all);
+          fresh = searchQuery ? filterModelsBySearch(all, searchQuery) : all;
+        }
+        allModels.push(...fresh);
+        providerResults[provider] = {
+          success: true,
+          count: fresh.length,
+          cached: false,
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        console.warn(`[Models] ${provider} search-miss retry failed: ${errorMessage}`);
+        // Leave the original empty-but-cached result in place
+      }
+    }
   }
 
   // Check if we got any models

--- a/src/components/modals/ModelSearchDialog.tsx
+++ b/src/components/modals/ModelSearchDialog.tsx
@@ -171,7 +171,8 @@ export function ModelSearchDialog({
     }
   }, [initialProvider]);
 
-  // Fetch models
+  // Fetch models with stale-while-revalidate: cache-hit returns immediately, then a
+  // background revalidate silently refreshes state + localStorage if upstream differs.
   const fetchModels = useCallback(async (bypassCache = false) => {
     // Increment version to track this request
     const thisVersion = ++requestVersionRef.current;
@@ -179,30 +180,11 @@ export function ModelSearchDialog({
     // Build cache key from filters
     const cacheKey = `${providerFilter}:${capabilityFilter}:${debouncedSearch}`;
 
-    // Check localStorage cache first (skip when bypassing)
-    if (!bypassCache) {
-      const cached = getCachedModels(cacheKey);
-      if (cached) {
-        setModels(cached.models);
-        if (cached.availableProviders) {
-          setServerAvailableProviders(cached.availableProviders);
-        }
-        return;
-      }
-    }
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      // Build query params
+    // Helper: build query params + headers for an API call
+    const buildRequest = (forceRefresh: boolean) => {
       const params = new URLSearchParams();
-      if (debouncedSearch) {
-        params.set("search", debouncedSearch);
-      }
-      if (providerFilter !== "all") {
-        params.set("provider", providerFilter);
-      }
+      if (debouncedSearch) params.set("search", debouncedSearch);
+      if (providerFilter !== "all") params.set("provider", providerFilter);
       if (capabilityFilter !== "all") {
         const capabilities =
           capabilityFilter === "image"
@@ -214,25 +196,76 @@ export function ModelSearchDialog({
             : "text-to-audio";
         params.set("capabilities", capabilities);
       }
-      if (bypassCache) {
-        params.set("refresh", "true");
-      }
+      if (forceRefresh) params.set("refresh", "true");
 
-      // Build headers with API keys
       const headers: Record<string, string> = {};
-      if (replicateApiKey) {
-        headers["X-Replicate-Key"] = replicateApiKey;
-      }
-      if (falApiKey) {
-        headers["X-Fal-Key"] = falApiKey;
-      }
-      if (kieApiKey) {
-        headers["X-Kie-Key"] = kieApiKey;
-      }
-      if (wavespeedApiKey) {
-        headers["X-WaveSpeed-Key"] = wavespeedApiKey;
+      if (replicateApiKey) headers["X-Replicate-Key"] = replicateApiKey;
+      if (falApiKey) headers["X-Fal-Key"] = falApiKey;
+      if (kieApiKey) headers["X-Kie-Key"] = kieApiKey;
+      if (wavespeedApiKey) headers["X-WaveSpeed-Key"] = wavespeedApiKey;
+
+      return { params, headers };
+    };
+
+    // Helper: hash the model list by length + sorted id signature. Used to detect
+    // whether an SWR revalidation response actually changed anything.
+    const signature = (models: ProviderModel[]): string =>
+      `${models.length}:${models
+        .map((m) => m.id)
+        .sort()
+        .join(",")}`;
+
+    // Check localStorage cache first (skip when bypassing)
+    const cached = bypassCache ? null : getCachedModels(cacheKey);
+    if (cached) {
+      // Serve cached immediately, no spinner
+      setModels(cached.models);
+      if (cached.availableProviders) {
+        setServerAvailableProviders(cached.availableProviders);
       }
 
+      // Background revalidate: fire and forget, only update if response differs
+      (async () => {
+        try {
+          const { params, headers } = buildRequest(false);
+          const response = await deduplicatedFetch(`/api/models?${params.toString()}`, {
+            headers,
+          });
+
+          // Drop if filters changed while we were in flight
+          if (thisVersion !== requestVersionRef.current) return;
+
+          const data: ModelsResponse = await response.json();
+          if (!data.success || !data.models) return;
+
+          const cachedSig = signature(cached.models);
+          const freshSig = signature(data.models);
+          if (cachedSig !== freshSig) {
+            console.debug("[ModelSearch] SWR detected diff, updating", {
+              cachedCount: cached.models.length,
+              freshCount: data.models.length,
+            });
+            setModels(data.models);
+            setCachedModels(cacheKey, data.models, data.availableProviders);
+            if (data.availableProviders) {
+              setServerAvailableProviders(data.availableProviders);
+            }
+          }
+        } catch (err) {
+          // Silent: cached data is still good. Log for devtools.
+          console.warn("[ModelSearch] SWR revalidate failed:", err);
+        }
+      })();
+
+      return;
+    }
+
+    // Cache miss: show spinner and fetch normally
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const { params, headers } = buildRequest(bypassCache);
       const response = await deduplicatedFetch(`/api/models?${params.toString()}`, {
         headers,
       });
@@ -246,9 +279,7 @@ export function ModelSearchDialog({
 
       if (data.success && data.models) {
         setModels(data.models);
-        // Cache the successful result (including available providers)
         setCachedModels(cacheKey, data.models, data.availableProviders);
-        // Update server-reported available providers
         if (data.availableProviders) {
           setServerAvailableProviders(data.availableProviders);
         }
@@ -257,14 +288,12 @@ export function ModelSearchDialog({
         setModels([]);
       }
     } catch (err) {
-      // Check if this request is still current
       if (thisVersion !== requestVersionRef.current) {
-        return; // Ignore stale error
+        return;
       }
       setError(err instanceof Error ? err.message : "Failed to fetch models");
       setModels([]);
     } finally {
-      // Only update loading state if this is still the current request
       if (thisVersion === requestVersionRef.current) {
         setIsLoading(false);
       }

--- a/src/components/modals/ModelSearchDialog.tsx
+++ b/src/components/modals/ModelSearchDialog.tsx
@@ -210,8 +210,8 @@ export function ModelSearchDialog({
     // Helper: hash the model list by sorted "id:capabilities" pairs. Detects both
     // list membership changes and capability drift — the latter matters because
     // capability filters (image/video/3d/audio) will mis-route if stale.
-    const signature = (models: ProviderModel[]): string =>
-      models
+    const signature = (list: ProviderModel[]): string =>
+      list
         .map((m) => `${m.id}:${[...m.capabilities].sort().join("+")}`)
         .sort()
         .join(",");

--- a/src/components/modals/ModelSearchDialog.tsx
+++ b/src/components/modals/ModelSearchDialog.tsx
@@ -207,24 +207,29 @@ export function ModelSearchDialog({
       return { params, headers };
     };
 
-    // Helper: hash the model list by length + sorted id signature. Used to detect
-    // whether an SWR revalidation response actually changed anything.
+    // Helper: hash the model list by sorted "id:capabilities" pairs. Detects both
+    // list membership changes and capability drift — the latter matters because
+    // capability filters (image/video/3d/audio) will mis-route if stale.
     const signature = (models: ProviderModel[]): string =>
-      `${models.length}:${models
-        .map((m) => m.id)
+      models
+        .map((m) => `${m.id}:${[...m.capabilities].sort().join("+")}`)
         .sort()
-        .join(",")}`;
+        .join(",");
 
     // Check localStorage cache first (skip when bypassing)
     const cached = bypassCache ? null : getCachedModels(cacheKey);
     if (cached) {
       // Serve cached immediately, no spinner
       setModels(cached.models);
+      setError(null);
       if (cached.availableProviders) {
         setServerAvailableProviders(cached.availableProviders);
       }
 
-      // Background revalidate: fire and forget, only update if response differs
+      // Background revalidate: fire and forget, only update if response differs.
+      // Note: deduplicatedFetch has a 5s response cache, so reopening the dialog
+      // within 5s will short-circuit the network call. That's fine — the data we
+      // just cached is equally fresh in that window.
       (async () => {
         try {
           const { params, headers } = buildRequest(false);
@@ -246,14 +251,19 @@ export function ModelSearchDialog({
               freshCount: data.models.length,
             });
             setModels(data.models);
-            setCachedModels(cacheKey, data.models, data.availableProviders);
+            setCachedModels(
+              cacheKey,
+              data.models,
+              data.availableProviders ?? cached.availableProviders
+            );
             if (data.availableProviders) {
               setServerAvailableProviders(data.availableProviders);
             }
           }
         } catch (err) {
-          // Silent: cached data is still good. Log for devtools.
-          console.warn("[ModelSearch] SWR revalidate failed:", err);
+          // Silent: cached data is still good. Log at debug so we don't spam
+          // the user's console when the user is offline or the API is flaky.
+          console.debug("[ModelSearch] SWR revalidate failed:", err);
         }
       })();
 


### PR DESCRIPTION
## Summary

Fixes the "I searched for a newly-released model and it's not there" problem across Replicate/Fal/WaveSpeed/Gemini. Three coordinated changes:

- **Client-side stale-while-revalidate** in `ModelSearchDialog`: cache-hit returns instantly, then a background revalidate silently updates state + localStorage if upstream differs. Signature hashes `id:capabilities` so capability drift is detected (not just add/remove).
- **Server-side search-miss retry** in `/api/models/route.ts`: when a search yields zero matches against a cache-hit provider (Replicate/Fal/WaveSpeed), bypass cache once and retry upstream. Per-cache-key 60s throttle prevents storms. Empty results don't poison the shared cache.
- **Gemini hybrid discovery**: `fetchGeminiModels` calls Google's `v1beta/models` endpoint and merges with hardcoded `GEMINI_IMAGE_MODELS`/`GEMINI_VIDEO_MODELS`. Hardcoded wins on ID collision. Discovery-only models get a minimal-metadata card. 5s AbortController timeout. API key sent via `x-goog-api-key` header (not query string).

Spec: `docs/superpowers/specs/2026-04-14-model-fetch-freshness-design.md`
Plan: `docs/superpowers/plans/2026-04-14-model-fetch-freshness.md`

Each task shipped with its own TDD cycle. Test count grew 26 → 41 in the models route test file (+15 new).

## Test plan

- [x] `pnpm vitest run src/app/api/models/__tests__/route.test.ts` — 41/41 pass
- [x] `npx tsc --noEmit` on changed files — no type errors
- [ ] Cold cache: open dialog, list loads with spinner
- [ ] Warm cache: dialog opens instantly, devtools Network tab shows a background `/api/models` call
- [ ] SWR diff: `[ModelSearch] SWR detected diff, updating` appears in console when upstream changed
- [ ] Search-miss retry: searching a newly-published model surfaces it within seconds
- [ ] Gemini discovery: with `GEMINI_API_KEY` set, a new Google model appears; with key unset, Gemini tab still shows hardcoded models
- [ ] Rapid filter switching during revalidate does not leak stale results

## Notes

- Pre-existing broken test in `src/app/api/social/automation/rules/[ruleId]/__tests__/route.test.ts` fails on `develop` too — not caused by this branch.
- `pnpm lint` is broken repo-wide (pre-existing Next.js 16 wiring issue, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)