### PR TITLE
fix(studio): verify workspace membership in server actions

### DIFF
--- a/src/app/studio/__tests__/actions.test.ts
+++ b/src/app/studio/__tests__/actions.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock setup ────────────────────────────────────────────────────────────────
+
+const mockIsDatabaseConfigured = vi.fn(() => true);
+const mockGetDb = vi.fn();
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => new Headers()),
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
+  getDb: (...args: unknown[]) => mockGetDb(...args),
+}));
+
+const mockGetAuthenticatedUserFromHeaders = vi.fn();
+
+vi.mock("@/lib/auth/session", () => ({
+  getAuthenticatedUserFromHeaders: (...args: unknown[]) =>
+    mockGetAuthenticatedUserFromHeaders(...args),
+}));
+
+const mockListProjects = vi.fn();
+const mockGetProject = vi.fn();
+const mockSoftDeleteProject = vi.fn();
+const mockListProjectAssets = vi.fn();
+const mockEnsurePersonalWorkspaceForUser = vi.fn();
+
+vi.mock("@/lib/studio/repository", () => ({
+  listProjects: (...args: unknown[]) => mockListProjects(...args),
+  getProject: (...args: unknown[]) => mockGetProject(...args),
+  softDeleteProject: (...args: unknown[]) => mockSoftDeleteProject(...args),
+  listProjectAssets: (...args: unknown[]) => mockListProjectAssets(...args),
+  ensurePersonalWorkspaceForUser: (...args: unknown[]) =>
+    mockEnsurePersonalWorkspaceForUser(...args),
+}));
+
+// Chainable Drizzle stub — built fresh per test via buildDbStub(result)
+function buildDbStub(membershipRows: { workspaceId: string }[]) {
+  const stub = {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(membershipRows),
+  };
+  return stub;
+}
+
+import {
+  fetchProjects,
+  fetchProjectDetail,
+  deleteProject,
+} from "../actions";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+const AUTHED_USER = {
+  id: "user_1",
+  name: "Alice",
+  email: "alice@example.com",
+};
+
+describe("studio server actions — workspace membership authz", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsDatabaseConfigured.mockReturnValue(true);
+    mockGetAuthenticatedUserFromHeaders.mockResolvedValue(AUTHED_USER);
+  });
+
+  // ── Case 5: DB not configured ─────────────────────────────────────────────
+
+  describe("when database is not configured", () => {
+    it("fetchProjects returns [] without calling auth", async () => {
+      mockIsDatabaseConfigured.mockReturnValue(false);
+      const result = await fetchProjects("ws_1");
+      expect(result).toEqual([]);
+      expect(mockGetAuthenticatedUserFromHeaders).not.toHaveBeenCalled();
+      expect(mockListProjects).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Case 1: Unauthenticated ───────────────────────────────────────────────
+
+  describe("when user is not authenticated", () => {
+    beforeEach(() => {
+      mockGetAuthenticatedUserFromHeaders.mockResolvedValue(null);
+    });
+
+    it("fetchProjects rejects with 'Not authenticated.' and does not call listProjects", async () => {
+      await expect(fetchProjects("ws_1")).rejects.toThrow("Not authenticated.");
+      expect(mockListProjects).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Case 2: Non-member (IDOR regression) ─────────────────────────────────
+
+  describe("when user is not a member of the workspace (IDOR regression)", () => {
+    beforeEach(() => {
+      // membership query returns empty — user is NOT a member
+      mockGetDb.mockReturnValue(buildDbStub([]));
+    });
+
+    it("fetchProjects rejects with 'no access' and does not call listProjects", async () => {
+      await expect(fetchProjects("ws_other")).rejects.toThrow(
+        "You do not have access to this workspace.",
+      );
+      expect(mockListProjects).not.toHaveBeenCalled();
+    });
+
+    it("fetchProjectDetail rejects with 'no access' and does not call getProject", async () => {
+      await expect(fetchProjectDetail("ws_other", "proj_1")).rejects.toThrow(
+        "You do not have access to this workspace.",
+      );
+      expect(mockGetProject).not.toHaveBeenCalled();
+    });
+
+    it("deleteProject rejects with 'no access' and does not call softDeleteProject", async () => {
+      await expect(deleteProject("ws_other", "proj_1")).rejects.toThrow(
+        "You do not have access to this workspace.",
+      );
+      expect(mockSoftDeleteProject).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Case 3: Member happy path ─────────────────────────────────────────────
+
+  describe("when user is a member of the workspace", () => {
+    beforeEach(() => {
+      mockGetDb.mockReturnValue(buildDbStub([{ workspaceId: "ws_1" }]));
+    });
+
+    it("fetchProjects returns mapped project summaries", async () => {
+      mockListProjects.mockResolvedValue([
+        {
+          id: "proj_1",
+          workspaceId: "ws_1",
+          name: "My Project",
+          slug: "my-project",
+          description: "desc",
+          status: "active",
+          sourceDirectoryPath: "/path",
+          updatedAt: new Date("2024-01-01"),
+        },
+      ]);
+
+      const result = await fetchProjects("ws_1");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("proj_1");
+      expect(result[0].name).toBe("My Project");
+      expect(mockListProjects).toHaveBeenCalledWith("ws_1");
+    });
+
+    it("deleteProject resolves when softDeleteProject returns truthy", async () => {
+      mockSoftDeleteProject.mockResolvedValue(true);
+      await expect(deleteProject("ws_1", "proj_1")).resolves.toBeUndefined();
+      expect(mockSoftDeleteProject).toHaveBeenCalledWith("ws_1", "proj_1");
+    });
+  });
+
+  // ── Case 4: deleteProject not-found ───────────────────────────────────────
+
+  describe("when deleteProject target project does not exist", () => {
+    beforeEach(() => {
+      mockGetDb.mockReturnValue(buildDbStub([{ workspaceId: "ws_1" }]));
+      mockSoftDeleteProject.mockResolvedValue(false);
+    });
+
+    it("rejects with 'Project not found.'", async () => {
+      await expect(deleteProject("ws_1", "proj_missing")).rejects.toThrow(
+        "Project not found.",
+      );
+    });
+  });
+});

--- a/src/app/studio/actions.ts
+++ b/src/app/studio/actions.ts
@@ -68,6 +68,26 @@ async function requireWorkspace(userId: string, userName: string | null, userEma
   return workspaceId;
 }
 
+async function requireWorkspaceMembership(userId: string, workspaceId: string): Promise<void> {
+  const db = getDb();
+  const rows = await db
+    .select({ workspaceId: workspaceMembers.workspaceId })
+    .from(workspaceMembers)
+    .innerJoin(workspaces, eq(workspaceMembers.workspaceId, workspaces.id))
+    .where(
+      and(
+        eq(workspaceMembers.userId, userId),
+        eq(workspaceMembers.workspaceId, workspaceId),
+        isNull(workspaces.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (rows.length === 0) {
+    throw new Error("You do not have access to this workspace.");
+  }
+}
+
 function toISOStringOrNull(value: Date | string | null | undefined): string | null {
   if (!value) return null;
   if (value instanceof Date) return value.toISOString();
@@ -134,7 +154,7 @@ export async function fetchProjects(workspaceId: string): Promise<SAProjectSumma
   if (!isDatabaseConfigured()) return [];
 
   const user = await requireUser();
-  await requireWorkspace(user.id, user.name, user.email);
+  await requireWorkspaceMembership(user.id, workspaceId);
 
   const rows = await listProjects(workspaceId);
 
@@ -157,7 +177,7 @@ export async function fetchProjectDetail(
   if (!isDatabaseConfigured()) return { project: null, assets: [] };
 
   const user = await requireUser();
-  await requireWorkspace(user.id, user.name, user.email);
+  await requireWorkspaceMembership(user.id, workspaceId);
 
   const [projectRow, assetRows] = await Promise.all([
     getProject(workspaceId, projectId),
@@ -198,7 +218,7 @@ export async function deleteProject(workspaceId: string, projectId: string): Pro
   if (!isDatabaseConfigured()) throw new Error("Database not configured.");
 
   const user = await requireUser();
-  await requireWorkspace(user.id, user.name, user.email);
+  await requireWorkspaceMembership(user.id, workspaceId);
 
   const deleted = await softDeleteProject(workspaceId, projectId);
   if (!deleted) throw new Error("Project not found.");


### PR DESCRIPTION
## Summary
- `fetchProjects`/`fetchProjectDetail`/`deleteProject` accepted a caller-supplied `workspaceId` without checking membership — cross-tenant IDOR (read `workflowJson`/asset keys, soft-delete projects) since server actions are public endpoints
- Adds `requireWorkspaceMembership(userId, workspaceId)` (workspaceMembers ⋈ non-deleted workspaces) and enforces it in all three; removes the no-op `requireWorkspace` calls there (kept for `deleteAsset`)
- Generic "no access" error — identical whether the workspace exists or not

## Tests
- New `src/app/studio/__tests__/actions.test.ts` (8 tests): unauthenticated, non-member IDOR regression (repository never called), member happy path, not-found, DB-unconfigured
- gate-a 120/120, scoped typecheck clean

Implements advisor-plans/002 (executor + advisor review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)