### PR TITLE
refactor(studio): extract withStudioAuth route wrapper, sanitize 500s, validate prompts PATCH

### DIFF
--- a/src/app/api/studio/assets/[assetId]/download/route.ts
+++ b/src/app/api/studio/assets/[assetId]/download/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
 import { buildCdnDownloadUrl, canUseS3Storage, createPresignedDownload } from "@/lib/storage";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import { getAsset } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface AssetDownloadResponse {
   success: boolean;
@@ -24,42 +23,27 @@ function isAssetReady(metadata: unknown): boolean {
   return true;
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ assetId: string }> },
-): Promise<NextResponse<AssetDownloadResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
-      },
-      { status: 503 },
-    );
-  }
+type AssetIdContext = { params: Promise<{ assetId: string }> };
 
-  if (!canUseS3Storage()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
-      },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets/[assetId]/download",
-      action: "read",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
+export const GET = withStudioAuth<AssetIdContext>(
+  { route: "/api/studio/assets/[assetId]/download", action: "read" },
+  async (
+    _request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<AssetDownloadResponse>> => {
+    if (!canUseS3Storage()) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
+        },
+        { status: 400 },
+      );
     }
 
-    const { assetId } = await params;
+    const { assetId } = await context.params;
     const asset = await getAsset(authz.workspaceId, assetId);
     if (!asset) {
       return NextResponse.json(
@@ -122,14 +106,5 @@ export async function GET(
       downloadUrl: signed.downloadUrl,
       expiresInSeconds: signed.expiresInSeconds,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          error instanceof Error ? error.message : "Failed to create asset download URL",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/assets/[assetId]/route.ts
+++ b/src/app/api/studio/assets/[assetId]/route.ts
@@ -1,6 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import {
   finalizeAssetUpload,
   getAsset,
@@ -8,6 +6,7 @@ import {
   StudioAssetNotFoundError,
   StudioAssetUploadTransitionError,
 } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface AssetResponse {
   success: boolean;
@@ -23,31 +22,16 @@ interface AssetPatchRequest {
   error?: unknown;
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ assetId: string }> },
-): Promise<NextResponse<AssetResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
-      },
-      { status: 503 },
-    );
-  }
+type AssetIdContext = { params: Promise<{ assetId: string }> };
 
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets/[assetId]",
-      action: "read",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
-    const { assetId } = await params;
+export const GET = withStudioAuth<AssetIdContext>(
+  { route: "/api/studio/assets/[assetId]", action: "read" },
+  async (
+    _request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<AssetResponse>> => {
+    const { assetId } = await context.params;
     const asset = await getAsset(authz.workspaceId, assetId);
     if (!asset) {
       return NextResponse.json(
@@ -60,42 +44,17 @@ export async function GET(
       success: true,
       asset,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to load asset",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ assetId: string }> },
-): Promise<NextResponse<AssetResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets/[assetId]",
-      action: "delete",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
-    const { assetId } = await params;
+export const DELETE = withStudioAuth<AssetIdContext>(
+  { route: "/api/studio/assets/[assetId]", action: "delete" },
+  async (
+    _request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<AssetResponse>> => {
+    const { assetId } = await context.params;
     const asset = await softDeleteAsset(authz.workspaceId, assetId);
     if (!asset) {
       return NextResponse.json(
@@ -108,33 +67,16 @@ export async function DELETE(
       success: true,
       asset,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to delete asset",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ assetId: string }> },
-): Promise<NextResponse<AssetResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  try {
+export const PATCH = withStudioAuth<AssetIdContext>(
+  { route: "/api/studio/assets/[assetId]", action: "write" },
+  async (
+    request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<AssetResponse>> => {
     const body = (await request.json()) as AssetPatchRequest;
 
     if (body.uploadState !== "ready" && body.uploadState !== "failed") {
@@ -180,50 +122,39 @@ export async function PATCH(
       );
     }
 
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets/[assetId]",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
+    try {
+      const { assetId } = await context.params;
+      const asset = await finalizeAssetUpload({
+        workspaceId: authz.workspaceId,
+        assetId,
+        uploadState: body.uploadState,
+        sizeBytes: typeof body.sizeBytes === "number" ? body.sizeBytes : undefined,
+        checksum: typeof body.checksum === "string" ? body.checksum : undefined,
+        mimeType: typeof body.mimeType === "string" ? body.mimeType : undefined,
+        error: typeof body.error === "string" ? body.error.trim() : undefined,
+      });
+
+      return NextResponse.json({
+        success: true,
+        asset,
+      });
+    } catch (error) {
+      if (error instanceof StudioAssetNotFoundError) {
+        return NextResponse.json(
+          { success: false, error: "Asset not found." },
+          { status: 404 },
+        );
+      }
+
+      if (error instanceof StudioAssetUploadTransitionError) {
+        return NextResponse.json(
+          { success: false, error: error.message },
+          { status: 409 },
+        );
+      }
+
+      // Re-throw to let the outer withStudioAuth catch handle as 500
+      throw error;
     }
-
-    const { assetId } = await params;
-    const asset = await finalizeAssetUpload({
-      workspaceId: authz.workspaceId,
-      assetId,
-      uploadState: body.uploadState,
-      sizeBytes: typeof body.sizeBytes === "number" ? body.sizeBytes : undefined,
-      checksum: typeof body.checksum === "string" ? body.checksum : undefined,
-      mimeType: typeof body.mimeType === "string" ? body.mimeType : undefined,
-      error: typeof body.error === "string" ? body.error.trim() : undefined,
-    });
-
-    return NextResponse.json({
-      success: true,
-      asset,
-    });
-  } catch (error) {
-    if (error instanceof StudioAssetNotFoundError) {
-      return NextResponse.json(
-        { success: false, error: "Asset not found." },
-        { status: 404 },
-      );
-    }
-
-    if (error instanceof StudioAssetUploadTransitionError) {
-      return NextResponse.json(
-        { success: false, error: error.message },
-        { status: 409 },
-      );
-    }
-
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to finalize asset upload",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/assets/ingest/__tests__/route.test.ts
+++ b/src/app/api/studio/assets/ingest/__tests__/route.test.ts
@@ -92,6 +92,13 @@ describe("/api/studio/assets/ingest", () => {
   });
 
   it("returns 400 when sourceDataUrl/sourceUrl contract is invalid", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: true,
+      userId: "user_1",
+      workspaceId: "ws_1",
+      role: "member",
+    });
+
     const response = await POST(
       createRequest({
         projectId: "proj_1",

--- a/src/app/api/studio/assets/ingest/route.ts
+++ b/src/app/api/studio/assets/ingest/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
 import { assetTypeEnum } from "@/lib/db/schema";
 import {
   buildAssetObjectKey,
@@ -9,13 +8,13 @@ import {
   putObjectToS3,
   streamUploadToS3,
 } from "@/lib/storage";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import {
   finalizeAssetUpload,
   getProject,
   recordPendingS3AssetWithQuota,
   StudioAssetQuotaExceededError,
 } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface IngestRequest {
   projectId?: string | null;
@@ -160,104 +159,132 @@ async function fetchRemoteStream(sourceUrl: string): Promise<{
   // to enforce the overall fetch timeout for the stream consumption.
 }
 
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<IngestResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  if (!canUseS3Storage()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
-      },
-      { status: 400 },
-    );
-  }
-
-  let createdAssetId: string | null = null;
-  let workspaceId: string | null = null;
-  let uploadMimeType: string | null = null;
-
-  try {
-    const body = (await request.json()) as IngestRequest;
-
-    if (!assetTypeEnum.enumValues.includes(body.assetType)) {
+export const POST = withStudioAuth<undefined>(
+  { route: "/api/studio/assets/ingest", action: "write" },
+  async (request: NextRequest, authz): Promise<NextResponse<IngestResponse>> => {
+    if (!canUseS3Storage()) {
       return NextResponse.json(
         {
           success: false,
-          error: `Unsupported asset type: ${body.assetType}`,
+          error:
+            "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
         },
         { status: 400 },
       );
     }
 
-    const hasDataUrl = typeof body.sourceDataUrl === "string" && body.sourceDataUrl.trim().length > 0;
-    const hasSourceUrl = typeof body.sourceUrl === "string" && body.sourceUrl.trim().length > 0;
+    let createdAssetId: string | null = null;
+    let uploadMimeType: string | null = null;
 
-    if (hasDataUrl === hasSourceUrl) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Exactly one of sourceDataUrl or sourceUrl is required.",
-        },
-        { status: 400 },
-      );
-    }
+    try {
+      const body = (await request.json()) as IngestRequest;
 
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets/ingest",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
-    workspaceId = authz.workspaceId;
-
-    const projectId = body.projectId?.trim() || null;
-    if (projectId) {
-      const project = await getProject(authz.workspaceId, projectId);
-      if (!project) {
+      if (!assetTypeEnum.enumValues.includes(body.assetType)) {
         return NextResponse.json(
           {
             success: false,
-            error: "No access to this project.",
+            error: `Unsupported asset type: ${body.assetType}`,
           },
-          { status: 403 },
-        );
-      }
-    }
-
-    if (hasDataUrl) {
-      // Data URL path: already in memory, use direct putObject
-      const parsed = parseDataUrl(body.sourceDataUrl!);
-      const bytes = parsed.bytes;
-      const sourceMimeType = parsed.mimeType;
-
-      if (bytes.length === 0) {
-        return NextResponse.json(
-          { success: false, error: "Source content is empty." },
           { status: 400 },
         );
       }
 
-      if (bytes.length > MAX_INGEST_BYTES) {
+      const hasDataUrl = typeof body.sourceDataUrl === "string" && body.sourceDataUrl.trim().length > 0;
+      const hasSourceUrl = typeof body.sourceUrl === "string" && body.sourceUrl.trim().length > 0;
+
+      if (hasDataUrl === hasSourceUrl) {
         return NextResponse.json(
-          { success: false, error: `Source size exceeds ${MAX_INGEST_BYTES} bytes.` },
-          { status: 413 },
+          {
+            success: false,
+            error: "Exactly one of sourceDataUrl or sourceUrl is required.",
+          },
+          { status: 400 },
         );
       }
+
+      const projectId = body.projectId?.trim() || null;
+      if (projectId) {
+        const project = await getProject(authz.workspaceId, projectId);
+        if (!project) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: "No access to this project.",
+            },
+            { status: 403 },
+          );
+        }
+      }
+
+      if (hasDataUrl) {
+        // Data URL path: already in memory, use direct putObject
+        const parsed = parseDataUrl(body.sourceDataUrl!);
+        const bytes = parsed.bytes;
+        const sourceMimeType = parsed.mimeType;
+
+        if (bytes.length === 0) {
+          return NextResponse.json(
+            { success: false, error: "Source content is empty." },
+            { status: 400 },
+          );
+        }
+
+        if (bytes.length > MAX_INGEST_BYTES) {
+          return NextResponse.json(
+            { success: false, error: `Source size exceeds ${MAX_INGEST_BYTES} bytes.` },
+            { status: 413 },
+          );
+        }
+
+        uploadMimeType = (body.contentType?.trim().toLowerCase() || sourceMimeType || pickDefaultMimeType(body.assetType));
+        const sanitizedName = sanitizeFileName(body.fileName);
+        const extension =
+          getExtensionFromFileName(sanitizedName || undefined) ||
+          getExtensionForMimeType(uploadMimeType, "bin");
+
+        const key = buildAssetObjectKey({
+          workspaceId: authz.workspaceId,
+          projectId,
+          assetType: body.assetType,
+          fileExtension: extension,
+        });
+
+        const pending = await recordPendingS3AssetWithQuota({
+          workspaceId: authz.workspaceId,
+          userId: authz.userId,
+          projectId,
+          type: body.assetType,
+          storageBucket: process.env.S3_BUCKET_NAME || null,
+          storageKey: key,
+          mimeType: uploadMimeType,
+          originalFileName: sanitizedName,
+          expectedSizeBytes: bytes.length,
+        });
+        createdAssetId = pending.id;
+
+        await putObjectToS3({ key, body: bytes, contentType: uploadMimeType });
+
+        await finalizeAssetUpload({
+          workspaceId: authz.workspaceId,
+          assetId: pending.id,
+          uploadState: "ready",
+          sizeBytes: bytes.length,
+          mimeType: uploadMimeType,
+        });
+
+        const signed = await createPresignedDownload({ key });
+        return NextResponse.json({
+          success: true,
+          assetId: pending.id,
+          key,
+          downloadUrl: signed.downloadUrl,
+          expiresInSeconds: signed.expiresInSeconds,
+        });
+      }
+
+      // Remote URL path: stream directly to S3 without buffering
+      const fetched = await fetchRemoteStream(body.sourceUrl!.trim());
+      const sourceMimeType = fetched.mimeType;
 
       uploadMimeType = (body.contentType?.trim().toLowerCase() || sourceMimeType || pickDefaultMimeType(body.assetType));
       const sanitizedName = sanitizeFileName(body.fileName);
@@ -272,6 +299,9 @@ export async function POST(
         fileExtension: extension,
       });
 
+      // Use content-length for quota if available, otherwise reserve max
+      const expectedSizeBytes = fetched.contentLength ?? MAX_INGEST_BYTES;
+
       const pending = await recordPendingS3AssetWithQuota({
         workspaceId: authz.workspaceId,
         userId: authz.userId,
@@ -281,17 +311,50 @@ export async function POST(
         storageKey: key,
         mimeType: uploadMimeType,
         originalFileName: sanitizedName,
-        expectedSizeBytes: bytes.length,
+        expectedSizeBytes,
       });
       createdAssetId = pending.id;
 
-      await putObjectToS3({ key, body: bytes, contentType: uploadMimeType });
+      const { sizeBytes } = await streamUploadToS3({
+        key,
+        body: fetched.body,
+        contentType: uploadMimeType,
+        contentLength: fetched.contentLength ?? undefined,
+      });
+
+      if (sizeBytes === 0) {
+        await deleteObjectFromS3({ key }).catch(() => {});
+        await finalizeAssetUpload({
+          workspaceId: authz.workspaceId,
+          assetId: pending.id,
+          uploadState: "failed",
+          error: "Source content is empty.",
+        });
+        return NextResponse.json(
+          { success: false, error: "Source content is empty." },
+          { status: 400 },
+        );
+      }
+
+      if (sizeBytes > MAX_INGEST_BYTES) {
+        await deleteObjectFromS3({ key }).catch(() => {});
+        await finalizeAssetUpload({
+          workspaceId: authz.workspaceId,
+          assetId: pending.id,
+          uploadState: "failed",
+          error: `Source size exceeds ${MAX_INGEST_BYTES} bytes.`,
+        });
+        return NextResponse.json(
+          { success: false, error: `Source size exceeds ${MAX_INGEST_BYTES} bytes.` },
+          { status: 413 },
+        );
+      }
 
       await finalizeAssetUpload({
         workspaceId: authz.workspaceId,
         assetId: pending.id,
         uploadState: "ready",
-        sizeBytes: bytes.length,
+        sizeBytes,
         mimeType: uploadMimeType,
       });
 
@@ -303,123 +366,33 @@ export async function POST(
         downloadUrl: signed.downloadUrl,
         expiresInSeconds: signed.expiresInSeconds,
       });
-    }
-
-    // Remote URL path: stream directly to S3 without buffering
-    const fetched = await fetchRemoteStream(body.sourceUrl!.trim());
-    const sourceMimeType = fetched.mimeType;
-
-    uploadMimeType = (body.contentType?.trim().toLowerCase() || sourceMimeType || pickDefaultMimeType(body.assetType));
-    const sanitizedName = sanitizeFileName(body.fileName);
-    const extension =
-      getExtensionFromFileName(sanitizedName || undefined) ||
-      getExtensionForMimeType(uploadMimeType, "bin");
-
-    const key = buildAssetObjectKey({
-      workspaceId: authz.workspaceId,
-      projectId,
-      assetType: body.assetType,
-      fileExtension: extension,
-    });
-
-    // Use content-length for quota if available, otherwise reserve max
-    const expectedSizeBytes = fetched.contentLength ?? MAX_INGEST_BYTES;
-
-    const pending = await recordPendingS3AssetWithQuota({
-      workspaceId: authz.workspaceId,
-      userId: authz.userId,
-      projectId,
-      type: body.assetType,
-      storageBucket: process.env.S3_BUCKET_NAME || null,
-      storageKey: key,
-      mimeType: uploadMimeType,
-      originalFileName: sanitizedName,
-      expectedSizeBytes,
-    });
-    createdAssetId = pending.id;
-
-    const { sizeBytes } = await streamUploadToS3({
-      key,
-      body: fetched.body,
-      contentType: uploadMimeType,
-      contentLength: fetched.contentLength ?? undefined,
-    });
-
-    if (sizeBytes === 0) {
-      await deleteObjectFromS3({ key }).catch(() => {});
-      await finalizeAssetUpload({
-        workspaceId: authz.workspaceId,
-        assetId: pending.id,
-        uploadState: "failed",
-        error: "Source content is empty.",
-      });
-      return NextResponse.json(
-        { success: false, error: "Source content is empty." },
-        { status: 400 },
-      );
-    }
-
-    if (sizeBytes > MAX_INGEST_BYTES) {
-      await deleteObjectFromS3({ key }).catch(() => {});
-      await finalizeAssetUpload({
-        workspaceId: authz.workspaceId,
-        assetId: pending.id,
-        uploadState: "failed",
-        error: `Source size exceeds ${MAX_INGEST_BYTES} bytes.`,
-      });
-      return NextResponse.json(
-        { success: false, error: `Source size exceeds ${MAX_INGEST_BYTES} bytes.` },
-        { status: 413 },
-      );
-    }
-
-    await finalizeAssetUpload({
-      workspaceId: authz.workspaceId,
-      assetId: pending.id,
-      uploadState: "ready",
-      sizeBytes,
-      mimeType: uploadMimeType,
-    });
-
-    const signed = await createPresignedDownload({ key });
-    return NextResponse.json({
-      success: true,
-      assetId: pending.id,
-      key,
-      downloadUrl: signed.downloadUrl,
-      expiresInSeconds: signed.expiresInSeconds,
-    });
-  } catch (error) {
-    if (error instanceof StudioAssetQuotaExceededError) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Workspace storage quota exceeded.",
-        },
-        { status: 403 },
-      );
-    }
-
-    if (workspaceId && createdAssetId) {
-      try {
-        await finalizeAssetUpload({
-          workspaceId,
-          assetId: createdAssetId,
-          uploadState: "failed",
-          mimeType: uploadMimeType || undefined,
-          error: error instanceof Error ? error.message : "Asset ingest failed",
-        });
-      } catch {
-        // best-effort failure finalization
+    } catch (error) {
+      if (error instanceof StudioAssetQuotaExceededError) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: "Workspace storage quota exceeded.",
+          },
+          { status: 403 },
+        );
       }
-    }
 
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to ingest asset",
-      },
-      { status: 500 },
-    );
-  }
-}
+      if (createdAssetId) {
+        try {
+          await finalizeAssetUpload({
+            workspaceId: authz.workspaceId,
+            assetId: createdAssetId,
+            uploadState: "failed",
+            mimeType: uploadMimeType || undefined,
+            error: error instanceof Error ? error.message : "Asset ingest failed",
+          });
+        } catch {
+          // best-effort failure finalization
+        }
+      }
+
+      // Re-throw to let the outer withStudioAuth catch handle as 500
+      throw error;
+    }
+  },
+);

--- a/src/app/api/studio/assets/legacy-download/route.ts
+++ b/src/app/api/studio/assets/legacy-download/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
 import { canUseS3Storage, createPresignedDownload, objectExistsInS3 } from "@/lib/storage";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import { getProject } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface LegacyDownloadRequest {
   projectId?: string;
@@ -17,32 +16,20 @@ interface LegacyDownloadResponse {
   error?: string;
 }
 
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<LegacyDownloadResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
-      },
-      { status: 503 },
-    );
-  }
+export const POST = withStudioAuth<undefined>(
+  { route: "/api/studio/assets/legacy-download", action: "read" },
+  async (request: NextRequest, authz): Promise<NextResponse<LegacyDownloadResponse>> => {
+    if (!canUseS3Storage()) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
+        },
+        { status: 400 },
+      );
+    }
 
-  if (!canUseS3Storage()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
-      },
-      { status: 400 },
-    );
-  }
-
-  try {
     const body = (await request.json()) as LegacyDownloadRequest;
     const projectId = body.projectId?.trim();
     const legacyKey = body.legacyKey?.trim();
@@ -55,14 +42,6 @@ export async function POST(
         },
         { status: 400 },
       );
-    }
-
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets/legacy-download",
-      action: "read",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
     }
 
     const project = await getProject(authz.workspaceId, projectId);
@@ -116,14 +95,5 @@ export async function POST(
       downloadUrl: signed.downloadUrl,
       expiresInSeconds: signed.expiresInSeconds,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          error instanceof Error ? error.message : "Failed to create legacy download URL",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/assets/presign-multipart/route.ts
+++ b/src/app/api/studio/assets/presign-multipart/route.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
 import { assetTypeEnum } from "@/lib/db/schema";
 import {
   abortMultipartUpload,
@@ -10,13 +9,13 @@ import {
   createMultipartUpload,
   presignUploadPart,
 } from "@/lib/storage";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import {
   finalizeAssetUpload,
   getProject,
   recordPendingS3AssetWithQuota,
   StudioAssetQuotaExceededError,
 } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 type MultipartAction = "create" | "complete" | "abort";
 
@@ -62,64 +61,45 @@ function isValidAction(action: unknown): action is MultipartAction {
   return action === "create" || action === "complete" || action === "abort";
 }
 
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<MultipartResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      { success: false, error: "DATABASE_URL is not configured." },
-      { status: 503 },
-    );
-  }
-
-  if (!canUseS3Storage()) {
-    return NextResponse.json(
-      { success: false, error: "S3 storage is not configured." },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const body = (await request.json()) as MultipartRequest;
-
-    if (!isValidAction(body.action)) {
+export const POST = withStudioAuth<undefined>(
+  { route: "/api/studio/assets/presign-multipart", action: "write" },
+  async (request: NextRequest, authz): Promise<NextResponse<MultipartResponse>> => {
+    if (!canUseS3Storage()) {
       return NextResponse.json(
-        { success: false, error: "action must be one of: create, complete, abort." },
+        { success: false, error: "S3 storage is not configured." },
         { status: 400 },
       );
     }
 
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets/presign-multipart",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
+    try {
+      const body = (await request.json()) as MultipartRequest;
 
-    if (body.action === "create") {
-      return await handleCreate(body, authz);
+      if (!isValidAction(body.action)) {
+        return NextResponse.json(
+          { success: false, error: "action must be one of: create, complete, abort." },
+          { status: 400 },
+        );
+      }
+
+      if (body.action === "create") {
+        return await handleCreate(body, authz);
+      }
+      if (body.action === "complete") {
+        return await handleComplete(body, authz);
+      }
+      return await handleAbort(body, authz);
+    } catch (error) {
+      if (error instanceof StudioAssetQuotaExceededError) {
+        return NextResponse.json(
+          { success: false, error: "Workspace storage quota exceeded." },
+          { status: 403 },
+        );
+      }
+      // Re-throw to let the outer withStudioAuth catch handle as 500
+      throw error;
     }
-    if (body.action === "complete") {
-      return await handleComplete(body, authz);
-    }
-    return await handleAbort(body, authz);
-  } catch (error) {
-    if (error instanceof StudioAssetQuotaExceededError) {
-      return NextResponse.json(
-        { success: false, error: "Workspace storage quota exceeded." },
-        { status: 403 },
-      );
-    }
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Multipart upload failed",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
 async function handleCreate(
   body: CreateRequest,

--- a/src/app/api/studio/assets/presign/route.ts
+++ b/src/app/api/studio/assets/presign/route.ts
@@ -1,14 +1,13 @@
 import path from "node:path";
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
 import { assetTypeEnum } from "@/lib/db/schema";
 import { canUseS3Storage, buildAssetObjectKey, createPresignedUpload } from "@/lib/storage";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import {
   getProject,
   recordPendingS3AssetWithQuota,
   StudioAssetQuotaExceededError,
 } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface PresignRequest {
   projectId?: string | null;
@@ -28,131 +27,107 @@ interface PresignResponse {
   error?: string;
 }
 
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<PresignResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use S3 presign APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  if (!canUseS3Storage()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
-      },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const body = (await request.json()) as PresignRequest;
-    if (!assetTypeEnum.enumValues.includes(body.assetType)) {
-      return NextResponse.json(
-        { success: false, error: `Unsupported asset type: ${body.assetType}` },
-        { status: 400 },
-      );
-    }
-    if (!body.contentType?.trim()) {
-      return NextResponse.json(
-        { success: false, error: "contentType is required." },
-        { status: 400 },
-      );
-    }
-    if (
-      typeof body.expectedSizeBytes !== "number" ||
-      !Number.isFinite(body.expectedSizeBytes) ||
-      !Number.isInteger(body.expectedSizeBytes) ||
-      body.expectedSizeBytes < 0
-    ) {
+export const POST = withStudioAuth<undefined>(
+  { route: "/api/studio/assets/presign", action: "write" },
+  async (request: NextRequest, authz): Promise<NextResponse<PresignResponse>> => {
+    if (!canUseS3Storage()) {
       return NextResponse.json(
         {
           success: false,
-          error: "expectedSizeBytes is required and must be a non-negative integer.",
+          error:
+            "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
         },
         { status: 400 },
       );
     }
 
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets/presign",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
-    if (body.projectId) {
-      const project = await getProject(authz.workspaceId, body.projectId);
-      if (!project) {
+    try {
+      const body = (await request.json()) as PresignRequest;
+      if (!assetTypeEnum.enumValues.includes(body.assetType)) {
+        return NextResponse.json(
+          { success: false, error: `Unsupported asset type: ${body.assetType}` },
+          { status: 400 },
+        );
+      }
+      if (!body.contentType?.trim()) {
+        return NextResponse.json(
+          { success: false, error: "contentType is required." },
+          { status: 400 },
+        );
+      }
+      if (
+        typeof body.expectedSizeBytes !== "number" ||
+        !Number.isFinite(body.expectedSizeBytes) ||
+        !Number.isInteger(body.expectedSizeBytes) ||
+        body.expectedSizeBytes < 0
+      ) {
         return NextResponse.json(
           {
             success: false,
-            error: "No access to this project.",
+            error: "expectedSizeBytes is required and must be a non-negative integer.",
+          },
+          { status: 400 },
+        );
+      }
+
+      if (body.projectId) {
+        const project = await getProject(authz.workspaceId, body.projectId);
+        if (!project) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: "No access to this project.",
+            },
+            { status: 403 },
+          );
+        }
+      }
+
+      const extFromName = body.fileName ? path.extname(body.fileName) : "";
+      const key = buildAssetObjectKey({
+        workspaceId: authz.workspaceId,
+        projectId: body.projectId || null,
+        assetType: body.assetType,
+        fileExtension: extFromName || undefined,
+      });
+
+      const signed = await createPresignedUpload({
+        key,
+        contentType: body.contentType.trim(),
+      });
+
+      const asset = await recordPendingS3AssetWithQuota({
+        workspaceId: authz.workspaceId,
+        userId: authz.userId,
+        projectId: body.projectId || null,
+        type: body.assetType,
+        storageBucket: process.env.S3_BUCKET_NAME || null,
+        storageKey: key,
+        mimeType: body.contentType.trim(),
+        originalFileName: body.fileName || null,
+        expectedSizeBytes: body.expectedSizeBytes,
+      });
+
+      return NextResponse.json({
+        success: true,
+        assetId: asset.id,
+        key: signed.key,
+        uploadUrl: signed.uploadUrl,
+        downloadUrl: signed.downloadUrl,
+        expiresInSeconds: signed.expiresInSeconds,
+      });
+    } catch (error) {
+      if (error instanceof StudioAssetQuotaExceededError) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: "Workspace storage quota exceeded.",
           },
           { status: 403 },
         );
       }
+      // Re-throw to let the outer withStudioAuth catch handle as 500
+      throw error;
     }
-
-    const extFromName = body.fileName ? path.extname(body.fileName) : "";
-    const key = buildAssetObjectKey({
-      workspaceId: authz.workspaceId,
-      projectId: body.projectId || null,
-      assetType: body.assetType,
-      fileExtension: extFromName || undefined,
-    });
-
-    const signed = await createPresignedUpload({
-      key,
-      contentType: body.contentType.trim(),
-    });
-
-    const asset = await recordPendingS3AssetWithQuota({
-      workspaceId: authz.workspaceId,
-      userId: authz.userId,
-      projectId: body.projectId || null,
-      type: body.assetType,
-      storageBucket: process.env.S3_BUCKET_NAME || null,
-      storageKey: key,
-      mimeType: body.contentType.trim(),
-      originalFileName: body.fileName || null,
-      expectedSizeBytes: body.expectedSizeBytes,
-    });
-
-    return NextResponse.json({
-      success: true,
-      assetId: asset.id,
-      key: signed.key,
-      uploadUrl: signed.uploadUrl,
-      downloadUrl: signed.downloadUrl,
-      expiresInSeconds: signed.expiresInSeconds,
-    });
-  } catch (error) {
-    if (error instanceof StudioAssetQuotaExceededError) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Workspace storage quota exceeded.",
-        },
-        { status: 403 },
-      );
-    }
-
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to create presigned URL",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/assets/route.ts
+++ b/src/app/api/studio/assets/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
 import { assetTypeEnum, storageProviderEnum } from "@/lib/db/schema";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import { getProject, listProjectAssets, recordAsset } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface AssetsGetResponse {
   success: boolean;
@@ -31,38 +30,18 @@ interface AssetsPostResponse {
   error?: string;
 }
 
-export async function GET(
-  request: NextRequest,
-): Promise<NextResponse<AssetsGetResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  const projectId = request.nextUrl.searchParams.get("projectId");
-  if (!projectId) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: "projectId query parameter is required.",
-      },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets",
-      action: "read",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
+export const GET = withStudioAuth<undefined>(
+  { route: "/api/studio/assets", action: "read" },
+  async (request: NextRequest, authz): Promise<NextResponse<AssetsGetResponse>> => {
+    const projectId = request.nextUrl.searchParams.get("projectId");
+    if (!projectId) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "projectId query parameter is required.",
+        },
+        { status: 400 },
+      );
     }
 
     const assets = await listProjectAssets(authz.workspaceId, projectId);
@@ -70,32 +49,12 @@ export async function GET(
       success: true,
       assets,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to list assets",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<AssetsPostResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use asset metadata APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  try {
+export const POST = withStudioAuth<undefined>(
+  { route: "/api/studio/assets", action: "write" },
+  async (request: NextRequest, authz): Promise<NextResponse<AssetsPostResponse>> => {
     const body = (await request.json()) as AssetsPostRequest;
     if (!body.storageKey?.trim()) {
       return NextResponse.json(
@@ -117,14 +76,6 @@ export async function POST(
         },
         { status: 400 },
       );
-    }
-
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/assets",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
     }
 
     if (body.projectId) {
@@ -161,13 +112,5 @@ export async function POST(
       success: true,
       asset,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to record asset",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/projects/[projectId]/route.ts
+++ b/src/app/api/studio/projects/[projectId]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import { getProject, softDeleteProject, upsertProject } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface ProjectResponse {
   success: boolean;
@@ -16,31 +15,16 @@ interface ProjectPatchRequest {
   sourceDirectoryPath?: string | null;
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ projectId: string }> },
-): Promise<NextResponse<ProjectResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use project persistence APIs.",
-      },
-      { status: 503 },
-    );
-  }
+type ProjectIdContext = { params: Promise<{ projectId: string }> };
 
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/projects/[projectId]",
-      action: "read",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
-    const { projectId } = await params;
+export const GET = withStudioAuth<ProjectIdContext>(
+  { route: "/api/studio/projects/[projectId]", action: "read" },
+  async (
+    _request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<ProjectResponse>> => {
+    const { projectId } = await context.params;
     const project = await getProject(authz.workspaceId, projectId);
     if (!project) {
       return NextResponse.json(
@@ -52,42 +36,17 @@ export async function GET(
       success: true,
       project,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to load project",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ projectId: string }> },
-): Promise<NextResponse<ProjectResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use project persistence APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/projects/[projectId]",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
-    const { projectId } = await params;
+export const PATCH = withStudioAuth<ProjectIdContext>(
+  { route: "/api/studio/projects/[projectId]", action: "write" },
+  async (
+    request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<ProjectResponse>> => {
+    const { projectId } = await context.params;
     const existing = await getProject(authz.workspaceId, projectId);
     if (!existing) {
       return NextResponse.json(
@@ -120,42 +79,17 @@ export async function PATCH(
       success: true,
       project,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to update project",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ projectId: string }> },
-): Promise<NextResponse<ProjectResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use project persistence APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/projects/[projectId]",
-      action: "delete",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
-    const { projectId } = await params;
+export const DELETE = withStudioAuth<ProjectIdContext>(
+  { route: "/api/studio/projects/[projectId]", action: "delete" },
+  async (
+    _request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<ProjectResponse>> => {
+    const { projectId } = await context.params;
     const deleted = await softDeleteProject(authz.workspaceId, projectId);
     if (!deleted) {
       return NextResponse.json(
@@ -167,13 +101,5 @@ export async function DELETE(
       success: true,
       project: deleted,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to delete project",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/projects/route.ts
+++ b/src/app/api/studio/projects/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import { countProjects, getProject, listProjects, upsertProject } from "@/lib/studio/repository";
 import { MAX_PROJECTS_PER_WORKSPACE } from "@/lib/studio/constants";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface ProjectsGetResponse {
   success: boolean;
@@ -26,29 +25,9 @@ interface ProjectsPostResponse {
   error?: string;
 }
 
-export async function GET(
-  request: NextRequest,
-): Promise<NextResponse<ProjectsGetResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use project persistence APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/projects",
-      action: "read",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
+export const GET = withStudioAuth<undefined>(
+  { route: "/api/studio/projects", action: "read" },
+  async (_request: NextRequest, authz): Promise<NextResponse<ProjectsGetResponse>> => {
     const [projectsList, projectCount] = await Promise.all([
       listProjects(authz.workspaceId),
       countProjects(authz.workspaceId),
@@ -59,46 +38,18 @@ export async function GET(
       projectCount,
       maxProjects: MAX_PROJECTS_PER_WORKSPACE,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to list projects",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<ProjectsPostResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use project persistence APIs.",
-      },
-      { status: 503 },
-    );
-  }
-
-  try {
+export const POST = withStudioAuth<undefined>(
+  { route: "/api/studio/projects", action: "write" },
+  async (request: NextRequest, authz): Promise<NextResponse<ProjectsPostResponse>> => {
     const body = (await request.json()) as ProjectsPostRequest;
     if (!body.name || !body.name.trim()) {
       return NextResponse.json(
         { success: false, error: "Project name is required." },
         { status: 400 },
       );
-    }
-
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/projects",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
     }
 
     // Enforce project limit: skip only for updates to projects that already exist in the DB
@@ -133,13 +84,5 @@ export async function POST(
       success: true,
       project,
     });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to save project",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/prompts/[promptId]/__tests__/route.test.ts
+++ b/src/app/api/studio/prompts/[promptId]/__tests__/route.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockAuthorizeStudioRequest = vi.fn();
+const mockGetPrompt = vi.fn();
+const mockUpdatePrompt = vi.fn();
+const mockSoftDeletePrompt = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) => mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json(
+      { success: false, error: result.error },
+      { status: result.status },
+    ),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getPrompt: (...args: unknown[]) => mockGetPrompt(...args),
+  updatePrompt: (...args: unknown[]) => mockUpdatePrompt(...args),
+  softDeletePrompt: (...args: unknown[]) => mockSoftDeletePrompt(...args),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { PATCH, DELETE } from "../route";
+
+const authorizedResult = {
+  authorized: true as const,
+  workspaceId: "ws_test",
+  userId: "user_test",
+  role: "owner" as const,
+  permissions: [] as never[],
+  contentSession: {} as never,
+};
+
+function createPatchRequest(body: unknown): NextRequest {
+  return {
+    headers: new Headers(),
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as NextRequest;
+}
+
+function createDeleteRequest(): NextRequest {
+  return {
+    headers: new Headers(),
+  } as unknown as NextRequest;
+}
+
+function makeContext(promptId: string) {
+  return { params: Promise.resolve({ promptId }) };
+}
+
+describe("/api/studio/prompts/[promptId] PATCH", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: false,
+      status: 401,
+      error: "Please sign in to access AI Studio.",
+      reason: "unauthenticated",
+    });
+
+    const response = await PATCH(
+      createPatchRequest({ name: "New name" }),
+      makeContext("sp_1"),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when name is empty string", async () => {
+    const response = await PATCH(
+      createPatchRequest({ name: "" }),
+      makeContext("sp_1"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toContain("name");
+  });
+
+  it("returns 400 when name is whitespace only", async () => {
+    const response = await PATCH(
+      createPatchRequest({ name: "   " }),
+      makeContext("sp_1"),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when isPublic is not a boolean", async () => {
+    mockGetPrompt.mockResolvedValue({ id: "sp_1", name: "Existing" });
+
+    const response = await PATCH(
+      createPatchRequest({ isPublic: "yes" }),
+      makeContext("sp_1"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("isPublic");
+  });
+
+  it("returns 400 when promptText is empty string", async () => {
+    const response = await PATCH(
+      createPatchRequest({ promptText: "" }),
+      makeContext("sp_1"),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when formConfig is an array", async () => {
+    mockGetPrompt.mockResolvedValue({ id: "sp_1", name: "Existing" });
+
+    const response = await PATCH(
+      createPatchRequest({ formConfig: [1, 2, 3] }),
+      makeContext("sp_1"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("formConfig");
+  });
+
+  it("returns 404 when prompt does not exist", async () => {
+    mockGetPrompt.mockResolvedValue(null);
+
+    const response = await PATCH(
+      createPatchRequest({ name: "New name" }),
+      makeContext("sp_missing"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("Prompt not found.");
+  });
+
+  it("calls updatePrompt with only the four allowed keys (trimmed strings)", async () => {
+    mockGetPrompt.mockResolvedValue({ id: "sp_1", name: "Existing" });
+    mockUpdatePrompt.mockResolvedValue({ id: "sp_1", name: "Updated Name" });
+
+    const response = await PATCH(
+      createPatchRequest({
+        name: "  Updated Name  ",
+        isPublic: true,
+        formConfig: { aspectRatio: "1:1" },
+      }),
+      makeContext("sp_1"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockUpdatePrompt).toHaveBeenCalledWith("ws_test", "sp_1", {
+      name: "Updated Name",
+      promptText: undefined,
+      formConfig: { aspectRatio: "1:1" },
+      isPublic: true,
+    });
+  });
+});
+
+describe("/api/studio/prompts/[promptId] DELETE", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+  });
+
+  it("returns 404 when prompt does not exist", async () => {
+    mockSoftDeletePrompt.mockResolvedValue(null);
+
+    const response = await DELETE(createDeleteRequest(), makeContext("sp_missing"));
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("Prompt not found.");
+  });
+
+  it("soft-deletes prompt and returns success", async () => {
+    const deleted = { id: "sp_1", name: "My Prompt" };
+    mockSoftDeletePrompt.mockResolvedValue(deleted);
+
+    const response = await DELETE(createDeleteRequest(), makeContext("sp_1"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.prompt).toEqual(deleted);
+    expect(mockSoftDeletePrompt).toHaveBeenCalledWith("ws_test", "sp_1");
+  });
+});

--- a/src/app/api/studio/prompts/[promptId]/route.ts
+++ b/src/app/api/studio/prompts/[promptId]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import { getPrompt, updatePrompt, softDeletePrompt } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface PromptResponse {
   success: boolean;
@@ -9,27 +8,60 @@ interface PromptResponse {
   error?: string;
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ promptId: string }> },
-): Promise<NextResponse<PromptResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      { success: false, error: "DATABASE_URL is not configured." },
-      { status: 503 },
-    );
-  }
+type PromptIdContext = { params: Promise<{ promptId: string }> };
 
-  try {
-    const { promptId } = await params;
+export const PATCH = withStudioAuth<PromptIdContext>(
+  { route: "/api/studio/prompts", action: "write" },
+  async (
+    request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<PromptResponse>> => {
+    const { promptId } = await context.params;
     const body = await request.json();
 
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/prompts",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json(
+        { success: false, error: "Request body must be a JSON object." },
+        { status: 400 },
+      );
+    }
+
+    if (body.name !== undefined) {
+      if (typeof body.name !== "string" || !body.name.trim()) {
+        return NextResponse.json(
+          { success: false, error: "name must be a non-empty string." },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (body.promptText !== undefined) {
+      if (typeof body.promptText !== "string" || !body.promptText.trim()) {
+        return NextResponse.json(
+          { success: false, error: "promptText must be a non-empty string." },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (body.isPublic !== undefined && typeof body.isPublic !== "boolean") {
+      return NextResponse.json(
+        { success: false, error: "isPublic must be a boolean." },
+        { status: 400 },
+      );
+    }
+
+    if (
+      body.formConfig !== undefined &&
+      (typeof body.formConfig !== "object" ||
+        body.formConfig === null ||
+        Array.isArray(body.formConfig))
+    ) {
+      return NextResponse.json(
+        { success: false, error: "formConfig must be a plain object." },
+        { status: 400 },
+      );
     }
 
     // Verify prompt exists and belongs to workspace
@@ -42,45 +74,25 @@ export async function PATCH(
     }
 
     const prompt = await updatePrompt(authz.workspaceId, promptId, {
-      name: body.name,
-      promptText: body.promptText,
+      name: body.name !== undefined ? String(body.name).trim() : undefined,
+      promptText:
+        body.promptText !== undefined ? String(body.promptText).trim() : undefined,
       formConfig: body.formConfig,
       isPublic: body.isPublic,
     });
 
     return NextResponse.json({ success: true, prompt });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to update prompt",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ promptId: string }> },
-): Promise<NextResponse<PromptResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      { success: false, error: "DATABASE_URL is not configured." },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const { promptId } = await params;
-
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/prompts",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
+export const DELETE = withStudioAuth<PromptIdContext>(
+  { route: "/api/studio/prompts", action: "write" },
+  async (
+    _request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<PromptResponse>> => {
+    const { promptId } = await context.params;
 
     const prompt = await softDeletePrompt(authz.workspaceId, promptId);
     if (!prompt) {
@@ -91,13 +103,5 @@ export async function DELETE(
     }
 
     return NextResponse.json({ success: true, prompt });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to delete prompt",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/prompts/public/route.ts
+++ b/src/app/api/studio/prompts/public/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import { listPublicPrompts } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface PublicPromptsGetResponse {
   success: boolean;
@@ -11,26 +10,10 @@ interface PublicPromptsGetResponse {
 
 const VALID_MODES = new Set(["photo", "video", "copy"]);
 
-export async function GET(
-  request: NextRequest,
-): Promise<NextResponse<PublicPromptsGetResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      { success: false, error: "DATABASE_URL is not configured." },
-      { status: 503 },
-    );
-  }
-
-  try {
-    // Public prompts require authentication but not workspace write access
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/prompts/public",
-      action: "read",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
+// Public prompts require authentication but not workspace write access
+export const GET = withStudioAuth<undefined>(
+  { route: "/api/studio/prompts/public", action: "read" },
+  async (request: NextRequest): Promise<NextResponse<PublicPromptsGetResponse>> => {
     const mode = request.nextUrl.searchParams.get("mode") || undefined;
     if (mode && !VALID_MODES.has(mode)) {
       return NextResponse.json(
@@ -41,13 +24,5 @@ export async function GET(
 
     const prompts = await listPublicPrompts(mode);
     return NextResponse.json({ success: true, prompts });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to list public prompts",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/studio/prompts/route.ts
+++ b/src/app/api/studio/prompts/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isDatabaseConfigured } from "@/lib/db";
-import { authorizeStudioRequest, authzErrorResponse } from "@/lib/studio/authz";
 import { createPrompt, listPrompts } from "@/lib/studio/repository";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 interface PromptsGetResponse {
   success: boolean;
@@ -25,25 +24,9 @@ interface PromptsPostResponse {
 
 const VALID_MODES = new Set(["photo", "video", "copy"]);
 
-export async function GET(
-  request: NextRequest,
-): Promise<NextResponse<PromptsGetResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      { success: false, error: "DATABASE_URL is not configured." },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/prompts",
-      action: "read",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
+export const GET = withStudioAuth<undefined>(
+  { route: "/api/studio/prompts", action: "read" },
+  async (request: NextRequest, authz): Promise<NextResponse<PromptsGetResponse>> => {
     const mode = request.nextUrl.searchParams.get("mode") || undefined;
     if (mode && !VALID_MODES.has(mode)) {
       return NextResponse.json(
@@ -54,28 +37,12 @@ export async function GET(
 
     const prompts = await listPrompts(authz.workspaceId, mode);
     return NextResponse.json({ success: true, prompts });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to list prompts",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<PromptsPostResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      { success: false, error: "DATABASE_URL is not configured." },
-      { status: 503 },
-    );
-  }
-
-  try {
+export const POST = withStudioAuth<undefined>(
+  { route: "/api/studio/prompts", action: "write" },
+  async (request: NextRequest, authz): Promise<NextResponse<PromptsPostResponse>> => {
     const body = (await request.json()) as PromptsPostRequest;
 
     if (!body.name?.trim()) {
@@ -97,14 +64,6 @@ export async function POST(
       );
     }
 
-    const authz = await authorizeStudioRequest(request, {
-      route: "/api/studio/prompts",
-      action: "write",
-    });
-    if (!authz.authorized) {
-      return authzErrorResponse(authz);
-    }
-
     const prompt = await createPrompt({
       workspaceId: authz.workspaceId,
       mode: body.mode,
@@ -115,13 +74,5 @@ export async function POST(
     });
 
     return NextResponse.json({ success: true, prompt });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to create prompt",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/lib/studio/__tests__/withStudioAuth.test.ts
+++ b/src/lib/studio/__tests__/withStudioAuth.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockIsDatabaseConfigured = vi.fn(() => true);
+const mockAuthorizeStudioRequest = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) =>
+    mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json(
+      { success: false, error: result.error },
+      { status: result.status },
+    ),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
+
+function createRequest(): NextRequest {
+  return {
+    headers: new Headers(),
+  } as unknown as NextRequest;
+}
+
+const authorizedResult = {
+  authorized: true as const,
+  userId: "user_1",
+  workspaceId: "ws_1",
+  role: "member" as const,
+  permissions: [] as never[],
+  contentSession: {} as never,
+};
+
+describe("withStudioAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsDatabaseConfigured.mockReturnValue(true);
+  });
+
+  it("returns 503 when database is not configured (handler not called)", async () => {
+    mockIsDatabaseConfigured.mockReturnValue(false);
+    const handler = vi.fn();
+
+    const route = withStudioAuth({ route: "/api/studio/test", action: "read" }, handler);
+    const response = await route(createRequest(), undefined as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("DATABASE_URL is not configured.");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 pass-through from authorizeStudioRequest failure", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: false,
+      status: 401,
+      error: "Please sign in to access AI Studio.",
+      reason: "unauthenticated",
+    });
+    const handler = vi.fn();
+
+    const route = withStudioAuth({ route: "/api/studio/test", action: "read" }, handler);
+    const response = await route(createRequest(), undefined as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Please sign in to access AI Studio.");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 pass-through from authorizeStudioRequest failure", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue({
+      authorized: false,
+      status: 403,
+      error: "No access to this workspace.",
+      reason: "forbidden",
+    });
+    const handler = vi.fn();
+
+    const route = withStudioAuth({ route: "/api/studio/test", action: "read" }, handler);
+    const response = await route(createRequest(), undefined as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("calls handler with narrowed authz result and returns its response", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+    const handlerResponse = NextResponse.json({ success: true, data: "ok" });
+    const handler = vi.fn().mockResolvedValue(handlerResponse);
+
+    const route = withStudioAuth({ route: "/api/studio/test", action: "read" }, handler);
+    const request = createRequest();
+    const response = await route(request, undefined as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(handler).toHaveBeenCalledWith(request, authorizedResult, undefined);
+  });
+
+  it("returns 500 with generic message when handler throws (not leaking error.message)", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+    const handler = vi.fn().mockRejectedValue(new Error("secret DB connection string"));
+
+    const route = withStudioAuth({ route: "/api/studio/test", action: "write" }, handler);
+    const response = await route(createRequest(), undefined as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Internal server error.");
+    expect(data.error).not.toContain("secret DB connection string");
+  });
+
+  it("forwards context to the handler for dynamic routes", async () => {
+    mockAuthorizeStudioRequest.mockResolvedValue(authorizedResult);
+    const handlerResponse = NextResponse.json({ success: true });
+    const handler = vi.fn().mockResolvedValue(handlerResponse);
+
+    const context = { params: Promise.resolve({ assetId: "asset_abc" }) };
+    const route = withStudioAuth<typeof context>(
+      { route: "/api/studio/assets/[assetId]", action: "read" },
+      handler,
+    );
+
+    const request = createRequest();
+    await route(request, context);
+
+    expect(handler).toHaveBeenCalledWith(request, authorizedResult, context);
+  });
+});

--- a/src/lib/studio/withStudioAuth.ts
+++ b/src/lib/studio/withStudioAuth.ts
@@ -24,7 +24,17 @@ export function withStudioAuth<C extends RouteContext | undefined = undefined>(
     context: C,
   ) => Promise<NextResponse>,
 ) {
-  return async (request: NextRequest, context?: C): Promise<NextResponse> => {
+  // The returned function's `context` parameter is typed as the widest shape
+  // Next.js passes: Next provides `{ params: Promise<...> }` even for
+  // non-dynamic routes, so typing it from the generic `C` (which defaults to
+  // `undefined`) fails Next's build-time RouteHandlerConfig validation. It
+  // stays optional so unit tests can invoke non-dynamic handlers with a
+  // single argument. The generic `C` narrows the context only for the inner
+  // handler (via the contained cast below).
+  return async (
+    request: NextRequest,
+    context?: RouteContext,
+  ): Promise<NextResponse> => {
     if (!isDatabaseConfigured()) {
       return NextResponse.json(
         { success: false, error: "DATABASE_URL is not configured." },

--- a/src/lib/studio/withStudioAuth.ts
+++ b/src/lib/studio/withStudioAuth.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isDatabaseConfigured } from "@/lib/db";
+import {
+  authorizeStudioRequest,
+  authzErrorResponse,
+  type StudioAuthorizationResult,
+} from "@/lib/studio/authz";
+import { logger } from "@/utils/logger";
+
+type AuthorizedStudio = Extract<StudioAuthorizationResult, { authorized: true }>;
+
+interface WithStudioAuthOptions {
+  route: string;
+  action: "read" | "write" | "delete";
+}
+
+type RouteContext = { params: Promise<Record<string, string>> };
+
+export function withStudioAuth<C extends RouteContext | undefined = undefined>(
+  options: WithStudioAuthOptions,
+  handler: (
+    request: NextRequest,
+    authz: AuthorizedStudio,
+    context: C,
+  ) => Promise<NextResponse>,
+) {
+  return async (request: NextRequest, context: C): Promise<NextResponse> => {
+    if (!isDatabaseConfigured()) {
+      return NextResponse.json(
+        { success: false, error: "DATABASE_URL is not configured." },
+        { status: 503 },
+      );
+    }
+
+    try {
+      const authz = await authorizeStudioRequest(request, options);
+      if (!authz.authorized) {
+        return authzErrorResponse(authz);
+      }
+      return await handler(request, authz, context);
+    } catch (error) {
+      logger.error(
+        "system",
+        "Unhandled studio route error",
+        { route: options.route },
+        error instanceof Error ? error : undefined,
+      );
+      return NextResponse.json(
+        { success: false, error: "Internal server error." },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/src/lib/studio/withStudioAuth.ts
+++ b/src/lib/studio/withStudioAuth.ts
@@ -24,7 +24,7 @@ export function withStudioAuth<C extends RouteContext | undefined = undefined>(
     context: C,
   ) => Promise<NextResponse>,
 ) {
-  return async (request: NextRequest, context: C): Promise<NextResponse> => {
+  return async (request: NextRequest, context?: C): Promise<NextResponse> => {
     if (!isDatabaseConfigured()) {
       return NextResponse.json(
         { success: false, error: "DATABASE_URL is not configured." },
@@ -37,7 +37,7 @@ export function withStudioAuth<C extends RouteContext | undefined = undefined>(
       if (!authz.authorized) {
         return authzErrorResponse(authz);
       }
-      return await handler(request, authz, context);
+      return await handler(request, authz, context as C);
     } catch (error) {
       logger.error(
         "system",


### PR DESCRIPTION
## Summary
- Extracts `withStudioAuth` (`src/lib/studio/withStudioAuth.ts`): one place for the db-guard → authz → outer-catch preamble that 12 studio routes duplicated (~25 lines each)
- 500 responses no longer leak raw `error.message` to clients — generic "Internal server error." with the real error logged server-side; domain catches (404/409 mappings, quota errors) stay in-handler
- Adds body validation to prompts PATCH (previously passed unvalidated `request.json()` fields straight to the repository), matching its POST sibling's style
- NOT migrated by design: `copy` (just auth-gated in #89), `internal/*` (different auth mechanism), and `workspaces` (discovered to hand-roll its own auth — flagged separately for an owner decision)

## Behavior changes
- 500 bodies: generic message instead of internal error text (the point of the change)
- Authz now precedes body validation on migrated routes (401/503 before 400); one ingest test updated accordingly

## Tests
- New `withStudioAuth.test.ts` (6 tests incl. an explicit no-leak assertion) and `prompts/[promptId]` route tests (10, covering PATCH validation)
- Studio routes 104/104, gate-a 120/120, no new full-suite failures

Implements advisor-plans/005 (executor + advisor review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)