### PR TITLE
fix(store): don't abort workflow save when an image sync fails

### DIFF
--- a/src/store/__tests__/waitForPendingImageSyncs.test.ts
+++ b/src/store/__tests__/waitForPendingImageSyncs.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for waitForPendingImageSyncs
+ *
+ * Tests the best-effort behavior: failed image syncs should not abort
+ * workflow saves — they should log a warning and let the save proceed.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { __testing } from "../workflowStore";
+
+const { waitForPendingImageSyncs, pendingImageSyncs } = __testing;
+
+afterEach(() => {
+  pendingImageSyncs.clear();
+  vi.restoreAllMocks();
+});
+
+describe("waitForPendingImageSyncs", () => {
+  it("resolves immediately when map is empty", async () => {
+    await expect(waitForPendingImageSyncs()).resolves.toBeUndefined();
+  });
+
+  it("resolves without warning when all syncs resolve", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    pendingImageSyncs.set("a", Promise.resolve());
+    pendingImageSyncs.set("b", Promise.resolve());
+
+    await expect(waitForPendingImageSyncs()).resolves.toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("resolves (does not reject) when one sync rejects and logs a warning", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const err = new Error("upload failed");
+    pendingImageSyncs.set("fail", Promise.reject(err));
+    pendingImageSyncs.set("ok", Promise.resolve());
+
+    // Should RESOLVE, not reject — this is the regression test
+    await expect(waitForPendingImageSyncs()).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [msg, reasons] = warnSpy.mock.calls[0];
+    expect(msg).toMatch(/1 pending image sync\(s\) failed/);
+    expect(reasons).toEqual([err]);
+  });
+
+  it("resolves via timeout when a sync never settles, warning about timeout", async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // A promise that never resolves or rejects
+    const neverSettles = new Promise<void>(() => {});
+    pendingImageSyncs.set("hanging", neverSettles);
+
+    const racePromise = waitForPendingImageSyncs(50);
+
+    // Advance past the timeout
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(racePromise).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toMatch(/timed out after 50ms/);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -409,7 +409,17 @@ async function waitForPendingImageSyncs(timeout: number = 60000): Promise<void> 
 
   try {
     await Promise.race([
-      Promise.all(pendingImageSyncs.values()),
+      Promise.allSettled(pendingImageSyncs.values()).then((results) => {
+        const failed = results.filter(
+          (r): r is PromiseRejectedResult => r.status === "rejected",
+        );
+        if (failed.length > 0) {
+          console.warn(
+            `${failed.length} pending image sync(s) failed, continuing with save`,
+            failed.map((r) => r.reason),
+          );
+        }
+      }),
       timeoutPromise,
     ]);
   } finally {
@@ -421,6 +431,9 @@ async function waitForPendingImageSyncs(timeout: number = 60000): Promise<void> 
 // Re-export for backward compatibility
 export { generateWorkflowId, saveGenerateImageDefaults, saveNanoBananaDefaults } from "./utils/localStorage";
 export { GROUP_COLORS } from "./utils/nodeDefaults";
+
+// Test-only seam for waitForPendingImageSyncs
+export const __testing = { waitForPendingImageSyncs, pendingImageSyncs };
 
 /** Node types whose output carries image data */
 const IMAGE_SOURCE_NODE_TYPES = new Set<string>([


### PR DESCRIPTION
## Summary
- `waitForPendingImageSyncs` used `Promise.all`, so one failed image upload rejected the wait and aborted the entire workflow save — while the sibling timeout path deliberately resolves and "continues with save"
- Switches to `Promise.allSettled`: failed syncs are logged (count + reasons) and the save proceeds; timeout behavior unchanged
- Save caller at `workflowStore.ts:1874` has its own catch/toast; nothing relied on the rejection

## Tests
- New `src/store/__tests__/waitForPendingImageSyncs.test.ts` (4 tests) incl. the regression case (one rejects, one resolves → save proceeds) and fake-timer timeout case, via a `__testing` seam export
- Store suite 115/115, scoped typecheck clean

Implements advisor-plans/003 (executor + advisor review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)