### PR TITLE
refactor(execution): shared HTTP error helper + typed getWorkflowId accessor

### DIFF
--- a/src/store/execution/__tests__/generateVideoExecutor.test.ts
+++ b/src/store/execution/__tests__/generateVideoExecutor.test.ts
@@ -71,6 +71,7 @@ function makeCtx(
     trackSaveGeneration: vi.fn(),
     appendOutputGalleryImage: vi.fn(),
     get: vi.fn(),
+    getWorkflowId: () => null,
     ...overrides,
   };
 }

--- a/src/store/execution/__tests__/httpResponseError.test.ts
+++ b/src/store/execution/__tests__/httpResponseError.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { throwIfResponseError } from "../httpResponseError";
+
+function makeResponse(
+  ok: boolean,
+  status: number,
+  body: string,
+): Response {
+  return {
+    ok,
+    status,
+    text: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe("throwIfResponseError", () => {
+  it("resolves without calling updateNodeData when response.ok is true", async () => {
+    const updateNodeData = vi.fn();
+    const response = makeResponse(true, 200, "");
+
+    await expect(
+      throwIfResponseError(response, "node-1", updateNodeData),
+    ).resolves.toBeUndefined();
+
+    expect(updateNodeData).not.toHaveBeenCalled();
+  });
+
+  it("throws with JSON error message and marks node errored on 500", async () => {
+    const updateNodeData = vi.fn();
+    const response = makeResponse(false, 500, '{"error": "boom"}');
+
+    await expect(
+      throwIfResponseError(response, "node-1", updateNodeData),
+    ).rejects.toThrow("boom");
+
+    expect(updateNodeData).toHaveBeenCalledWith("node-1", {
+      status: "error",
+      error: "boom",
+    });
+  });
+
+  it("throws with truncated text fallback on non-JSON 502 body", async () => {
+    const updateNodeData = vi.fn();
+    const longBody = "x".repeat(300);
+    const response = makeResponse(false, 502, longBody);
+
+    await expect(
+      throwIfResponseError(response, "node-2", updateNodeData),
+    ).rejects.toThrow(`HTTP 502 - ${"x".repeat(200)}`);
+
+    expect(updateNodeData).toHaveBeenCalledWith("node-2", {
+      status: "error",
+      error: `HTTP 502 - ${"x".repeat(200)}`,
+    });
+  });
+
+  it("throws 'HTTP 404' with no suffix when body is empty on 404", async () => {
+    const updateNodeData = vi.fn();
+    const response = makeResponse(false, 404, "");
+
+    await expect(
+      throwIfResponseError(response, "node-3", updateNodeData),
+    ).rejects.toThrow("HTTP 404");
+
+    expect(updateNodeData).toHaveBeenCalledWith("node-3", {
+      status: "error",
+      error: "HTTP 404",
+    });
+  });
+});

--- a/src/store/execution/__tests__/llmGenerateExecutor.test.ts
+++ b/src/store/execution/__tests__/llmGenerateExecutor.test.ts
@@ -72,6 +72,7 @@ function makeCtx(
     trackSaveGeneration: vi.fn(),
     appendOutputGalleryImage: vi.fn(),
     get: vi.fn(),
+    getWorkflowId: () => null,
     ...overrides,
   };
 }

--- a/src/store/execution/__tests__/nanoBananaExecutor.test.ts
+++ b/src/store/execution/__tests__/nanoBananaExecutor.test.ts
@@ -80,6 +80,7 @@ function makeCtx(
       addIncurredCost: vi.fn(),
       generationsPath: null,
     }),
+    getWorkflowId: () => null,
     ...overrides,
   };
 }

--- a/src/store/execution/__tests__/simpleNodeExecutors.test.ts
+++ b/src/store/execution/__tests__/simpleNodeExecutors.test.ts
@@ -37,6 +37,7 @@ function makeCtx(
     trackSaveGeneration: vi.fn(),
     appendOutputGalleryImage: vi.fn(),
     get: vi.fn(),
+    getWorkflowId: () => null,
     ...overrides,
   };
 }

--- a/src/store/execution/__tests__/splitGridExecutor.test.ts
+++ b/src/store/execution/__tests__/splitGridExecutor.test.ts
@@ -86,6 +86,7 @@ function makeCtx(
     trackSaveGeneration: vi.fn(),
     appendOutputGalleryImage: vi.fn(),
     get: vi.fn(),
+    getWorkflowId: () => null,
     ...overrides,
   };
 }

--- a/src/store/execution/__tests__/videoProcessingExecutors.test.ts
+++ b/src/store/execution/__tests__/videoProcessingExecutors.test.ts
@@ -50,6 +50,7 @@ function makeCtx(
     trackSaveGeneration: vi.fn(),
     appendOutputGalleryImage: vi.fn(),
     get: vi.fn(),
+    getWorkflowId: () => null,
     ...overrides,
   };
 }

--- a/src/store/execution/generate3dExecutor.ts
+++ b/src/store/execution/generate3dExecutor.ts
@@ -10,6 +10,7 @@ import { buildGenerateHeaders } from "@/store/utils/buildApiHeaders";
 import { isCloudMode } from "@/lib/storage";
 import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
 import { uploadImagesToR2 } from "./uploadInputAssets";
+import { throwIfResponseError } from "./httpResponseError";
 import type { NodeExecutionContext } from "./types";
 
 export interface Generate3DOptions {
@@ -32,6 +33,7 @@ export async function executeGenerate3D(
     generationsPath,
     trackSaveGeneration,
     get,
+    getWorkflowId,
   } = ctx;
 
   const { useStoredFallback = false } = options;
@@ -77,7 +79,7 @@ export async function executeGenerate3D(
   const headers = buildGenerateHeaders(provider, providerSettings);
 
   // Upload images to R2 in cloud mode to avoid Vercel payload limits
-  const projectId = (get() as { workflowId?: string | null } | undefined)?.workflowId ?? null;
+  const projectId = getWorkflowId();
   const { images: resolvedImages, dynamicInputs: resolvedDynamicInputs } =
     await uploadImagesToR2({ images, dynamicInputs, projectId });
 
@@ -98,22 +100,7 @@ export async function executeGenerate3D(
       ...(signal ? { signal } : {}),
     });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      let errorMessage = `HTTP ${response.status}`;
-      try {
-        const errorJson = JSON.parse(errorText);
-        errorMessage = errorJson.error || errorMessage;
-      } catch {
-        if (errorText) errorMessage += ` - ${errorText.substring(0, 200)}`;
-      }
-
-      updateNodeData(node.id, {
-        status: "error",
-        error: errorMessage,
-      });
-      throw new Error(errorMessage);
-    }
+    await throwIfResponseError(response, node.id, updateNodeData);
 
     const result = await response.json();
 
@@ -133,7 +120,7 @@ export async function executeGenerate3D(
         const savePromise = syncStudioAssetFromSource({
           assetType: "model3d",
           source: result.model3dUrl,
-          projectId: (get() as { workflowId?: string | null }).workflowId || null,
+          projectId: getWorkflowId(),
           getStoreState: () => get(),
         })
           .then((assetId) => {

--- a/src/store/execution/generateAudioExecutor.ts
+++ b/src/store/execution/generateAudioExecutor.ts
@@ -9,6 +9,7 @@ import type { GenerateAudioNodeData } from "@/types";
 import { buildGenerateHeaders } from "@/store/utils/buildApiHeaders";
 import { isCloudMode } from "@/lib/storage";
 import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
+import { throwIfResponseError } from "./httpResponseError";
 import type { NodeExecutionContext } from "./types";
 
 export interface GenerateAudioOptions {
@@ -32,6 +33,7 @@ export async function executeGenerateAudio(
     getNodes,
     trackSaveGeneration,
     get,
+    getWorkflowId,
   } = ctx;
 
   const { useStoredFallback = false } = options;
@@ -103,23 +105,8 @@ export async function executeGenerateAudio(
       ...(signal ? { signal } : {}),
     });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      let errorMessage = `HTTP ${response.status}`;
-      try {
-        const errorJson = JSON.parse(errorText);
-        errorMessage = errorJson.error || errorMessage;
-      } catch {
-        if (errorText) errorMessage += ` - ${errorText.substring(0, 200)}`;
-      }
-
-      updateNodeData(node.id, {
-        status: "error",
-        error: errorMessage,
-      });
-      errorHandled = true;
-      throw new Error(errorMessage);
-    }
+    if (!response.ok) errorHandled = true;
+    await throwIfResponseError(response, node.id, updateNodeData);
 
     const result = await response.json();
 
@@ -157,7 +144,7 @@ export async function executeGenerateAudio(
         const savePromise = syncStudioAssetFromSource({
           assetType: "audio",
           source,
-          projectId: (get() as { workflowId?: string | null }).workflowId || null,
+          projectId: getWorkflowId(),
           getStoreState: () => get(),
         })
           .then((assetId) => {

--- a/src/store/execution/generateVideoExecutor.ts
+++ b/src/store/execution/generateVideoExecutor.ts
@@ -10,6 +10,7 @@ import { buildGenerateHeaders } from "@/store/utils/buildApiHeaders";
 import { isCloudMode } from "@/lib/storage";
 import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
 import { uploadImagesToR2 } from "./uploadInputAssets";
+import { throwIfResponseError } from "./httpResponseError";
 import type { NodeExecutionContext } from "./types";
 
 export interface GenerateVideoOptions {
@@ -33,6 +34,7 @@ export async function executeGenerateVideo(
     getNodes,
     trackSaveGeneration,
     get,
+    getWorkflowId,
   } = ctx;
 
   const { useStoredFallback = false } = options;
@@ -92,7 +94,7 @@ export async function executeGenerateVideo(
   const headers = buildGenerateHeaders(provider, providerSettings);
 
   // Upload images to R2 in cloud mode to avoid Vercel payload limits
-  const projectId = (get() as { workflowId?: string | null } | undefined)?.workflowId ?? null;
+  const projectId = getWorkflowId();
   const { images: resolvedImages, dynamicInputs: resolvedDynamicInputs } =
     await uploadImagesToR2({ images, dynamicInputs, projectId });
 
@@ -113,22 +115,7 @@ export async function executeGenerateVideo(
       ...(signal ? { signal } : {}),
     });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      let errorMessage = `HTTP ${response.status}`;
-      try {
-        const errorJson = JSON.parse(errorText);
-        errorMessage = errorJson.error || errorMessage;
-      } catch {
-        if (errorText) errorMessage += ` - ${errorText.substring(0, 200)}`;
-      }
-
-      updateNodeData(node.id, {
-        status: "error",
-        error: errorMessage,
-      });
-      throw new Error(errorMessage);
-    }
+    await throwIfResponseError(response, node.id, updateNodeData);
 
     const result = await response.json();
 

--- a/src/store/execution/generateVideoExecutor.ts
+++ b/src/store/execution/generateVideoExecutor.ts
@@ -154,7 +154,7 @@ export async function executeGenerateVideo(
         const savePromise = syncStudioAssetFromSource({
           assetType: "video",
           source,
-          projectId: (get() as { workflowId?: string | null }).workflowId || null,
+          projectId: getWorkflowId(),
           getStoreState: () => get(),
         })
           .then((assetId) => {

--- a/src/store/execution/httpResponseError.ts
+++ b/src/store/execution/httpResponseError.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared HTTP error extraction for generation executors.
+ * Parses the API error envelope ({ error: string }) with a truncated-text
+ * fallback, marks the node as errored, and throws.
+ */
+import type { WorkflowNodeData } from "@/types";
+
+export async function throwIfResponseError(
+  response: Response,
+  nodeId: string,
+  updateNodeData: (nodeId: string, data: Partial<WorkflowNodeData>) => void,
+): Promise<void> {
+  if (response.ok) return;
+
+  const errorText = await response.text();
+  let errorMessage = `HTTP ${response.status}`;
+  try {
+    const errorJson = JSON.parse(errorText);
+    errorMessage = errorJson.error || errorMessage;
+  } catch {
+    if (errorText) errorMessage += ` - ${errorText.substring(0, 200)}`;
+  }
+
+  updateNodeData(nodeId, { status: "error", error: errorMessage });
+  throw new Error(errorMessage);
+}

--- a/src/store/execution/index.ts
+++ b/src/store/execution/index.ts
@@ -8,6 +8,8 @@
 
 export type { NodeExecutionContext, NodeExecutor } from "./types";
 
+export { throwIfResponseError } from "./httpResponseError";
+
 export {
   executeAnnotation,
   executeArray,

--- a/src/store/execution/llmGenerateExecutor.ts
+++ b/src/store/execution/llmGenerateExecutor.ts
@@ -8,6 +8,7 @@
 import type { LLMGenerateNodeData } from "@/types";
 import { buildLlmHeaders } from "@/store/utils/buildApiHeaders";
 import { uploadImagesToR2 } from "./uploadInputAssets";
+import { throwIfResponseError } from "./httpResponseError";
 import type { NodeExecutionContext } from "./types";
 
 export interface LlmGenerateOptions {
@@ -26,6 +27,7 @@ export async function executeLlmGenerate(
     signal,
     providerSettings,
     get,
+    getWorkflowId,
   } = ctx;
 
   const { useStoredFallback = false } = options;
@@ -63,7 +65,7 @@ export async function executeLlmGenerate(
   const headers = buildLlmHeaders(nodeData.provider, providerSettings);
 
   // Upload images to R2 in cloud mode to avoid Vercel payload limits
-  const projectId = (get() as { workflowId?: string | null } | undefined)?.workflowId ?? null;
+  const projectId = getWorkflowId();
   const { images: resolvedImages } = await uploadImagesToR2({ images, projectId });
 
   try {
@@ -81,21 +83,7 @@ export async function executeLlmGenerate(
       ...(signal ? { signal } : {}),
     });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      let errorMessage = `HTTP ${response.status}`;
-      try {
-        const errorJson = JSON.parse(errorText);
-        errorMessage = errorJson.error || errorMessage;
-      } catch {
-        if (errorText) errorMessage += ` - ${errorText.substring(0, 200)}`;
-      }
-      updateNodeData(node.id, {
-        status: "error",
-        error: errorMessage,
-      });
-      throw new Error(errorMessage);
-    }
+    await throwIfResponseError(response, node.id, updateNodeData);
 
     const result = await response.json();
 

--- a/src/store/execution/nanoBananaExecutor.ts
+++ b/src/store/execution/nanoBananaExecutor.ts
@@ -13,6 +13,7 @@ import { buildGenerateHeaders } from "@/store/utils/buildApiHeaders";
 import { isCloudMode } from "@/lib/storage";
 import { syncStudioAssetFromSaveResult, syncStudioAssetFromSource } from "./studioAssetSync";
 import { uploadImagesToR2 } from "./uploadInputAssets";
+import { throwIfResponseError } from "./httpResponseError";
 import type { NodeExecutionContext } from "./types";
 
 export interface NanoBananaOptions {
@@ -39,6 +40,7 @@ export async function executeNanoBanana(
     trackSaveGeneration,
     appendOutputGalleryImage,
     get,
+    getWorkflowId,
   } = ctx;
 
   const { useStoredFallback = false } = options;
@@ -98,7 +100,7 @@ export async function executeNanoBanana(
   delete sanitizedDynamicInputs.prompt;
 
   // Upload images to R2 in cloud mode to avoid Vercel payload limits
-  const projectId = (get() as { workflowId?: string | null } | undefined)?.workflowId ?? null;
+  const projectId = getWorkflowId();
   const { images: resolvedImages, dynamicInputs: resolvedDynamicInputs } =
     await uploadImagesToR2({
       images,
@@ -136,22 +138,7 @@ export async function executeNanoBanana(
       ...(signal ? { signal } : {}),
     });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      let errorMessage = `HTTP ${response.status}`;
-      try {
-        const errorJson = JSON.parse(errorText);
-        errorMessage = errorJson.error || errorMessage;
-      } catch {
-        if (errorText) errorMessage += ` - ${errorText.substring(0, 200)}`;
-      }
-
-      updateNodeData(node.id, {
-        status: "error",
-        error: errorMessage,
-      });
-      throw new Error(errorMessage);
-    }
+    await throwIfResponseError(response, node.id, updateNodeData);
 
     const result = await response.json();
 

--- a/src/store/execution/nanoBananaExecutor.ts
+++ b/src/store/execution/nanoBananaExecutor.ts
@@ -201,7 +201,7 @@ export async function executeNanoBanana(
         const savePromise = syncStudioAssetFromSource({
           assetType: "image",
           source: result.image,
-          projectId: (get() as { workflowId?: string | null }).workflowId || null,
+          projectId: getWorkflowId(),
           getStoreState: () => get(),
         })
           .then((assetId) => {

--- a/src/store/execution/simpleNodeExecutors.ts
+++ b/src/store/execution/simpleNodeExecutors.ts
@@ -190,6 +190,7 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
     saveDirectoryPath,
     trackSaveGeneration,
     get,
+    getWorkflowId,
   } = ctx;
   const { images, videos, audio } = getConnectedInputs(node.id);
 
@@ -213,7 +214,7 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
             assetType: "audio",
             source: audioContent,
             fileName: outputNodeData.outputFilename || undefined,
-            projectId: (get() as { workflowId?: string | null }).workflowId || null,
+            projectId: getWorkflowId(),
             getStoreState: () => get(),
           }).then(() => undefined)
           .catch((syncError) => {
@@ -264,7 +265,7 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
             assetType: "video",
             source: videoContent,
             fileName: outputNodeData.outputFilename || undefined,
-            projectId: (get() as { workflowId?: string | null }).workflowId || null,
+            projectId: getWorkflowId(),
             getStoreState: () => get(),
           }).then(() => undefined)
           .catch((syncError) => {
@@ -326,7 +327,7 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
             assetType: isVideoContent ? "video" : "image",
             source: content,
             fileName: outputNodeData.outputFilename || undefined,
-            projectId: (get() as { workflowId?: string | null }).workflowId || null,
+            projectId: getWorkflowId(),
             getStoreState: () => get(),
           }).then(() => undefined)
           .catch((syncError) => {

--- a/src/store/execution/types.ts
+++ b/src/store/execution/types.ts
@@ -48,6 +48,8 @@ export interface NodeExecutionContext {
   trackSaveGeneration: (key: string, promise: Promise<void>) => void;
   appendOutputGalleryImage: (targetId: string, image: string) => void;
   get: () => unknown;
+  /** Current workflow/project id, or null when unsaved. */
+  getWorkflowId: () => string | null;
 }
 
 /**

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -1004,6 +1004,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
       }));
     },
     get: get as () => unknown,
+    getWorkflowId: () => get().workflowId ?? null,
   }),
 
   executeWorkflow: async (startFromNodeId?: string) => {


### PR DESCRIPTION
## Summary
- Extracts `throwIfResponseError` (`src/store/execution/httpResponseError.ts`) — byte-equivalent replacement for the `!response.ok` block that five generation executors duplicated verbatim
- Adds typed `getWorkflowId(): string | null` to `NodeExecutionContext`, eliminating all 8 `(get() as { workflowId?... })` casts across 6 executor files (`ctx.get` is `() => unknown`, so these were fully unchecked)
- `generateAudio`'s `errorHandled` flag preserved via a one-line guard — no catch-block restructuring; deeper success-path consolidation deliberately deferred until generateAudio/generate3d get characterization tests

## Tests
- New `httpResponseError.test.ts` (4 cases: ok pass-through, JSON error envelope, truncated text fallback, empty body)
- Executor suite 84/84; existing error-message assertions double as byte-equivalence checks; no new full-suite failures

Implements advisor-plans/006 (executor + advisor review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)