### PR TITLE
feat(social): Social Copilot #80 — commit with human-in-the-loop gate ⚠️ HITL

### DIFF
--- a/src/components/social/copilot/CopilotChat.tsx
+++ b/src/components/social/copilot/CopilotChat.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState, useSyncExternalStore } from "react"
 import { useChat } from "@ai-sdk/react"
-import { DefaultChatTransport } from "ai"
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalResponses } from "ai"
 import Link from "next/link"
 import { KeyRoundIcon, SendIcon, SparklesIcon, SquareIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -136,8 +136,9 @@ export function CopilotChat() {
   )
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const { messages, sendMessage, status, stop } = useChat({
+  const { messages, sendMessage, status, stop, addToolApprovalResponse } = useChat({
     transport,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onError: (error) => {
       setErrorMessage(error.message)
       if (/x-api-key|api[- ]?key|unauthor|authentication|invalid.*key|\b401\b/i.test(error.message)) {
@@ -254,6 +255,20 @@ export function CopilotChat() {
                 p.state === "output-available",
             ) ?? []
 
+            const approvalParts = message.parts?.filter(
+              (p) =>
+                (p.type === "tool-scheduleDraft" || p.type === "tool-publishNow") &&
+                "state" in p &&
+                p.state === "approval-requested",
+            ) ?? []
+
+            const commitResultParts = message.parts?.filter(
+              (p) =>
+                (p.type === "tool-scheduleDraft" || p.type === "tool-publishNow") &&
+                "state" in p &&
+                p.state === "output-available",
+            ) ?? []
+
             const draftParts = message.parts?.filter(
               (p) =>
                 (p.type === "tool-createDraft" ||
@@ -283,6 +298,58 @@ export function CopilotChat() {
                     return output?.readiness ? (
                       <ReadinessChip key={`r${i}`} readiness={output.readiness} />
                     ) : null
+                  })}
+                  {approvalParts.map((p, i) => {
+                    const action = p.type === "tool-scheduleDraft" ? "Schedule this post" : "Publish this post now"
+                    const input = (p as { input?: { scheduledAt?: string } }).input
+                    const approvalId = (p as { approval?: { id?: string } }).approval?.id
+                    return (
+                      <div
+                        key={`ap${i}`}
+                        className="rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-xs"
+                      >
+                        <p className="font-medium">{action}?</p>
+                        {input?.scheduledAt && (
+                          <p className="text-muted-foreground">
+                            At {new Date(input.scheduledAt).toLocaleString()}
+                          </p>
+                        )}
+                        <div className="mt-2 flex gap-2">
+                          <Button
+                            size="sm"
+                            disabled={!approvalId}
+                            onClick={() =>
+                              approvalId && addToolApprovalResponse({ id: approvalId, approved: true })
+                            }
+                          >
+                            Approve
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            disabled={!approvalId}
+                            onClick={() =>
+                              approvalId && addToolApprovalResponse({ id: approvalId, approved: false })
+                            }
+                          >
+                            Deny
+                          </Button>
+                        </div>
+                      </div>
+                    )
+                  })}
+                  {commitResultParts.map((p, i) => {
+                    const out = (p as { output?: { scheduledAt?: string | null } }).output
+                    return (
+                      <div
+                        key={`cr${i}`}
+                        className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs"
+                      >
+                        {out?.scheduledAt
+                          ? `Scheduled for ${new Date(out.scheduledAt).toLocaleString()}`
+                          : "Queued to publish now"}
+                      </div>
+                    )
                   })}
                   {text &&
                     (message.role === "assistant" ? (

--- a/src/lib/social/copilot/__tests__/commit.test.ts
+++ b/src/lib/social/copilot/__tests__/commit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockValidate, mockUpdatePostStatus } = vi.hoisted(() => ({
+  mockValidate: vi.fn(),
+  mockUpdatePostStatus: vi.fn(),
+}));
+
+vi.mock("../validate", () => ({
+  validatePublishForDraft: mockValidate,
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  updatePostStatus: mockUpdatePostStatus,
+}));
+
+import { scheduleDraftForWorkspace, publishNowForWorkspace } from "../commit";
+
+const ctx = { workspaceId: "ws_1", userId: "u_1" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdatePostStatus.mockResolvedValue({ id: "spost_1", status: "queued" });
+});
+
+describe("scheduleDraftForWorkspace", () => {
+  it("queues a ready draft with the requested schedule", async () => {
+    mockValidate.mockResolvedValue({
+      postId: "spost_1",
+      channelId: "ch_x",
+      platform: "bluesky",
+      ready: true,
+      reasons: [],
+    });
+
+    const result = await scheduleDraftForWorkspace(ctx, "spost_1", "2026-06-01T10:00:00.000Z");
+
+    expect(mockValidate).toHaveBeenCalledWith(ctx, "spost_1");
+    expect(mockUpdatePostStatus).toHaveBeenCalledWith(
+      "spost_1",
+      "queued",
+      expect.objectContaining({ dispatchStatus: "pending" }),
+    );
+    expect(mockUpdatePostStatus.mock.calls[0][2].scheduledAt).toBeInstanceOf(Date);
+    expect(result).toMatchObject({ postId: "spost_1", scheduledAt: "2026-06-01T10:00:00.000Z" });
+  });
+
+  it("refuses to queue an unready draft and changes nothing", async () => {
+    mockValidate.mockResolvedValue({
+      postId: "spost_1",
+      channelId: "ch_yt",
+      platform: "youtube",
+      ready: false,
+      reasons: ["YouTube: title is required."],
+    });
+
+    await expect(
+      scheduleDraftForWorkspace(ctx, "spost_1", "2026-06-01T10:00:00.000Z"),
+    ).rejects.toThrow(/title is required/i);
+
+    expect(mockUpdatePostStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("publishNowForWorkspace", () => {
+  it("queues a ready draft for immediate publish (no future schedule)", async () => {
+    mockValidate.mockResolvedValue({
+      postId: "spost_1",
+      channelId: "ch_x",
+      platform: "bluesky",
+      ready: true,
+      reasons: [],
+    });
+
+    const result = await publishNowForWorkspace(ctx, "spost_1");
+
+    expect(mockUpdatePostStatus).toHaveBeenCalledWith(
+      "spost_1",
+      "queued",
+      expect.objectContaining({ scheduledAt: null, dispatchStatus: "pending" }),
+    );
+    expect(result).toMatchObject({ postId: "spost_1", scheduledAt: null });
+  });
+
+  it("refuses to publish an unready draft and changes nothing", async () => {
+    mockValidate.mockResolvedValue({
+      postId: "spost_1",
+      channelId: "ch_x",
+      platform: "bluesky",
+      ready: false,
+      reasons: ["Post has no content or media."],
+    });
+
+    await expect(publishNowForWorkspace(ctx, "spost_1")).rejects.toThrow(/no content/i);
+    expect(mockUpdatePostStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/social/copilot/agent.ts
+++ b/src/lib/social/copilot/agent.ts
@@ -11,7 +11,11 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import type { CopilotProvider } from "./byok";
 import type { CopilotContext } from "./context";
-import { createCopilotTools } from "./tools";
+import {
+  createCopilotTools,
+  COMMIT_TOOL_NAMES,
+  DRAFT_CONTEXT_TOOL_NAMES,
+} from "./tools";
 import { SOCIAL_COPILOT_SYSTEM_PROMPT } from "./prompt";
 
 export interface CopilotRunConfig {
@@ -48,11 +52,29 @@ export function buildSocialCopilotAgent({
   apiKey,
   ctx,
 }: CopilotRunConfig) {
+  const tools = createCopilotTools(ctx);
+  const stagedTools = Object.keys(tools).filter(
+    (name) => !COMMIT_TOOL_NAMES.includes(name),
+  );
+
   return new ToolLoopAgent({
     model: resolveModel(provider, modelId, apiKey),
     instructions: SOCIAL_COPILOT_SYSTEM_PROMPT,
-    tools: createCopilotTools(ctx),
+    tools,
     stopWhen: stepCountIs(12),
+    // Hide the irreversible commit tools until the agent is working with a
+    // concrete draft, so it can't try to schedule/publish nothing.
+    prepareStep: ({ steps }) => {
+      const hasDraftContext = steps.some((step) =>
+        step.toolCalls?.some((call) =>
+          DRAFT_CONTEXT_TOOL_NAMES.includes(call.toolName),
+        ),
+      );
+      if (!hasDraftContext) {
+        return { activeTools: stagedTools as Array<keyof typeof tools> };
+      }
+      return {};
+    },
   });
 }
 

--- a/src/lib/social/copilot/commit.ts
+++ b/src/lib/social/copilot/commit.ts
@@ -1,0 +1,70 @@
+import { updatePostStatus } from "@/lib/social/repository";
+import type { CopilotContext } from "./context";
+import { validatePublishForDraft } from "./validate";
+
+export interface CopilotCommitResult {
+  postId: string;
+  channelId: string;
+  status: "queued";
+  scheduledAt: string | null;
+}
+
+/**
+ * Schedule a draft for publishing. Re-runs Publish Validation server-side and
+ * refuses to queue an unready draft (ADR 0002). On success, transitions the
+ * post to `queued` with the schedule; the dispatcher claims it and starts the
+ * publish workflow. Gated behind needsApproval at the tool layer.
+ */
+export async function scheduleDraftForWorkspace(
+  ctx: CopilotContext,
+  postId: string,
+  scheduledAtIso: string,
+): Promise<CopilotCommitResult> {
+  const readiness = await validatePublishForDraft(ctx, postId);
+  if (!readiness.ready) {
+    throw new Error(
+      `Draft is not ready to publish: ${readiness.reasons.join("; ")}`,
+    );
+  }
+
+  await updatePostStatus(postId, "queued", {
+    scheduledAt: new Date(scheduledAtIso),
+    dispatchStatus: "pending",
+  });
+
+  return {
+    postId,
+    channelId: readiness.channelId,
+    status: "queued",
+    scheduledAt: scheduledAtIso,
+  };
+}
+
+/**
+ * Publish a draft immediately. Same server-side gate as scheduleDraft, then
+ * queues with no future schedule so the dispatcher picks it up at once. Gated
+ * behind needsApproval at the tool layer.
+ */
+export async function publishNowForWorkspace(
+  ctx: CopilotContext,
+  postId: string,
+): Promise<CopilotCommitResult> {
+  const readiness = await validatePublishForDraft(ctx, postId);
+  if (!readiness.ready) {
+    throw new Error(
+      `Draft is not ready to publish: ${readiness.reasons.join("; ")}`,
+    );
+  }
+
+  await updatePostStatus(postId, "queued", {
+    scheduledAt: null,
+    dispatchStatus: "pending",
+  });
+
+  return {
+    postId,
+    channelId: readiness.channelId,
+    status: "queued",
+    scheduledAt: null,
+  };
+}

--- a/src/lib/social/copilot/tools/index.ts
+++ b/src/lib/social/copilot/tools/index.ts
@@ -11,6 +11,18 @@ import {
 import { getPublishingSettingsSchema } from "../settings";
 import { listMediaPoolAssets, attachMedia } from "../media";
 import { validatePublishForDraft } from "../validate";
+import { scheduleDraftForWorkspace, publishNowForWorkspace } from "../commit";
+
+/** Tools whose use signals the agent is working with a concrete draft. */
+export const DRAFT_CONTEXT_TOOL_NAMES = [
+  "createDraft",
+  "getDraft",
+  "listDrafts",
+  "updateDraft",
+];
+
+/** Irreversible commit tools, gated behind needsApproval + staged until a draft exists. */
+export const COMMIT_TOOL_NAMES = ["scheduleDraft", "publishNow"];
 import type { SocialPlatform } from "@/lib/db/schema";
 
 /**
@@ -125,6 +137,28 @@ export function createCopilotTools(ctx: CopilotContext) {
       execute: async ({ postId }) => ({
         readiness: await validatePublishForDraft(ctx, postId),
       }),
+    }),
+
+    scheduleDraft: tool({
+      description:
+        "Schedule a draft to publish at a specific time (ISO 8601). Requires the user's explicit approval. Re-validates the draft server-side and refuses if it isn't ready.",
+      inputSchema: z.object({
+        postId: z.string().describe("The draft post id"),
+        scheduledAt: z.string().describe("ISO 8601 time to publish"),
+      }),
+      needsApproval: true,
+      execute: async ({ postId, scheduledAt }) =>
+        scheduleDraftForWorkspace(ctx, postId, scheduledAt),
+    }),
+
+    publishNow: tool({
+      description:
+        "Publish a draft immediately. Requires the user's explicit approval. Re-validates the draft server-side and refuses if it isn't ready.",
+      inputSchema: z.object({
+        postId: z.string().describe("The draft post id"),
+      }),
+      needsApproval: true,
+      execute: async ({ postId }) => publishNowForWorkspace(ctx, postId),
     }),
   };
 }


### PR DESCRIPTION
Slice **#80** of the Social Copilot (epic #75). **This opens the publish path — please review carefully** (the slice was flagged HITL for a design/safety check).

## What's included
- **`scheduleDraftForWorkspace` / `publishNowForWorkspace`** (`commit.ts`): re-run `validatePublishForDraft` server-side and **throw if not ready** (ADR 0002), then transition the post to `queued` (with schedule, or immediate). The existing cron **dispatcher** claims queued posts and starts the publish workflow — no workflow-start/locking reimplemented.
- **Tools `scheduleDraft` + `publishNow`** with **`needsApproval: true`** (AI SDK native HITL).
- **`prepareStep` activeTools staging** — commit tools are hidden until the agent has worked with a concrete draft (createDraft/getDraft/listDrafts/updateDraft), so it can't schedule/publish nothing.
- **Approval UI** — `useChat({ sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses })` + `addToolApprovalResponse`; an Approve/Deny panel for `approval-requested` parts and a queued/scheduled confirmation chip.

## Please scrutinize
- **Server-side gate** is the only thing standing between the model and a publish — confirm `validatePublishForDraft` is sufficient and that `execute` cannot proceed when `!ready`.
- **Ownership**: `updatePostStatus` is by post-id (not workspace-scoped); ownership is enforced by the gate's workspace-scoped `getSocialPost`. Confirm that's adequate.
- **Delegation**: setting `status=queued` + `scheduledAt` + `dispatchStatus=pending` is exactly what the dispatcher (`/api/social/internal/dispatch`) expects; confirm no double-dispatch or missed-window.
- A status guard (only draft/failed may be queued) is **not** yet added — noted as a hardening follow-up.

## Tests
- 26 copilot unit tests green; +4 commit-gate behaviors (ready/not-ready × schedule/publish, asserting no status change when unready).
- tsc + lint clean. Not yet exercised live.

## Follow-ups
- #82 (server-side encrypted keys), orphan `cmdk` dep, social-hub settings page gap, commit status-guard hardening.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)