### PR TITLE
feat(social): Social Copilot #81 — scheduling intelligence & draft ops

### DIFF
--- a/src/components/social/copilot/CopilotChat.tsx
+++ b/src/components/social/copilot/CopilotChat.tsx
@@ -274,7 +274,8 @@ export function CopilotChat() {
                 (p.type === "tool-createDraft" ||
                   p.type === "tool-listDrafts" ||
                   p.type === "tool-getDraft" ||
-                  p.type === "tool-updateDraft") &&
+                  p.type === "tool-updateDraft" ||
+                  p.type === "tool-duplicateDraft") &&
                 "state" in p &&
                 p.state === "output-available",
             ) ?? []

--- a/src/lib/social/copilot/__tests__/drafts.test.ts
+++ b/src/lib/social/copilot/__tests__/drafts.test.ts
@@ -6,12 +6,14 @@ const {
   mockListSocialPosts,
   mockGetSocialPost,
   mockUpdateSocialPost,
+  mockDeleteSocialPost,
 } = vi.hoisted(() => ({
   mockListSocialAccounts: vi.fn(),
   mockCreateSocialPost: vi.fn(),
   mockListSocialPosts: vi.fn(),
   mockGetSocialPost: vi.fn(),
   mockUpdateSocialPost: vi.fn(),
+  mockDeleteSocialPost: vi.fn(),
 }));
 
 vi.mock("@/lib/social/repository", () => ({
@@ -20,6 +22,7 @@ vi.mock("@/lib/social/repository", () => ({
   listSocialPosts: mockListSocialPosts,
   getSocialPost: mockGetSocialPost,
   updateSocialPost: mockUpdateSocialPost,
+  deleteSocialPost: mockDeleteSocialPost,
 }));
 
 import {
@@ -27,7 +30,12 @@ import {
   listDraftsForWorkspace,
   getDraftForWorkspace,
   updateDraftForWorkspace,
+  listScheduledPostsForWorkspace,
+  duplicateDraftForWorkspace,
+  deleteDraftForWorkspace,
 } from "../drafts";
+
+const ctx = { workspaceId: "ws_1", userId: "u_1" };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -106,6 +114,95 @@ describe("getDraftForWorkspace", () => {
 
     expect(mockGetSocialPost).toHaveBeenCalledWith("ws_1", "spost_1");
     expect(draft.id).toBe("spost_1");
+  });
+});
+
+describe("listScheduledPostsForWorkspace", () => {
+  it("returns non-draft posts in the date range as calendar entries", async () => {
+    mockListSocialPosts.mockResolvedValue([
+      {
+        id: "spost_q",
+        socialAccountId: "ch_x",
+        status: "queued",
+        content: "scheduled one",
+        scheduledAt: new Date("2026-06-01T10:00:00.000Z"),
+      },
+      {
+        id: "spost_d",
+        socialAccountId: "ch_x",
+        status: "draft",
+        content: "just a draft",
+        scheduledAt: null,
+      },
+    ]);
+
+    const entries = await listScheduledPostsForWorkspace(ctx, {
+      start: "2026-06-01T00:00:00.000Z",
+      end: "2026-06-07T00:00:00.000Z",
+    });
+
+    expect(mockListSocialPosts).toHaveBeenCalledWith(
+      "ws_1",
+      expect.objectContaining({
+        startDate: expect.any(Date),
+        endDate: expect.any(Date),
+      }),
+    );
+    expect(entries.map((e) => e.postId)).toEqual(["spost_q"]);
+    expect(entries[0]).toMatchObject({
+      channelId: "ch_x",
+      status: "queued",
+      scheduledAt: "2026-06-01T10:00:00.000Z",
+    });
+  });
+});
+
+describe("duplicateDraftForWorkspace", () => {
+  it("clones content/media/settings into a new draft, retargeting the channel when given", async () => {
+    mockGetSocialPost.mockResolvedValue({
+      id: "spost_1",
+      socialAccountId: "ch_x",
+      status: "draft",
+      content: "hello",
+      mediaUrls: [{ type: "image", url: "key.png" }],
+      platformSettings: { subreddit: "r/test" },
+      scheduledAt: null,
+    });
+    mockCreateSocialPost.mockImplementation(async (input: Record<string, unknown>) => ({
+      id: "spost_2",
+      socialAccountId: input.socialAccountId,
+      status: "draft",
+      content: input.content ?? null,
+      scheduledAt: null,
+    }));
+
+    const draft = await duplicateDraftForWorkspace(ctx, "spost_1", {
+      channelId: "ch_li",
+    });
+
+    expect(mockGetSocialPost).toHaveBeenCalledWith("ws_1", "spost_1");
+    expect(mockCreateSocialPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        createdByUserId: "u_1",
+        socialAccountId: "ch_li",
+        content: "hello",
+        mediaUrls: [{ type: "image", url: "key.png" }],
+        platformSettings: { subreddit: "r/test" },
+      }),
+    );
+    expect(draft.id).toBe("spost_2");
+  });
+});
+
+describe("deleteDraftForWorkspace", () => {
+  it("deletes a draft scoped to the workspace", async () => {
+    mockDeleteSocialPost.mockResolvedValue(undefined);
+
+    const result = await deleteDraftForWorkspace(ctx, "spost_1");
+
+    expect(mockDeleteSocialPost).toHaveBeenCalledWith("ws_1", "spost_1");
+    expect(result).toEqual({ postId: "spost_1", deleted: true });
   });
 });
 

--- a/src/lib/social/copilot/drafts.ts
+++ b/src/lib/social/copilot/drafts.ts
@@ -1,5 +1,6 @@
 import {
   createSocialPost,
+  deleteSocialPost,
   getSocialPost,
   listSocialAccounts,
   listSocialPosts,
@@ -23,6 +24,19 @@ type SocialPostRow = {
   content: string | null;
   scheduledAt: Date | string | null;
 };
+
+/** A committed (non-draft) post on the workspace calendar. */
+export interface CopilotCalendarEntry {
+  postId: string;
+  channelId: string;
+  status: string;
+  scheduledAt: string | null;
+  content: string | null;
+}
+
+function toIso(value: Date | string | null): string | null {
+  return value instanceof Date ? value.toISOString() : (value ?? null);
+}
 
 function toCopilotDraft(row: SocialPostRow): CopilotDraft {
   return {
@@ -108,4 +122,64 @@ export async function updateDraftForWorkspace(
 
   const row = await updateSocialPost(ctx.workspaceId, postId, data);
   return toCopilotDraft(row as SocialPostRow);
+}
+
+/** Delete a draft, scoped to the workspace. Backs the `deleteDraft` tool. */
+export async function deleteDraftForWorkspace(
+  ctx: CopilotContext,
+  postId: string,
+): Promise<{ postId: string; deleted: true }> {
+  await deleteSocialPost(ctx.workspaceId, postId);
+  return { postId, deleted: true };
+}
+
+/**
+ * Duplicate a draft into a new draft, optionally retargeting a different
+ * Channel (enables Reddit one-subreddit-per-post fanout and retargeting, ADR
+ * 0004). Backs the `duplicateDraft` tool.
+ */
+export async function duplicateDraftForWorkspace(
+  ctx: CopilotContext,
+  postId: string,
+  opts?: { channelId?: string },
+): Promise<CopilotDraft> {
+  const source = (await getSocialPost(ctx.workspaceId, postId)) as SocialPostRow & {
+    mediaUrls: Array<{ type: string; url: string; alt?: string }> | null;
+    platformSettings: Record<string, unknown> | null;
+  };
+
+  const row = await createSocialPost({
+    workspaceId: ctx.workspaceId,
+    socialAccountId: opts?.channelId ?? source.socialAccountId,
+    content: source.content ?? undefined,
+    mediaUrls: source.mediaUrls ?? undefined,
+    platformSettings: source.platformSettings ?? undefined,
+    createdByUserId: ctx.userId,
+  });
+  return toCopilotDraft(row as SocialPostRow);
+}
+
+/**
+ * List committed (non-draft) posts whose calendar date falls in the range, so
+ * the copilot can reason about cadence and avoid collisions. Backs the
+ * `listScheduledPosts` tool.
+ */
+export async function listScheduledPostsForWorkspace(
+  ctx: CopilotContext,
+  range: { start: string; end: string },
+): Promise<CopilotCalendarEntry[]> {
+  const rows = (await listSocialPosts(ctx.workspaceId, {
+    startDate: new Date(range.start),
+    endDate: new Date(range.end),
+  })) as SocialPostRow[];
+
+  return rows
+    .filter((row) => row.status !== "draft")
+    .map((row) => ({
+      postId: row.id,
+      channelId: row.socialAccountId,
+      status: row.status,
+      scheduledAt: toIso(row.scheduledAt),
+      content: row.content,
+    }));
 }

--- a/src/lib/social/copilot/prompt.ts
+++ b/src/lib/social/copilot/prompt.ts
@@ -17,6 +17,8 @@ Behaviour:
 - To attach media, call listMediaPoolAssets to find assets, then attachMedia with the chosen asset id(s). You attach existing media — you do not generate it.
 - Use listDrafts / getDraft to review existing drafts when the user refers to them.
 - Before suggesting the user schedule or publish a draft, call validatePublish and report the per-channel readiness. If anything is blocking, tell the user the reasons and help fix them.
+- When proposing schedule times, call listScheduledPosts for the relevant range first and pick times that avoid collisions and keep a sensible cadence; offer 2-3 options.
+- Reddit posts target one subreddit at a time — to post to several, use duplicateDraft per subreddit and set each copy's subreddit via updateDraft. Use duplicateDraft to adapt a post for another channel, and deleteDraft to discard a draft.
 - Never claim a post was scheduled or published. createDraft only saves a draft; scheduling and publishing happen through explicit, separately-confirmed actions.
 - Be concise and direct. Ask one clarifying question at a time when intent is unclear.
 - If a Channel is disabled or needs re-authentication, tell the user rather than drafting for it.`;

--- a/src/lib/social/copilot/tools/index.ts
+++ b/src/lib/social/copilot/tools/index.ts
@@ -7,6 +7,9 @@ import {
   listDraftsForWorkspace,
   getDraftForWorkspace,
   updateDraftForWorkspace,
+  listScheduledPostsForWorkspace,
+  duplicateDraftForWorkspace,
+  deleteDraftForWorkspace,
 } from "../drafts";
 import { getPublishingSettingsSchema } from "../settings";
 import { listMediaPoolAssets, attachMedia } from "../media";
@@ -19,6 +22,7 @@ export const DRAFT_CONTEXT_TOOL_NAMES = [
   "getDraft",
   "listDrafts",
   "updateDraft",
+  "duplicateDraft",
 ];
 
 /** Irreversible commit tools, gated behind needsApproval + staged until a draft exists. */
@@ -60,6 +64,41 @@ export function createCopilotTools(ctx: CopilotContext) {
       description: "List the workspace's existing draft posts.",
       inputSchema: z.object({}),
       execute: async () => ({ drafts: await listDraftsForWorkspace(ctx) }),
+    }),
+
+    listScheduledPosts: tool({
+      description:
+        "List already-scheduled/published posts in a date range so you can suggest non-colliding times and a sensible cadence. Dates are ISO 8601.",
+      inputSchema: z.object({
+        start: z.string().describe("Range start, ISO 8601"),
+        end: z.string().describe("Range end, ISO 8601"),
+      }),
+      execute: async ({ start, end }) => ({
+        scheduled: await listScheduledPostsForWorkspace(ctx, { start, end }),
+      }),
+    }),
+
+    duplicateDraft: tool({
+      description:
+        "Duplicate a draft into a new draft, optionally retargeting a different channel. Use to fan a post out across multiple Reddit subreddits (one post per subreddit) or to adapt a post for another channel.",
+      inputSchema: z.object({
+        postId: z.string().describe("The draft post id to clone"),
+        channelId: z
+          .string()
+          .optional()
+          .describe("Retarget the copy to this channel id (defaults to the same channel)"),
+      }),
+      execute: async ({ postId, channelId }) => ({
+        draft: await duplicateDraftForWorkspace(ctx, postId, { channelId }),
+      }),
+    }),
+
+    deleteDraft: tool({
+      description: "Delete a draft post by id.",
+      inputSchema: z.object({
+        postId: z.string().describe("The draft post id to delete"),
+      }),
+      execute: async ({ postId }) => deleteDraftForWorkspace(ctx, postId),
     }),
 
     getDraft: tool({


### PR DESCRIPTION
Final slice **#81** of the Social Copilot (epic #75), completing the v1 tool surface.

## What's included
- **`listScheduledPosts(start, end)`** — committed (non-draft) posts in a date range as calendar entries, so the agent proposes non-colliding times and a sensible cadence.
- **`duplicateDraft(postId, channelId?)`** — clone content/media/settings into a new draft, optionally retargeting a channel. Enables Reddit one-subreddit-per-post fanout and cross-channel adaptation (ADR 0004).
- **`deleteDraft(postId)`** — scoped delete (delegates to `deleteSocialPost`, which refuses published posts).
- Prompt: collision-aware scheduling + Reddit-fanout guidance; `duplicateDraft` added to commit-staging signal; duplicated drafts render Open-draft links.

## Tests
- 29 copilot unit tests green; +3 new behaviors. Full suite: 2679 pass; the only failures (`open-file` window ReferenceError, `automation/rules updates rule`) are **pre-existing on develop**, unrelated to this work.
- tsc + lint clean.

## Epic status
With this, all v1 slices (#76–#81) are implemented. Out of scope / follow-ups: #82 (server-side encrypted keys + MCP), orphan `cmdk` dep, social-hub settings page gap, commit status-guard hardening. Not yet exercised live in a browser.

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)