### PR TITLE
feat(social): Social Copilot #79 — publish validation & readiness

### DIFF
--- a/src/components/social/copilot/CopilotChat.tsx
+++ b/src/components/social/copilot/CopilotChat.tsx
@@ -20,6 +20,7 @@ import { useWorkflowStore } from "@/store/workflowStore"
 import { buildLlmHeaders } from "@/store/utils/buildApiHeaders"
 import type { CopilotChannel } from "@/lib/social/copilot/channels"
 import type { CopilotDraft } from "@/lib/social/copilot/drafts"
+import type { CopilotReadiness } from "@/lib/social/copilot/validate"
 
 // SSR-safe "are we on the client yet" signal via useSyncExternalStore:
 // the server snapshot is false and the client snapshot is true, so the first
@@ -75,6 +76,30 @@ function DraftLinks({ drafts }: { drafts: CopilotDraft[] }) {
           {d.content ? `“${d.content.slice(0, 40)}${d.content.length > 40 ? "…" : ""}”` : "Draft"} · Open draft →
         </Link>
       ))}
+    </div>
+  )
+}
+
+/** Render per-channel publish readiness as a ready/blocked chip with reasons. */
+function ReadinessChip({ readiness }: { readiness: CopilotReadiness }) {
+  return (
+    <div
+      className={`rounded-md border px-2 py-1 text-xs ${
+        readiness.ready
+          ? "border-emerald-500/40 bg-emerald-500/10"
+          : "border-amber-500/40 bg-amber-500/10"
+      }`}
+    >
+      <span className="font-medium">
+        {readiness.platform}: {readiness.ready ? "Ready to publish" : "Not ready"}
+      </span>
+      {!readiness.ready && readiness.reasons.length > 0 && (
+        <ul className="mt-1 list-disc ps-4">
+          {readiness.reasons.map((r, i) => (
+            <li key={i}>{r}</li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }
@@ -222,6 +247,13 @@ export function CopilotChat() {
                 p.state === "output-available",
             ) ?? []
 
+            const readinessParts = message.parts?.filter(
+              (p) =>
+                p.type === "tool-validatePublish" &&
+                "state" in p &&
+                p.state === "output-available",
+            ) ?? []
+
             const draftParts = message.parts?.filter(
               (p) =>
                 (p.type === "tool-createDraft" ||
@@ -245,6 +277,12 @@ export function CopilotChat() {
                     }).output
                     const drafts = output?.drafts ?? (output?.draft ? [output.draft] : [])
                     return <DraftLinks key={`d${i}`} drafts={drafts} />
+                  })}
+                  {readinessParts.map((p, i) => {
+                    const output = (p as { output?: { readiness?: CopilotReadiness } }).output
+                    return output?.readiness ? (
+                      <ReadinessChip key={`r${i}`} readiness={output.readiness} />
+                    ) : null
                   })}
                   {text &&
                     (message.role === "assistant" ? (

--- a/src/lib/social/copilot/__tests__/validate.test.ts
+++ b/src/lib/social/copilot/__tests__/validate.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetSocialPost,
+  mockGetSocialAccount,
+  mockGetProvider,
+  mockValidateSettings,
+} = vi.hoisted(() => ({
+  mockGetSocialPost: vi.fn(),
+  mockGetSocialAccount: vi.fn(),
+  mockGetProvider: vi.fn(),
+  mockValidateSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  getSocialPost: mockGetSocialPost,
+  getSocialAccount: mockGetSocialAccount,
+}));
+
+vi.mock("@/lib/social/provider-registry", () => ({
+  getProvider: mockGetProvider,
+}));
+
+vi.mock("@/lib/social/publishing-settings", () => ({
+  validateSelectedPublishingSettings: mockValidateSettings,
+}));
+
+import { validatePublishForDraft } from "../validate";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetProvider.mockReturnValue({
+    getCapabilities: () => ({ displayName: "Bluesky", maxContentLength: 300 }),
+  });
+  mockValidateSettings.mockReturnValue({ valid: true, errors: [] });
+});
+
+describe("validatePublishForDraft", () => {
+  it("reports a ready draft with no reasons", async () => {
+    mockGetSocialPost.mockResolvedValue({
+      socialAccountId: "ch_x",
+      content: "hello",
+      mediaUrls: null,
+      platformSettings: null,
+    });
+    mockGetSocialAccount.mockResolvedValue({ platform: "bluesky" });
+
+    const readiness = await validatePublishForDraft(
+      { workspaceId: "ws_1", userId: "u_1" },
+      "spost_1",
+    );
+
+    expect(mockGetSocialPost).toHaveBeenCalledWith("ws_1", "spost_1");
+    expect(readiness).toEqual({
+      postId: "spost_1",
+      channelId: "ch_x",
+      platform: "bluesky",
+      ready: true,
+      reasons: [],
+    });
+  });
+
+  it("flags content that exceeds the platform's max length", async () => {
+    mockGetSocialPost.mockResolvedValue({
+      socialAccountId: "ch_x",
+      content: "x".repeat(301),
+      mediaUrls: null,
+      platformSettings: null,
+    });
+    mockGetSocialAccount.mockResolvedValue({ platform: "bluesky" });
+
+    const readiness = await validatePublishForDraft(
+      { workspaceId: "ws_1", userId: "u_1" },
+      "spost_1",
+    );
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.reasons.join(" ")).toMatch(/300/);
+  });
+
+  it("surfaces publishing-settings errors as reasons", async () => {
+    mockGetSocialPost.mockResolvedValue({
+      socialAccountId: "ch_yt",
+      content: "my video",
+      mediaUrls: null,
+      platformSettings: {},
+    });
+    mockGetSocialAccount.mockResolvedValue({ platform: "youtube" });
+    mockGetProvider.mockReturnValue({
+      getCapabilities: () => ({ displayName: "YouTube", maxContentLength: 5000 }),
+    });
+    mockValidateSettings.mockReturnValue({
+      valid: false,
+      errors: ["YouTube: title is required."],
+    });
+
+    const readiness = await validatePublishForDraft(
+      { workspaceId: "ws_1", userId: "u_1" },
+      "spost_2",
+    );
+
+    expect(mockValidateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedChannelIds: ["ch_yt"],
+        platformByChannelId: { ch_yt: "youtube" },
+        content: "my video",
+      }),
+    );
+    expect(readiness.ready).toBe(false);
+    expect(readiness.reasons).toContain("YouTube: title is required.");
+  });
+});

--- a/src/lib/social/copilot/prompt.ts
+++ b/src/lib/social/copilot/prompt.ts
@@ -16,6 +16,7 @@ Behaviour:
 - Use updateDraft to revise a draft's text, set platform-specific Publishing Settings, or set a schedule. Call getPublishingSettingsSchema(platform) first to learn the available fields and safe defaults (e.g. Reddit subreddit, Mastodon visibility).
 - To attach media, call listMediaPoolAssets to find assets, then attachMedia with the chosen asset id(s). You attach existing media — you do not generate it.
 - Use listDrafts / getDraft to review existing drafts when the user refers to them.
+- Before suggesting the user schedule or publish a draft, call validatePublish and report the per-channel readiness. If anything is blocking, tell the user the reasons and help fix them.
 - Never claim a post was scheduled or published. createDraft only saves a draft; scheduling and publishing happen through explicit, separately-confirmed actions.
 - Be concise and direct. Ask one clarifying question at a time when intent is unclear.
 - If a Channel is disabled or needs re-authentication, tell the user rather than drafting for it.`;

--- a/src/lib/social/copilot/tools/index.ts
+++ b/src/lib/social/copilot/tools/index.ts
@@ -10,6 +10,7 @@ import {
 } from "../drafts";
 import { getPublishingSettingsSchema } from "../settings";
 import { listMediaPoolAssets, attachMedia } from "../media";
+import { validatePublishForDraft } from "../validate";
 import type { SocialPlatform } from "@/lib/db/schema";
 
 /**
@@ -113,6 +114,17 @@ export function createCopilotTools(ctx: CopilotContext) {
         assetIds: z.array(z.string()).min(1).describe("Asset ids to attach"),
       }),
       execute: async ({ postId, assetIds }) => attachMedia(ctx, postId, assetIds),
+    }),
+
+    validatePublish: tool({
+      description:
+        "Check whether a draft is ready to publish. Returns per-channel readiness with reasons for anything blocking (content length, missing required Publishing Settings, empty post). Always run this before suggesting the user schedule or publish.",
+      inputSchema: z.object({
+        postId: z.string().describe("The draft post id"),
+      }),
+      execute: async ({ postId }) => ({
+        readiness: await validatePublishForDraft(ctx, postId),
+      }),
     }),
   };
 }

--- a/src/lib/social/copilot/validate.ts
+++ b/src/lib/social/copilot/validate.ts
@@ -1,0 +1,69 @@
+import type { SocialPlatform } from "@/lib/db/schema";
+import { getSocialPost, getSocialAccount } from "@/lib/social/repository";
+import { getProvider } from "@/lib/social/provider-registry";
+import { validateSelectedPublishingSettings } from "@/lib/social/publishing-settings";
+import type { PublishMediaItem } from "@/lib/social/provider-interface";
+import type { CopilotContext } from "./context";
+
+export interface CopilotReadiness {
+  postId: string;
+  channelId: string;
+  platform: string;
+  ready: boolean;
+  reasons: string[];
+}
+
+type DraftRow = {
+  socialAccountId: string;
+  content: string | null;
+  mediaUrls: Array<{ type: string; url: string; alt?: string }> | null;
+  platformSettings: Record<string, unknown> | null;
+};
+
+/**
+ * Run Publish Validation for a draft and report per-Channel Publishing
+ * Readiness (a draft maps to one Channel). Backs the `validatePublish` tool.
+ */
+export async function validatePublishForDraft(
+  ctx: CopilotContext,
+  postId: string,
+): Promise<CopilotReadiness> {
+  const post = (await getSocialPost(ctx.workspaceId, postId)) as DraftRow;
+  const account = (await getSocialAccount(ctx.workspaceId, post.socialAccountId)) as {
+    platform: SocialPlatform;
+  };
+  const platform = account.platform;
+  const caps = getProvider(platform).getCapabilities();
+
+  const content = post.content ?? "";
+  const media = post.mediaUrls ?? [];
+  const reasons: string[] = [];
+
+  if (!content && media.length === 0) {
+    reasons.push("Post has no content or media.");
+  }
+  if (content.length > caps.maxContentLength) {
+    reasons.push(
+      `Content is ${content.length} characters; ${caps.displayName} allows ${caps.maxContentLength}.`,
+    );
+  }
+
+  const settingsResult = validateSelectedPublishingSettings({
+    selectedChannelIds: [post.socialAccountId],
+    settingsByChannelId: { [post.socialAccountId]: post.platformSettings ?? {} },
+    platformByChannelId: { [post.socialAccountId]: platform },
+    content,
+    media: media as PublishMediaItem[],
+  });
+  if (!settingsResult.valid) {
+    reasons.push(...settingsResult.errors);
+  }
+
+  return {
+    postId,
+    channelId: post.socialAccountId,
+    platform,
+    ready: reasons.length === 0,
+    reasons,
+  };
+}


### PR DESCRIPTION
Slice **#79** of the Social Copilot (epic #75), building on #76–#78. Adds Publish Validation surfaced as per-channel Publishing Readiness in the chat.

## What's included
- **`validatePublishForDraft`** — combines content-length (provider `maxContentLength`), empty-post, and per-platform Publishing Settings (`validateSelectedPublishingSettings`) into `{ ready, reasons[] }` for a draft's Channel. Workspace-scoped.
- **`validatePublish`** tool; prompt now requires validating before suggesting schedule/publish.
- **Readiness chips** in the chat (green ready / amber not-ready with reasons).

## Tests
- 22 copilot unit tests green (`pnpm test:run src/lib/social/copilot src/app/api/social/copilot`); +3 new validation behaviors.
- tsc + lint clean.

## Notes
- This is the exact check slice #80's commit tools will re-run server-side before the `needsApproval` gate (ADR 0002).
- Not yet exercised in a live browser; logic unit-tested, UI render-clean.
- Follow-ups unchanged: #82 (secure keys), orphan `cmdk` dep, social-hub settings page gap.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)