### PR TITLE
feat(social): Social Copilot #78 — compose richness (settings, updateDraft, media)

### DIFF
--- a/src/components/social/copilot/CopilotChat.tsx
+++ b/src/components/social/copilot/CopilotChat.tsx
@@ -226,7 +226,8 @@ export function CopilotChat() {
               (p) =>
                 (p.type === "tool-createDraft" ||
                   p.type === "tool-listDrafts" ||
-                  p.type === "tool-getDraft") &&
+                  p.type === "tool-getDraft" ||
+                  p.type === "tool-updateDraft") &&
                 "state" in p &&
                 p.state === "output-available",
             ) ?? []

--- a/src/lib/social/copilot/__tests__/drafts.test.ts
+++ b/src/lib/social/copilot/__tests__/drafts.test.ts
@@ -5,11 +5,13 @@ const {
   mockCreateSocialPost,
   mockListSocialPosts,
   mockGetSocialPost,
+  mockUpdateSocialPost,
 } = vi.hoisted(() => ({
   mockListSocialAccounts: vi.fn(),
   mockCreateSocialPost: vi.fn(),
   mockListSocialPosts: vi.fn(),
   mockGetSocialPost: vi.fn(),
+  mockUpdateSocialPost: vi.fn(),
 }));
 
 vi.mock("@/lib/social/repository", () => ({
@@ -17,9 +19,15 @@ vi.mock("@/lib/social/repository", () => ({
   createSocialPost: mockCreateSocialPost,
   listSocialPosts: mockListSocialPosts,
   getSocialPost: mockGetSocialPost,
+  updateSocialPost: mockUpdateSocialPost,
 }));
 
-import { createDrafts, listDraftsForWorkspace, getDraftForWorkspace } from "../drafts";
+import {
+  createDrafts,
+  listDraftsForWorkspace,
+  getDraftForWorkspace,
+  updateDraftForWorkspace,
+} from "../drafts";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -98,5 +106,32 @@ describe("getDraftForWorkspace", () => {
 
     expect(mockGetSocialPost).toHaveBeenCalledWith("ws_1", "spost_1");
     expect(draft.id).toBe("spost_1");
+  });
+});
+
+describe("updateDraftForWorkspace", () => {
+  it("updates content/settings/schedule scoped to the workspace, converting schedule to a Date", async () => {
+    mockUpdateSocialPost.mockResolvedValue({
+      id: "spost_1",
+      socialAccountId: "ch_x",
+      status: "draft",
+      content: "new text",
+      scheduledAt: new Date("2026-06-01T10:00:00.000Z"),
+    });
+
+    const draft = await updateDraftForWorkspace(
+      { workspaceId: "ws_1", userId: "u_1" },
+      "spost_1",
+      { content: "new text", scheduledAt: "2026-06-01T10:00:00.000Z" },
+    );
+
+    expect(mockUpdateSocialPost).toHaveBeenCalledWith(
+      "ws_1",
+      "spost_1",
+      expect.objectContaining({ content: "new text" }),
+    );
+    expect(mockUpdateSocialPost.mock.calls[0][2].scheduledAt).toBeInstanceOf(Date);
+    expect(draft.content).toBe("new text");
+    expect(draft.scheduledAt).toBe("2026-06-01T10:00:00.000Z");
   });
 });

--- a/src/lib/social/copilot/__tests__/media.test.ts
+++ b/src/lib/social/copilot/__tests__/media.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockListWorkspaceAssets, mockGetAsset, mockGetSocialPost, mockUpdateSocialPost } =
+  vi.hoisted(() => ({
+    mockListWorkspaceAssets: vi.fn(),
+    mockGetAsset: vi.fn(),
+    mockGetSocialPost: vi.fn(),
+    mockUpdateSocialPost: vi.fn(),
+  }));
+
+vi.mock("@/lib/studio/repository", () => ({
+  listWorkspaceAssets: mockListWorkspaceAssets,
+  getAsset: mockGetAsset,
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  getSocialPost: mockGetSocialPost,
+  updateSocialPost: mockUpdateSocialPost,
+}));
+
+import { listMediaPoolAssets, attachMedia } from "../media";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listMediaPoolAssets", () => {
+  it("returns workspace assets mapped to the copilot shape, scoped to the workspace", async () => {
+    mockListWorkspaceAssets.mockResolvedValue([
+      {
+        id: "asset_1",
+        type: "image",
+        mimeType: "image/png",
+        storageKey: "ws_1/asset_1.png",
+        width: 1024,
+        height: 768,
+      },
+    ]);
+
+    const assets = await listMediaPoolAssets(
+      { workspaceId: "ws_1", userId: "u_1" },
+      { type: "image", limit: 20 },
+    );
+
+    expect(mockListWorkspaceAssets).toHaveBeenCalledWith("ws_1", {
+      type: "image",
+      limit: 20,
+    });
+    expect(assets).toEqual([
+      {
+        id: "asset_1",
+        type: "image",
+        mimeType: "image/png",
+        storageKey: "ws_1/asset_1.png",
+        width: 1024,
+        height: 768,
+      },
+    ]);
+  });
+});
+
+describe("attachMedia", () => {
+  it("appends resolved assets to the draft's existing media, scoped to the workspace", async () => {
+    mockGetSocialPost.mockResolvedValue({
+      id: "spost_1",
+      mediaUrls: [{ type: "image", url: "existing/key.png" }],
+    });
+    mockGetAsset.mockResolvedValue({
+      id: "asset_1",
+      type: "image",
+      storageKey: "ws_1/asset_1.png",
+    });
+    mockUpdateSocialPost.mockResolvedValue({ id: "spost_1" });
+
+    const result = await attachMedia(
+      { workspaceId: "ws_1", userId: "u_1" },
+      "spost_1",
+      ["asset_1"],
+    );
+
+    expect(mockGetSocialPost).toHaveBeenCalledWith("ws_1", "spost_1");
+    expect(mockGetAsset).toHaveBeenCalledWith("ws_1", "asset_1");
+    expect(mockUpdateSocialPost).toHaveBeenCalledWith("ws_1", "spost_1", {
+      mediaUrls: [
+        { type: "image", url: "existing/key.png" },
+        { type: "image", url: "ws_1/asset_1.png" },
+      ],
+    });
+    expect(result.media).toHaveLength(2);
+  });
+
+  it("rejects an asset id that doesn't belong to the workspace and updates nothing", async () => {
+    mockGetSocialPost.mockResolvedValue({ id: "spost_1", mediaUrls: null });
+    mockGetAsset.mockResolvedValue(null);
+
+    await expect(
+      attachMedia({ workspaceId: "ws_1", userId: "u_1" }, "spost_1", ["asset_x"]),
+    ).rejects.toThrow(/asset_x/);
+
+    expect(mockUpdateSocialPost).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/social/copilot/__tests__/settings.test.ts
+++ b/src/lib/social/copilot/__tests__/settings.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetDefinition } = vi.hoisted(() => ({
+  mockGetDefinition: vi.fn(),
+}));
+
+vi.mock("@/lib/social/publishing-settings", () => ({
+  getPublishingSettingsDefinition: mockGetDefinition,
+}));
+
+import { getPublishingSettingsSchema } from "../settings";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getPublishingSettingsSchema", () => {
+  it("returns the label and safe defaults for a platform with settings", () => {
+    mockGetDefinition.mockReturnValue({
+      platform: "youtube",
+      label: "YouTube",
+      defaults: { privacyStatus: "private", madeForKids: false, tags: [] },
+      normalize: () => ({}),
+      validateForPublish: () => ({ valid: true, errors: [] }),
+    });
+
+    const schema = getPublishingSettingsSchema("youtube");
+
+    expect(schema).toEqual({
+      platform: "youtube",
+      label: "YouTube",
+      defaults: { privacyStatus: "private", madeForKids: false, tags: [] },
+    });
+  });
+
+  it("returns null for a platform with no settings definition", () => {
+    mockGetDefinition.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    expect(getPublishingSettingsSchema("bluesky")).toBeNull();
+  });
+});

--- a/src/lib/social/copilot/drafts.ts
+++ b/src/lib/social/copilot/drafts.ts
@@ -3,6 +3,7 @@ import {
   getSocialPost,
   listSocialAccounts,
   listSocialPosts,
+  updateSocialPost,
 } from "@/lib/social/repository";
 import type { CopilotContext } from "./context";
 
@@ -78,5 +79,33 @@ export async function getDraftForWorkspace(
   postId: string,
 ): Promise<CopilotDraft> {
   const row = await getSocialPost(ctx.workspaceId, postId);
+  return toCopilotDraft(row as SocialPostRow);
+}
+
+/**
+ * Update a draft's content, per-channel Publishing Settings, and/or schedule.
+ * Workspace-scoped (the repo verifies ownership). Backs the `updateDraft` tool.
+ */
+export async function updateDraftForWorkspace(
+  ctx: CopilotContext,
+  postId: string,
+  input: {
+    content?: string;
+    platformSettings?: Record<string, unknown>;
+    scheduledAt?: string | null;
+  },
+): Promise<CopilotDraft> {
+  const data: {
+    content?: string;
+    platformSettings?: Record<string, unknown>;
+    scheduledAt?: Date | null;
+  } = {};
+  if (input.content !== undefined) data.content = input.content;
+  if (input.platformSettings !== undefined) data.platformSettings = input.platformSettings;
+  if (input.scheduledAt !== undefined) {
+    data.scheduledAt = input.scheduledAt === null ? null : new Date(input.scheduledAt);
+  }
+
+  const row = await updateSocialPost(ctx.workspaceId, postId, data);
   return toCopilotDraft(row as SocialPostRow);
 }

--- a/src/lib/social/copilot/media.ts
+++ b/src/lib/social/copilot/media.ts
@@ -1,0 +1,82 @@
+import { getAsset, listWorkspaceAssets } from "@/lib/studio/repository";
+import { getSocialPost, updateSocialPost } from "@/lib/social/repository";
+import type { CopilotContext } from "./context";
+
+export interface CopilotMediaItem {
+  type: string;
+  url: string;
+  alt?: string;
+}
+
+export interface CopilotMediaAsset {
+  id: string;
+  type: string;
+  mimeType: string | null;
+  storageKey: string;
+  width: number | null;
+  height: number | null;
+}
+
+type AssetRow = {
+  id: string;
+  type: string;
+  mimeType: string | null;
+  storageKey: string;
+  width: number | null;
+  height: number | null;
+};
+
+function toCopilotMediaAsset(row: AssetRow): CopilotMediaAsset {
+  return {
+    id: row.id,
+    type: row.type,
+    mimeType: row.mimeType,
+    storageKey: row.storageKey,
+    width: row.width,
+    height: row.height,
+  };
+}
+
+/**
+ * List the workspace's media-pool assets for the copilot to attach. Backs the
+ * `listMediaPoolAssets` tool. Workspace-wide because the copilot has no project
+ * context.
+ */
+export async function listMediaPoolAssets(
+  ctx: CopilotContext,
+  opts?: { type?: "image" | "video"; limit?: number },
+): Promise<CopilotMediaAsset[]> {
+  const rows = await listWorkspaceAssets(ctx.workspaceId, opts);
+  return (rows as AssetRow[]).map(toCopilotMediaAsset);
+}
+
+/**
+ * Attach media-pool asset(s) to a draft by id. Resolves each asset within the
+ * workspace (rejecting unknown ids), then appends them to the draft's existing
+ * media as `{ type, url: storageKey }` references. Backs the `attachMedia` tool.
+ */
+export async function attachMedia(
+  ctx: CopilotContext,
+  postId: string,
+  assetIds: string[],
+): Promise<{ postId: string; media: CopilotMediaItem[] }> {
+  const post = (await getSocialPost(ctx.workspaceId, postId)) as {
+    mediaUrls: CopilotMediaItem[] | null;
+  };
+
+  const newItems: CopilotMediaItem[] = [];
+  for (const assetId of assetIds) {
+    const asset = (await getAsset(ctx.workspaceId, assetId)) as {
+      type: string;
+      storageKey: string;
+    } | null;
+    if (!asset) {
+      throw new Error(`Unknown asset for this workspace: ${assetId}`);
+    }
+    newItems.push({ type: asset.type, url: asset.storageKey });
+  }
+
+  const media = [...(post.mediaUrls ?? []), ...newItems];
+  await updateSocialPost(ctx.workspaceId, postId, { mediaUrls: media });
+  return { postId, media };
+}

--- a/src/lib/social/copilot/prompt.ts
+++ b/src/lib/social/copilot/prompt.ts
@@ -13,6 +13,8 @@ Domain language (use these terms with the user):
 Behaviour:
 - Before drafting, call listChannels to see which Channels exist and their capabilities (character limits, media support). Tailor content to each Channel's limits.
 - To save a draft, call createDraft with the content and the target channel id(s) from listChannels. One draft is created per Channel. Tell the user the draft was saved and that they can open it to review.
+- Use updateDraft to revise a draft's text, set platform-specific Publishing Settings, or set a schedule. Call getPublishingSettingsSchema(platform) first to learn the available fields and safe defaults (e.g. Reddit subreddit, Mastodon visibility).
+- To attach media, call listMediaPoolAssets to find assets, then attachMedia with the chosen asset id(s). You attach existing media — you do not generate it.
 - Use listDrafts / getDraft to review existing drafts when the user refers to them.
 - Never claim a post was scheduled or published. createDraft only saves a draft; scheduling and publishing happen through explicit, separately-confirmed actions.
 - Be concise and direct. Ask one clarifying question at a time when intent is unclear.

--- a/src/lib/social/copilot/settings.ts
+++ b/src/lib/social/copilot/settings.ts
@@ -1,0 +1,25 @@
+import type { SocialPlatform } from "@/lib/db/schema";
+import { getPublishingSettingsDefinition } from "@/lib/social/publishing-settings";
+
+export interface CopilotPublishingSettingsSchema {
+  platform: SocialPlatform;
+  label: string;
+  /** Safe Defaults — also reveals the available field names for this platform. */
+  defaults: Record<string, unknown>;
+}
+
+/**
+ * Return the per-platform Publishing Settings schema (label + Safe Defaults) for
+ * the copilot, or null when the platform has no extra settings. Backs the
+ * `getPublishingSettingsSchema` tool.
+ */
+export function getPublishingSettingsSchema(
+  platform: SocialPlatform,
+): CopilotPublishingSettingsSchema | null {
+  try {
+    const def = getPublishingSettingsDefinition(platform);
+    return { platform: def.platform, label: def.label, defaults: def.defaults };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/social/copilot/tools/index.ts
+++ b/src/lib/social/copilot/tools/index.ts
@@ -6,7 +6,11 @@ import {
   createDrafts,
   listDraftsForWorkspace,
   getDraftForWorkspace,
+  updateDraftForWorkspace,
 } from "../drafts";
+import { getPublishingSettingsSchema } from "../settings";
+import { listMediaPoolAssets, attachMedia } from "../media";
+import type { SocialPlatform } from "@/lib/db/schema";
 
 /**
  * Build the Social Copilot tool set bound to a request context.
@@ -51,6 +55,64 @@ export function createCopilotTools(ctx: CopilotContext) {
         postId: z.string().describe("The draft post id"),
       }),
       execute: async ({ postId }) => ({ draft: await getDraftForWorkspace(ctx, postId) }),
+    }),
+
+    updateDraft: tool({
+      description:
+        "Update an existing draft: change its text, set per-platform Publishing Settings, and/or set a scheduled time (ISO 8601). Only provide the fields you want to change.",
+      inputSchema: z.object({
+        postId: z.string().describe("The draft post id"),
+        content: z.string().optional().describe("New post text"),
+        platformSettings: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Per-platform Publishing Settings (see getPublishingSettingsSchema)"),
+        scheduledAt: z
+          .string()
+          .nullable()
+          .optional()
+          .describe("ISO 8601 time to schedule, or null to clear"),
+      }),
+      execute: async ({ postId, content, platformSettings, scheduledAt }) => ({
+        draft: await updateDraftForWorkspace(ctx, postId, {
+          content,
+          platformSettings,
+          scheduledAt,
+        }),
+      }),
+    }),
+
+    getPublishingSettingsSchema: tool({
+      description:
+        "Get the per-platform Publishing Settings fields and safe defaults for a platform (e.g. Reddit subreddit, Mastodon visibility). Returns null if the platform has no extra settings.",
+      inputSchema: z.object({
+        platform: z.string().describe("Platform identifier, e.g. youtube, mastodon, reddit"),
+      }),
+      execute: async ({ platform }) => ({
+        schema: getPublishingSettingsSchema(platform as SocialPlatform),
+      }),
+    }),
+
+    listMediaPoolAssets: tool({
+      description:
+        "List the workspace's media-pool assets (generated/uploaded images and videos) so they can be attached to a draft.",
+      inputSchema: z.object({
+        type: z.enum(["image", "video"]).optional().describe("Filter by media type"),
+        limit: z.number().int().positive().max(50).optional(),
+      }),
+      execute: async ({ type, limit }) => ({
+        assets: await listMediaPoolAssets(ctx, { type, limit }),
+      }),
+    }),
+
+    attachMedia: tool({
+      description:
+        "Attach one or more media-pool assets (by asset id from listMediaPoolAssets) to a draft.",
+      inputSchema: z.object({
+        postId: z.string().describe("The draft post id"),
+        assetIds: z.array(z.string()).min(1).describe("Asset ids to attach"),
+      }),
+      execute: async ({ postId, assetIds }) => attachMedia(ctx, postId, assetIds),
     }),
   };
 }

--- a/src/lib/studio/repository.ts
+++ b/src/lib/studio/repository.ts
@@ -867,6 +867,26 @@ export async function listProjectAssets(workspaceId: string, projectId: string) 
     .orderBy(desc(assets.createdAt));
 }
 
+export async function listWorkspaceAssets(
+  workspaceId: string,
+  opts?: { type?: (typeof assetTypeEnum.enumValues)[number]; limit?: number },
+) {
+  const db = getDb();
+  const conditions = [
+    eq(assets.workspaceId, workspaceId),
+    isNull(assets.deletedAt),
+  ];
+  if (opts?.type) {
+    conditions.push(eq(assets.type, opts.type));
+  }
+  const base = db
+    .select()
+    .from(assets)
+    .where(and(...conditions))
+    .orderBy(desc(assets.createdAt));
+  return opts?.limit ? base.limit(opts.limit) : base;
+}
+
 export async function getAsset(workspaceId: string, assetId: string) {
   const db = getDb();
   const [asset] = await db


### PR DESCRIPTION
Slice **#78** of the Social Copilot (epic #75), building on #76/#77 (merged in #83). Adds the tools that turn a bare draft into a platform-tailored, media-bearing post.

## What's included
- **`getPublishingSettingsSchema`** — per-platform Publishing Settings fields + Safe Defaults from the registry (null when a platform has none).
- **`updateDraft`** — revise content / per-platform Publishing Settings / schedule (ISO→Date), workspace-scoped.
- **`listMediaPoolAssets`** — workspace-wide media listing via new `listWorkspaceAssets` repo fn (the copilot has no project context).
- **`attachMedia`** — resolve asset id(s) via `getAsset` (rejects unknown), append to the draft as `{type, url: storageKey}` — matching the composer's existing convention; the publish pipeline resolves storage keys to presigned URLs.
- Prompt + chat draft-link rendering updated.

## Tests
- 19 copilot unit tests green (`pnpm test:run src/lib/social/copilot src/app/api/social/copilot`); +10 new behaviors this slice (settings, updateDraft, media).
- tsc + lint clean.

## Notes
- Media scope is **workspace-wide** by design (copilot has no project); switch to project-scoped later if desired.
- Not yet exercised in a live browser; logic unit-tested, UI render-clean.
- Follow-ups unchanged: #82 (server-side encrypted keys), orphan `cmdk` dep, social-hub settings page gap.

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)