### PR TITLE
fix: classify Replicate models by default_example output extension

### DIFF
--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -1138,4 +1138,185 @@ describe("/api/models route", () => {
       mockGetCachedModels.mockReturnValue(null);
     });
   });
+
+  describe("Replicate capability detection via default_example.output", () => {
+    beforeEach(() => {
+      process.env.REPLICATE_API_KEY = "fake-replicate-key";
+    });
+
+    afterEach(() => {
+      delete process.env.REPLICATE_API_KEY;
+    });
+
+    it("classifies video model (mp4 output) even when description mentions audio", async () => {
+      // Real-world case: Seedance 2.0 — "multimodal video generation ... with native audio"
+      // The keyword heuristic alone picks up "audio" first and mis-tags as text-to-audio.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                owner: "bytedance",
+                name: "seedance-2.0",
+                description:
+                  "ByteDance's multimodal video generation model with native audio, multimodal reference inputs, and intelligent duration control.",
+                visibility: "public",
+                run_count: 1000,
+                default_example: {
+                  output:
+                    "https://replicate.delivery/xezq/abcdef/tmp1234.mp4",
+                },
+              },
+            ],
+            next: null,
+            previous: null,
+          }),
+      });
+
+      const request = createMockGetRequest({ provider: "replicate" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      const seedance = data.models.find(
+        (m: { id: string }) => m.id === "bytedance/seedance-2.0"
+      );
+      expect(seedance).toBeDefined();
+      expect(seedance.capabilities).toContain("text-to-video");
+      expect(seedance.capabilities).not.toContain("text-to-audio");
+    });
+
+    it("classifies model when default_example.output is an array of URLs", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                owner: "test",
+                name: "array-output-image-model",
+                description: "Generates multiple images per run.",
+                visibility: "public",
+                run_count: 100,
+                default_example: {
+                  output: [
+                    "https://example.com/a.png",
+                    "https://example.com/b.png",
+                  ],
+                },
+              },
+            ],
+            next: null,
+            previous: null,
+          }),
+      });
+
+      const request = createMockGetRequest({ provider: "replicate" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      const model = data.models.find(
+        (m: { id: string }) => m.id === "test/array-output-image-model"
+      );
+      expect(model.capabilities).toContain("text-to-image");
+    });
+
+    it("classifies 3D model when output is .glb", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                owner: "test",
+                name: "three-d-model",
+                description: "Generates meshes from photos.",
+                visibility: "public",
+                run_count: 100,
+                default_example: {
+                  output: "https://example.com/result.glb",
+                },
+              },
+            ],
+            next: null,
+            previous: null,
+          }),
+      });
+
+      const request = createMockGetRequest({ provider: "replicate" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      const model = data.models.find(
+        (m: { id: string }) => m.id === "test/three-d-model"
+      );
+      // Description mentions "photos" so image-to-3d path
+      expect(model.capabilities).toContain("image-to-3d");
+    });
+
+    it("falls back to keyword heuristic when default_example is absent", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                owner: "test",
+                name: "plain-video-model",
+                description: "Text to video generation.",
+                visibility: "public",
+                run_count: 100,
+                // No default_example at all — forces keyword fallback
+              },
+            ],
+            next: null,
+            previous: null,
+          }),
+      });
+
+      const request = createMockGetRequest({ provider: "replicate" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      const model = data.models.find(
+        (m: { id: string }) => m.id === "test/plain-video-model"
+      );
+      expect(model.capabilities).toContain("text-to-video");
+    });
+
+    it("falls back to keyword heuristic when default_example.output is non-URL text", async () => {
+      // Some text-generation models have string outputs that aren't URLs,
+      // e.g. BLIP-2 outputs "san francisco bay". Ensure we don't mis-classify.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                owner: "test",
+                name: "text-output-model",
+                description: "Image-to-image style transfer.",
+                visibility: "public",
+                run_count: 100,
+                default_example: {
+                  output: "some plain text answer",
+                },
+              },
+            ],
+            next: null,
+            previous: null,
+          }),
+      });
+
+      const request = createMockGetRequest({ provider: "replicate" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      const model = data.models.find(
+        (m: { id: string }) => m.id === "test/text-output-model"
+      );
+      // Fallback heuristic: description has "image-to-image" so that capability is present
+      expect(model.capabilities).toContain("image-to-image");
+    });
+  });
 });

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -519,7 +519,76 @@ type ModelsResponse = ModelsSuccessResponse | ModelsErrorResponse;
 
 // ============ Replicate Helpers ============
 
+/**
+ * Inspect `default_example.output` for an output URL and classify by extension.
+ * Returns null when no classifiable output is present, so callers can fall back
+ * to the keyword heuristic.
+ */
+function inferReplicateCapabilitiesFromExample(
+  model: ReplicateModel
+): ModelCapability[] | null {
+  const example = model.default_example as { output?: unknown } | undefined;
+  if (!example) return null;
+
+  // Output can be a string URL, an array of URLs, or something else (text, number).
+  const raw = example.output;
+  const urlCandidate =
+    typeof raw === "string"
+      ? raw
+      : Array.isArray(raw) && typeof raw[0] === "string"
+      ? (raw[0] as string)
+      : null;
+  if (!urlCandidate) return null;
+
+  // Strip query string, take the last path segment, take the extension.
+  const pathname = urlCandidate.split("?")[0];
+  const ext = pathname.split(".").pop()?.toLowerCase();
+  if (!ext) return null;
+
+  const name = model.name.toLowerCase();
+  const desc = (model.description ?? "").toLowerCase();
+  const searchText = `${name} ${desc}`;
+
+  if (["mp4", "webm", "mov", "avi", "mkv"].includes(ext)) {
+    const isImageToVideo =
+      searchText.includes("image-to-video") ||
+      searchText.includes("img2vid") ||
+      searchText.includes("i2v");
+    return isImageToVideo ? ["image-to-video"] : ["text-to-video"];
+  }
+  if (["mp3", "wav", "ogg", "flac", "m4a"].includes(ext)) {
+    return ["text-to-audio"];
+  }
+  if (["glb", "usdz", "ply", "obj", "stl", "gltf"].includes(ext)) {
+    const hasImageInput =
+      searchText.includes("image") ||
+      searchText.includes("img") ||
+      searchText.includes("photo");
+    return hasImageInput ? ["image-to-3d"] : ["text-to-3d"];
+  }
+  if (["png", "jpg", "jpeg", "webp", "gif"].includes(ext)) {
+    const capabilities: ModelCapability[] = ["text-to-image"];
+    if (
+      searchText.includes("img2img") ||
+      searchText.includes("image-to-image") ||
+      searchText.includes("inpaint") ||
+      searchText.includes("controlnet") ||
+      searchText.includes("upscale") ||
+      searchText.includes("restore")
+    ) {
+      capabilities.push("image-to-image");
+    }
+    return capabilities;
+  }
+
+  return null;
+}
+
 function inferReplicateCapabilities(model: ReplicateModel): ModelCapability[] {
+  // Prefer the authoritative signal from the model's example output when available.
+  const fromExample = inferReplicateCapabilitiesFromExample(model);
+  if (fromExample) return fromExample;
+
   const capabilities: ModelCapability[] = [];
   const searchText = `${model.name} ${model.description ?? ""}`.toLowerCase();
 


### PR DESCRIPTION
## Summary

Replicate models whose description mentions secondary capabilities (e.g. video models with "native audio", image models with "upscale" features) get misclassified by the keyword-only heuristic. Concrete example: \`bytedance/seedance-2.0\` is currently tagged \`text-to-audio\` because its description says "video generation model with native audio" and the audio keyword check runs before the video check.

Fix: Replicate's \`/v1/models\` list response already includes \`default_example.output\` — a URL whose extension is an authoritative output-type signal. When present, classify by extension. Fall back to the existing keyword heuristic only when \`default_example\` is absent or its output is non-URL text.

## Extension mapping

| Extensions | Capability |
|-----------|-----------|
| \`mp4\`, \`webm\`, \`mov\`, \`avi\`, \`mkv\` | \`text-to-video\` / \`image-to-video\` |
| \`mp3\`, \`wav\`, \`ogg\`, \`flac\`, \`m4a\` | \`text-to-audio\` |
| \`glb\`, \`usdz\`, \`ply\`, \`obj\`, \`stl\`, \`gltf\` | \`text-to-3d\` / \`image-to-3d\` |
| \`png\`, \`jpg\`, \`jpeg\`, \`webp\`, \`gif\` | \`text-to-image\` / \`image-to-image\` |

Subtype (text-to-X vs image-to-X) is still determined by keyword hints on the name/description.

## Test plan

- [x] \`pnpm vitest run src/app/api/models/__tests__/route.test.ts\` — 27/27 pass (5 new tests added)
- [x] Seedance regression test: video-with-audio description now classifies as \`text-to-video\`
- [x] Array output form (e.g. image batches) correctly classified
- [x] 3D (\`.glb\`) path with image-to-3d subtype detection
- [x] Fallback to keyword heuristic when \`default_example\` missing
- [x] Fallback to keyword heuristic when \`default_example.output\` is plain text (not a URL)

## Notes

- Independent of #68 (model-fetch-freshness). Both can merge in either order.
- No changes to public API or cache format; safe to roll forward or back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)