### PR TITLE
test(types): green tsc baseline + typecheck script and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Type check
+        run: pnpm typecheck
+
       - name: Run Gate A deterministic tests
         run: pnpm test:gate-a
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:run": "vitest run",
     "test:gate-a": "vitest run src/app/api/studio/workspaces/__tests__/route.test.ts src/app/api/studio/projects/__tests__/route.test.ts src/app/api/studio/projects/[projectId]/__tests__/route.test.ts src/app/api/studio/assets/__tests__/route.test.ts src/app/api/studio/assets/[assetId]/__tests__/route.test.ts src/app/api/studio/assets/presign/__tests__/route.test.ts src/app/api/social/accounts/__tests__/route.test.ts src/app/api/social/posts/__tests__/route.test.ts src/components/__tests__/Header.test.tsx",
     "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
     "db:generate": "drizzle-kit generate",

--- a/src/app/api/generate/__tests__/route.test.ts
+++ b/src/app/api/generate/__tests__/route.test.ts
@@ -2173,7 +2173,7 @@ describe("/api/generate route", () => {
 
       // Find the queue submit call (the one to queue.fal.run)
       const queueSubmitCall = mockFetch.mock.calls.find(
-        (call: [string, ...unknown[]]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
       );
       expect(queueSubmitCall).toBeDefined();
       const requestBody = JSON.parse((queueSubmitCall![1] as { body: string }).body);
@@ -2227,7 +2227,7 @@ describe("/api/generate route", () => {
 
       // Find the queue submit call
       const queueSubmitCall = mockFetch.mock.calls.find(
-        (call: [string, ...unknown[]]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
       );
       expect(queueSubmitCall).toBeDefined();
       const requestBody = JSON.parse((queueSubmitCall![1] as { body: string }).body);
@@ -2324,7 +2324,7 @@ describe("/api/generate route", () => {
 
       // Find the queue submit call
       const queueSubmitCall = mockFetch.mock.calls.find(
-        (call: [string, ...unknown[]]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
       );
       expect(queueSubmitCall).toBeDefined();
       const requestBody = JSON.parse((queueSubmitCall![1] as { body: string }).body);
@@ -2379,7 +2379,7 @@ describe("/api/generate route", () => {
 
       // Find the queue submit call
       const queueSubmitCall = mockFetch.mock.calls.find(
-        (call: [string, ...unknown[]]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
       );
       expect(queueSubmitCall).toBeDefined();
       const requestBody = JSON.parse((queueSubmitCall![1] as { body: string }).body);
@@ -2453,7 +2453,7 @@ describe("/api/generate route", () => {
 
       // Find the queue submit call
       const queueSubmitCall = mockFetch.mock.calls.find(
-        (call: [string, ...unknown[]]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
       );
       expect(queueSubmitCall).toBeDefined();
       const requestBody = JSON.parse((queueSubmitCall![1] as { body: string }).body);
@@ -2523,7 +2523,7 @@ describe("/api/generate route", () => {
 
       // Find the queue submit call
       const queueSubmitCall = mockFetch.mock.calls.find(
-        (call: [string, ...unknown[]]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
       );
       expect(queueSubmitCall).toBeDefined();
       const requestBody = JSON.parse((queueSubmitCall![1] as { body: string }).body);
@@ -2604,7 +2604,7 @@ describe("/api/generate route", () => {
 
       // Find the queue submit call
       const queueSubmitCall = mockFetch.mock.calls.find(
-        (call: [string, ...unknown[]]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("queue.fal.run") && !call[0].includes("/requests/")
       );
       expect(queueSubmitCall).toBeDefined();
       const requestBody = JSON.parse((queueSubmitCall![1] as { body: string }).body);

--- a/src/app/api/open-file/__tests__/route.test.ts
+++ b/src/app/api/open-file/__tests__/route.test.ts
@@ -12,17 +12,19 @@ const { mockExecFileAsync, mockStat, mockPlatform, mockHomedir } = vi.hoisted(()
 
 vi.mock(import("child_process"), async (importOriginal) => {
   const actual = await importOriginal();
+  // execFile mock: cast as unknown to satisfy __promisify__ type requirement in vitest
   return {
     ...actual,
-    execFile: vi.fn(),
+    execFile: vi.fn() as unknown as typeof actual.execFile,
   };
 });
 
 vi.mock(import("util"), async (importOriginal) => {
   const actual = await importOriginal();
+  // promisify mock: cast as unknown to satisfy custom symbol type requirement in vitest
   return {
     ...actual,
-    promisify: () => mockExecFileAsync,
+    promisify: (() => mockExecFileAsync) as unknown as typeof actual.promisify,
   };
 });
 

--- a/src/app/api/social/accounts/__tests__/route.test.ts
+++ b/src/app/api/social/accounts/__tests__/route.test.ts
@@ -101,7 +101,7 @@ function createRequest(
   url = "http://localhost:3000/api/social/accounts",
   init?: RequestInit,
 ): NextRequest {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 describe("/api/social/accounts GET", () => {

--- a/src/app/api/social/automation/rules/[ruleId]/__tests__/route.test.ts
+++ b/src/app/api/social/automation/rules/[ruleId]/__tests__/route.test.ts
@@ -44,7 +44,7 @@ function authorized() {
 }
 
 function request(url: string, init?: RequestInit): NextRequest {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 describe("/api/social/automation/rules/[ruleId]", () => {

--- a/src/app/api/social/automation/rules/__tests__/route.test.ts
+++ b/src/app/api/social/automation/rules/__tests__/route.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/social/repository", () => ({
 }));
 
 function createRequest(url: string, init?: RequestInit): NextRequest {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 const mockSession = {

--- a/src/app/api/social/automation/tasks/[taskId]/__tests__/route.test.ts
+++ b/src/app/api/social/automation/tasks/[taskId]/__tests__/route.test.ts
@@ -50,7 +50,7 @@ function authorized() {
 }
 
 function request(url: string, init?: RequestInit): NextRequest {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 describe("/api/social/automation/tasks/[taskId]", () => {

--- a/src/app/api/social/automation/tasks/__tests__/route.test.ts
+++ b/src/app/api/social/automation/tasks/__tests__/route.test.ts
@@ -37,7 +37,7 @@ vi.mock("@/lib/social/repository", () => ({
 }));
 
 function createRequest(url: string, init?: RequestInit): NextRequest {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 const mockSession = {

--- a/src/app/api/social/events/__tests__/route.test.ts
+++ b/src/app/api/social/events/__tests__/route.test.ts
@@ -66,7 +66,7 @@ function unauthorized(status: 401 | 403) {
 }
 
 function request(url: string, init?: RequestInit): NextRequest {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 describe("/api/social/events", () => {

--- a/src/app/api/social/internal/automation-dispatch/__tests__/route.test.ts
+++ b/src/app/api/social/internal/automation-dispatch/__tests__/route.test.ts
@@ -12,7 +12,7 @@ const mockIncrementAutomationRuleRunCount = vi.fn();
 const mockCreateAutomationTask = vi.fn();
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
 }));
 
 vi.mock("@/lib/social/repository", () => ({

--- a/src/app/api/social/internal/digest-dispatch/__tests__/route.test.ts
+++ b/src/app/api/social/internal/digest-dispatch/__tests__/route.test.ts
@@ -14,7 +14,7 @@ class MockSocialNotificationPreferencesNotFoundError extends Error {
 }
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
   getDb: () => ({
     select: mockSelect,
   }),

--- a/src/app/api/social/internal/ops-snapshot/__tests__/route.test.ts
+++ b/src/app/api/social/internal/ops-snapshot/__tests__/route.test.ts
@@ -6,8 +6,8 @@ const mockGetDb = vi.fn();
 const mockEnsureInternalSocialAuth = vi.fn();
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
-  getDb: (...args: unknown[]) => mockGetDb(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
+  getDb: (...args: unknown[]) => mockGetDb(...(args as [])),
 }));
 
 vi.mock("@/lib/social/internal-auth", () => ({

--- a/src/app/api/social/internal/sweep-stuck/__tests__/route.test.ts
+++ b/src/app/api/social/internal/sweep-stuck/__tests__/route.test.ts
@@ -7,7 +7,7 @@ const mockUpdatePostStatus = vi.fn();
 const mockEmitSocialEvent = vi.fn();
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
 }));
 
 vi.mock("@/lib/social/repository", () => ({

--- a/src/app/api/social/internal/token-refresh-dispatch/__tests__/route.test.ts
+++ b/src/app/api/social/internal/token-refresh-dispatch/__tests__/route.test.ts
@@ -6,7 +6,7 @@ const mockListExpiringSocialAccounts = vi.fn();
 const mockWorkflowStart = vi.fn();
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
 }));
 
 vi.mock("@/lib/social/repository", () => ({

--- a/src/app/api/social/notifications/preferences/__tests__/route.test.ts
+++ b/src/app/api/social/notifications/preferences/__tests__/route.test.ts
@@ -36,7 +36,7 @@ vi.mock("@/lib/social/repository", () => ({
 }));
 
 function createRequest(url: string, init?: RequestInit) {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 const mockSession = {

--- a/src/app/api/social/webhooks/[webhookId]/__tests__/route.test.ts
+++ b/src/app/api/social/webhooks/[webhookId]/__tests__/route.test.ts
@@ -56,7 +56,7 @@ function authorized() {
 }
 
 function req(url: string, init?: RequestInit): NextRequest {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 describe("/api/social/webhooks/[webhookId]", () => {

--- a/src/app/api/social/webhooks/__tests__/route.test.ts
+++ b/src/app/api/social/webhooks/__tests__/route.test.ts
@@ -57,7 +57,7 @@ function unauthorized(status: 401 | 403) {
 }
 
 function req(url: string, init?: RequestInit): NextRequest {
-  return new NextRequest(url, init);
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
 }
 
 describe("/api/social/webhooks", () => {

--- a/src/app/api/studio/internal/migrate-legacy-assets/__tests__/route.test.ts
+++ b/src/app/api/studio/internal/migrate-legacy-assets/__tests__/route.test.ts
@@ -9,7 +9,7 @@ const mockBuildAssetObjectKey = vi.fn();
 const mockRecordAsset = vi.fn();
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
 }));
 
 vi.mock("@/lib/storage", () => ({

--- a/src/app/api/studio/internal/orphan-cleanup/__tests__/route.test.ts
+++ b/src/app/api/studio/internal/orphan-cleanup/__tests__/route.test.ts
@@ -7,7 +7,7 @@ const mockFinalizeAssetUpload = vi.fn();
 const mockDeleteObjectFromS3 = vi.fn();
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
 }));
 
 vi.mock("@/lib/studio/repository", () => ({

--- a/src/app/api/studio/internal/purge-deleted/__tests__/route.test.ts
+++ b/src/app/api/studio/internal/purge-deleted/__tests__/route.test.ts
@@ -7,7 +7,7 @@ const mockHardDeleteAsset = vi.fn();
 const mockDeleteObjectFromS3 = vi.fn();
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
 }));
 
 vi.mock("@/lib/studio/repository", () => ({

--- a/src/app/studio/__tests__/actions.test.ts
+++ b/src/app/studio/__tests__/actions.test.ts
@@ -10,8 +10,8 @@ vi.mock("next/headers", () => ({
 }));
 
 vi.mock("@/lib/db", () => ({
-  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...args),
-  getDb: (...args: unknown[]) => mockGetDb(...args),
+  isDatabaseConfigured: (...args: unknown[]) => mockIsDatabaseConfigured(...(args as [])),
+  getDb: (...args: unknown[]) => mockGetDb(...(args as [])),
 }));
 
 const mockGetAuthenticatedUserFromHeaders = vi.fn();

--- a/src/components/__tests__/AnnotationNode.test.tsx
+++ b/src/components/__tests__/AnnotationNode.test.tsx
@@ -108,6 +108,14 @@ describe("AnnotationNode", () => {
     type: "annotation" as const,
     data: createNodeData(data),
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Basic Rendering", () => {

--- a/src/components/__tests__/AudioInputNode.test.tsx
+++ b/src/components/__tests__/AudioInputNode.test.tsx
@@ -116,6 +116,14 @@ const createNodeProps = (data: Partial<AudioInputNodeData> = {}) => ({
   type: "audioInput" as const,
   data: createNodeData(data),
   selected: false,
+  dragging: false,
+  draggable: true,
+  selectable: true,
+  deletable: true,
+  zIndex: 0,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
 });
 
 describe("AudioInputNode", () => {

--- a/src/components/__tests__/EaseCurveNode.test.tsx
+++ b/src/components/__tests__/EaseCurveNode.test.tsx
@@ -117,6 +117,14 @@ const createNodeProps = (data: Partial<EaseCurveNodeData> = {}) => ({
   type: "easeCurve" as const,
   data: createNodeData(data),
   selected: false,
+  dragging: false,
+  draggable: true,
+  selectable: true,
+  deletable: true,
+  zIndex: 0,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
 });
 
 describe("EaseCurveNode", () => {

--- a/src/components/__tests__/FloatingActionBar.test.tsx
+++ b/src/components/__tests__/FloatingActionBar.test.tsx
@@ -64,6 +64,7 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },

--- a/src/components/__tests__/Generate3DNode.test.tsx
+++ b/src/components/__tests__/Generate3DNode.test.tsx
@@ -110,6 +110,8 @@ describe("Generate3DNode", () => {
     inputImages: [],
     inputPrompt: null,
     output3dUrl: null,
+    savedFilename: null,
+    savedFilePath: null,
     status: "idle",
     error: null,
     ...overrides,
@@ -120,6 +122,14 @@ describe("Generate3DNode", () => {
     type: "generate3d" as const,
     data: createNodeData(data),
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Basic Rendering", () => {

--- a/src/components/__tests__/GenerateAudioNode.test.tsx
+++ b/src/components/__tests__/GenerateAudioNode.test.tsx
@@ -90,6 +90,7 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
@@ -149,6 +150,14 @@ describe("GenerateAudioNode", () => {
     type: "generateAudio" as const,
     data: createNodeData(data),
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Basic Rendering", () => {

--- a/src/components/__tests__/GenerateImageNode.test.tsx
+++ b/src/components/__tests__/GenerateImageNode.test.tsx
@@ -85,6 +85,7 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
@@ -136,6 +137,7 @@ describe("GenerateImageNode", () => {
     resolution: "1K",
     model: "nano-banana-pro",
     useGoogleSearch: false,
+    useImageSearch: false,
     status: "idle",
     error: null,
     imageHistory: [],
@@ -148,6 +150,14 @@ describe("GenerateImageNode", () => {
     type: "nanoBanana" as const,
     data: createNodeData(data),
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Basic Rendering", () => {

--- a/src/components/__tests__/GenerateVideoNode.test.tsx
+++ b/src/components/__tests__/GenerateVideoNode.test.tsx
@@ -84,6 +84,7 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
@@ -143,6 +144,14 @@ describe("GenerateVideoNode", () => {
     type: "generateVideo" as const,
     data: createNodeData(data),
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Basic Rendering", () => {

--- a/src/components/__tests__/GroupNode.test.tsx
+++ b/src/components/__tests__/GroupNode.test.tsx
@@ -79,6 +79,14 @@ describe("GroupNode", () => {
     type: "group" as const,
     data,
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Basic Rendering", () => {

--- a/src/components/__tests__/GroupsOverlay.test.tsx
+++ b/src/components/__tests__/GroupsOverlay.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { GroupBackgroundsPortal, GroupControlsOverlay, GroupsOverlay } from "@/components/GroupsOverlay";
-import { Group } from "@/types";
+import { NodeGroup as Group } from "@/types";
 
 // Mock ReactFlow hooks and components
 vi.mock("@xyflow/react", () => ({
@@ -40,11 +40,11 @@ vi.mock("@/store/workflowStore", () => ({
 
 // Helper to create mock group
 const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
+  id: "test-group-1",
   name: "Test Group",
   color: "blue",
   position: { x: 100, y: 100 },
   size: { width: 400, height: 300 },
-  nodeIds: ["node-1", "node-2"],
   locked: false,
   ...overrides,
 });

--- a/src/components/__tests__/ImageInputNode.test.tsx
+++ b/src/components/__tests__/ImageInputNode.test.tsx
@@ -75,6 +75,7 @@ describe("ImageInputNode", () => {
     positionAbsoluteY: 0,
     zIndex: 0,
     dragging: false,
+    draggable: true,
     deletable: true,
     selectable: true,
     parentId: undefined,

--- a/src/components/__tests__/LLMGenerateNode.test.tsx
+++ b/src/components/__tests__/LLMGenerateNode.test.tsx
@@ -66,6 +66,14 @@ describe("LLMGenerateNode", () => {
     type: "llmGenerate" as const,
     data: createNodeData(data),
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Basic Rendering", () => {

--- a/src/components/__tests__/ModelSearchDialog.test.tsx
+++ b/src/components/__tests__/ModelSearchDialog.test.tsx
@@ -71,6 +71,7 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: true, apiKey: "test-replicate-key" },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: "test-fal-key" },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },

--- a/src/components/__tests__/OutputNode.test.tsx
+++ b/src/components/__tests__/OutputNode.test.tsx
@@ -82,6 +82,14 @@ describe("OutputNode", () => {
       ...data,
     },
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Empty State Rendering", () => {

--- a/src/components/__tests__/ProjectSetupModal.test.tsx
+++ b/src/components/__tests__/ProjectSetupModal.test.tsx
@@ -46,6 +46,7 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: false, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },

--- a/src/components/__tests__/PromptNode.test.tsx
+++ b/src/components/__tests__/PromptNode.test.tsx
@@ -49,6 +49,7 @@ describe("PromptNode", () => {
     positionAbsoluteY: 0,
     zIndex: 0,
     dragging: false,
+    draggable: true,
     deletable: true,
     selectable: true,
     parentId: undefined,

--- a/src/components/__tests__/SplitGridNode.test.tsx
+++ b/src/components/__tests__/SplitGridNode.test.tsx
@@ -70,6 +70,7 @@ describe("SplitGridNode", () => {
       resolution: "1K",
       model: "nano-banana",
       useGoogleSearch: false,
+      useImageSearch: false,
     },
     childNodeIds: [],
     gridRows: 2,
@@ -85,6 +86,14 @@ describe("SplitGridNode", () => {
     type: "splitGrid" as const,
     data: createDefaultNodeData(data),
     selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: true,
+    zIndex: 0,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
   });
 
   describe("Basic Rendering", () => {

--- a/src/components/__tests__/SplitGridSettingsModal.test.tsx
+++ b/src/components/__tests__/SplitGridSettingsModal.test.tsx
@@ -24,6 +24,7 @@ const createDefaultNodeData = (): SplitGridNodeData => ({
     resolution: "1K",
     model: "nano-banana",
     useGoogleSearch: false,
+    useImageSearch: false,
   },
   sourceImage: null,
   childNodeIds: [],
@@ -469,6 +470,7 @@ describe("SplitGridSettingsModal", () => {
         resolution: "2K",
         model: "nano-banana-pro",
         useGoogleSearch: true,
+        useImageSearch: false,
       };
 
       render(

--- a/src/components/__tests__/VideoStitchNode.test.tsx
+++ b/src/components/__tests__/VideoStitchNode.test.tsx
@@ -96,6 +96,7 @@ const createNodeData = (overrides: Partial<VideoStitchNodeData> = {}): VideoStit
   clips: [],
   clipOrder: [],
   outputVideo: null,
+  loopCount: 1,
   status: "idle",
   error: null,
   progress: 0,
@@ -108,6 +109,14 @@ const createNodeProps = (data: Partial<VideoStitchNodeData> = {}) => ({
   type: "videoStitch" as const,
   data: createNodeData(data),
   selected: false,
+  dragging: false,
+  draggable: true,
+  selectable: true,
+  deletable: true,
+  zIndex: 0,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
 });
 
 describe("VideoStitchNode", () => {

--- a/src/hooks/__tests__/useAudioMixing.test.ts
+++ b/src/hooks/__tests__/useAudioMixing.test.ts
@@ -7,16 +7,16 @@ class MockAudioBuffer implements AudioBuffer {
   readonly length: number;
   readonly duration: number;
   readonly numberOfChannels: number;
-  private channels: Float32Array[];
+  private channels: Float32Array<ArrayBuffer>[];
 
   constructor(options: { length: number; numberOfChannels: number; sampleRate: number }) {
     this.length = options.length;
     this.numberOfChannels = options.numberOfChannels;
     this.sampleRate = options.sampleRate;
     this.duration = options.length / options.sampleRate;
-    this.channels = Array.from({ length: options.numberOfChannels }, () => new Float32Array(options.length));
+    this.channels = Array.from({ length: options.numberOfChannels }, () => new Float32Array(new ArrayBuffer(options.length * 4)));
   }
-  getChannelData(channel: number): Float32Array { return this.channels[channel]; }
+  getChannelData(channel: number): Float32Array<ArrayBuffer> { return this.channels[channel]; }
   copyFromChannel(dest: Float32Array, channel: number, offset = 0) {
     dest.set(this.channels[channel].subarray(offset, offset + dest.length));
   }

--- a/src/hooks/__tests__/useAudioVisualization.test.ts
+++ b/src/hooks/__tests__/useAudioVisualization.test.ts
@@ -227,7 +227,7 @@ describe("useAudioVisualization", () => {
     const blob = createAudioBlob("audio-for-reset");
     const { result, rerender } = renderHook(
       ({ file }: { file: Blob | null }) => useAudioVisualization(file),
-      { initialProps: { file: blob } }
+      { initialProps: { file: blob as Blob | null } }
     );
 
     await waitFor(() => {

--- a/src/lib/chat/tools.test.ts
+++ b/src/lib/chat/tools.test.ts
@@ -280,7 +280,7 @@ describe("createChatTools", () => {
     it("execute returns { answer } when called", async () => {
       const tools = createChatTools(nodeIds);
 
-      const result = await tools.answerQuestion.execute(
+      const result = await tools.answerQuestion.execute!(
         { answer: "Use the Resolution dropdown on the Generate node." },
         { toolCallId: "test", messages: [], abortSignal: undefined as any }
       );
@@ -301,7 +301,7 @@ describe("createChatTools", () => {
     it("execute returns { description } when called", async () => {
       const tools = createChatTools(nodeIds);
 
-      const result = await tools.createWorkflow.execute(
+      const result = await tools.createWorkflow.execute!(
         { description: "A workflow for batch image processing" },
         { toolCallId: "test", messages: [], abortSignal: undefined as any }
       );
@@ -327,7 +327,7 @@ describe("createChatTools", () => {
         { type: "removeNode" as const, nodeId: "out-1" },
       ];
 
-      const result = await tools.editWorkflow.execute(
+      const result = await tools.editWorkflow.execute!(
         {
           operations: testOps,
           explanation: "Added prompt and removed output",
@@ -337,8 +337,10 @@ describe("createChatTools", () => {
 
       expect(result).toHaveProperty("operations");
       expect(result).toHaveProperty("explanation");
-      expect(result.explanation).toBe("Added prompt and removed output");
-      expect(result.operations).toHaveLength(2);
+      // Narrow: execute returns plain object (not AsyncIterable) in these tests
+      const syncResult = result as { operations: unknown[]; explanation: string };
+      expect(syncResult.explanation).toBe("Added prompt and removed output");
+      expect(syncResult.operations).toHaveLength(2);
     });
   });
 });

--- a/src/store/__tests__/workflowStore.integration.test.ts
+++ b/src/store/__tests__/workflowStore.integration.test.ts
@@ -2297,10 +2297,12 @@ describe("workflowStore integration tests", () => {
 
         const store = useWorkflowStore.getState();
         await store.loadWorkflow({
+          version: 1,
           id: "test-workflow",
           name: "Test",
           nodes: [],
           edges: [],
+          edgeStyle: "curved",
         });
 
         expect(useWorkflowStore.getState().viewedCommentNodeIds.size).toBe(0);

--- a/src/store/utils/__tests__/buildApiHeaders.test.ts
+++ b/src/store/utils/__tests__/buildApiHeaders.test.ts
@@ -12,7 +12,7 @@ function makeSettings(overrides: Partial<Record<string, { apiKey: string | null 
     openai: { id: "openai", name: "OpenAI", enabled: true, apiKey: null },
   };
   for (const [key, val] of Object.entries(overrides)) {
-    if (defaults[key]) {
+    if (defaults[key] && val !== undefined) {
       defaults[key].apiKey = val.apiKey;
     }
   }

--- a/src/store/utils/__tests__/localStorage.test.ts
+++ b/src/store/utils/__tests__/localStorage.test.ts
@@ -81,8 +81,9 @@ describe("localStorage utilities", () => {
       const config = {
         workflowId: "wf_456",
         name: "New Workflow",
-        path: "/path/to/new",
-        lastSaved: Date.now(),
+        directoryPath: "/path/to/new",
+        generationsPath: null,
+        lastSavedAt: Date.now(),
       };
 
       saveSaveConfig(config);
@@ -95,8 +96,9 @@ describe("localStorage utilities", () => {
       const existingConfig = {
         workflowId: "wf_existing",
         name: "Existing",
-        path: "/existing",
-        lastSaved: Date.now(),
+        directoryPath: "/existing",
+        generationsPath: null,
+        lastSavedAt: Date.now(),
       };
       localStorageMock.setItem(
         STORAGE_KEY,
@@ -106,8 +108,9 @@ describe("localStorage utilities", () => {
       const newConfig = {
         workflowId: "wf_new",
         name: "New",
-        path: "/new",
-        lastSaved: Date.now(),
+        directoryPath: "/new",
+        generationsPath: null,
+        lastSavedAt: Date.now(),
       };
       saveSaveConfig(newConfig);
 
@@ -154,7 +157,7 @@ describe("localStorage utilities", () => {
 
   describe("saveWorkflowCostData", () => {
     it("stores cost data", () => {
-      const costData = { workflowId: "wf_789", totalCost: 2.5 };
+      const costData = { workflowId: "wf_789", incurredCost: 2.5, lastUpdated: Date.now() };
 
       saveWorkflowCostData(costData);
 
@@ -327,7 +330,7 @@ describe("localStorage utilities", () => {
     it("stores config to localStorage", () => {
       const config = {
         generateVideo: {
-          selectedModel: { provider: "replicate", modelId: "video-model", displayName: "Video Model" },
+          selectedModel: { provider: "replicate" as const, modelId: "video-model", displayName: "Video Model" },
         },
       };
 


### PR DESCRIPTION
## Summary
- `npx tsc --noEmit` failed with ~298 errors, all in test files — fixture drift against current types (incomplete `NodeProps`, missing `anthropic` provider entries, renamed `WorkflowCostData`/`WorkflowSaveConfig` fields, TS2556 mock-factory spreads). All fixed test-side; zero production source changes.
- Adds `"typecheck": "tsc --noEmit"` to package.json and a Type check step to CI.
- No `@ts-ignore`/`@ts-expect-error`/`any` introduced; no assertions weakened, no tests skipped.

## Verification
- `pnpm typecheck` → exit 0
- Full suite: 2696/2697 — only the two known pre-existing failures (open-file jsdom env, social automation rules 400-vs-200)

Implements advisor-plans/004 (executor + advisor review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)