### PR TITLE
test: MSW harness + X provider contract tests (#111)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "baseline-browser-mapping": "^2.10.12",
     "drizzle-kit": "^0.31.10",
     "jsdom": "^27.4.0",
+    "msw": "^2.12.14",
     "typescript": "5.9.3",
     "vite-tsconfig-paths": "^6.0.4",
     "vitest": "^4.0.16"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0
+      msw:
+        specifier: ^2.12.14
+        version: 2.12.14(@types/node@24.10.1)(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -2944,6 +2947,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@use-gesture/core@10.3.1':
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}

--- a/src/lib/social/providers/__tests__/x.contract.test.ts
+++ b/src/lib/social/providers/__tests__/x.contract.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment node
+
+/**
+ * X (Twitter) provider CONTRACT tests (MSW).
+ *
+ * Unlike `x.test.ts` — which replaces `twitter-api-v2` wholesale with `vi.mock`
+ * — these tests exercise the *real* SDK and the provider's real request/response
+ * handling, intercepting HTTP at the network boundary with MSW. That means the
+ * OAuth 1.0a signing, URL construction, JSON (de)serialisation, and — crucially
+ * — the `twitter-api-v2` error objects fed into `classifyError()` are all real.
+ *
+ * Scenario classes (the contract every provider must satisfy):
+ *   1. successful post publish
+ *   2. token-refresh trigger path        (401 → "refresh-token")
+ *   3. rate-limit retry classification   (429 → "retry")
+ *   4. permanent-failure classification  (403 duplicate → "bad-body")
+ *
+ * The provider code is intentionally UNMODIFIED.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { xProvider } from "@/lib/social/providers/x";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// X platform endpoints exercised by xProvider.post()
+// (see node_modules/twitter-api-v2 globals: API_V2_PREFIX = https://api.x.com/2/)
+// ---------------------------------------------------------------------------
+
+const X_API = "https://api.x.com/2";
+const TWEETS_URL = `${X_API}/tweets`;
+const ME_URL = `${X_API}/users/me`;
+
+// Access token is stored by the provider as "token:secret".
+const ACCESS_TOKEN = "acc-token:acc-secret";
+
+const textPost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+};
+
+// ---------------------------------------------------------------------------
+// MSW server — default handlers describe the HAPPY PATH; individual tests
+// override with server.use(...) to inject platform failures.
+// ---------------------------------------------------------------------------
+
+const server = setupMswServer(
+  http.post(TWEETS_URL, () =>
+    HttpResponse.json({ data: { id: "tweet-123", text: textPost.content } }),
+  ),
+  http.get(ME_URL, () =>
+    HttpResponse.json({ data: { id: "user-1", username: "contractbot" } }),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.X_API_KEY = "test-api-key";
+  process.env.X_API_SECRET = "test-api-secret";
+});
+
+afterEach(() => {
+  delete process.env.X_API_KEY;
+  delete process.env.X_API_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("xProvider contract — successful post publish", () => {
+  it("publishes a text tweet against the live X HTTP contract", async () => {
+    const results = await xProvider.post("user-1", ACCESS_TOKEN, [textPost]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "tweet-123",
+      platformPostUrl: "https://x.com/contractbot/status/tweet-123",
+      status: "published",
+    });
+  });
+});
+
+/**
+ * Helper: run a publish that the platform rejects, and return the *real*
+ * `twitter-api-v2` error object the provider threw. This is what the publish
+ * pipeline actually catches and hands to `classifyError()` — no synthetic
+ * `new Error("429 ...")` strings.
+ */
+async function captureThrownError(): Promise<unknown> {
+  return xProvider.post("user-1", ACCESS_TOKEN, [textPost]).then(
+    () => {
+      throw new Error("expected post() to reject, but it resolved");
+    },
+    (err: unknown) => err,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path (HTTP 401)
+// ---------------------------------------------------------------------------
+
+describe("xProvider contract — token-refresh trigger", () => {
+  it("classifies a real 401 from the tweet endpoint as refresh-token", async () => {
+    server.use(
+      http.post(TWEETS_URL, () =>
+        HttpResponse.json(
+          {
+            title: "Unauthorized",
+            detail: "Unauthorized",
+            type: "about:blank",
+            status: 401,
+          },
+          { status: 401 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = xProvider.classifyError(error);
+
+    expect(classified.type).toBe("refresh-token");
+    // The real SDK error is preserved for the pipeline / logs.
+    expect(classified.original).toBe(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification (HTTP 429)
+// ---------------------------------------------------------------------------
+
+describe("xProvider contract — rate-limit retry", () => {
+  it("classifies a real 429 from the tweet endpoint as retry", async () => {
+    server.use(
+      http.post(TWEETS_URL, () =>
+        HttpResponse.json(
+          { title: "Too Many Requests", detail: "Too Many Requests" },
+          {
+            status: 429,
+            headers: {
+              "x-rate-limit-limit": "50",
+              "x-rate-limit-remaining": "0",
+              "x-rate-limit-reset": "9999999999",
+            },
+          },
+        ),
+      ),
+    );
+
+    // Sanity-check the real SDK error carried the 429 before classifying, so a
+    // generic "unknown → retry" fallback can't masquerade as rate-limit handling.
+    const error = await captureThrownError();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("429");
+
+    const classified = xProvider.classifyError(error);
+
+    expect(classified.type).toBe("retry");
+    // Distinct rate-limit message — NOT the default retry fallback (which echoes
+    // the raw error text) — proving the 429 branch fired.
+    expect(classified.message).toBe("X rate limit reached. Will retry shortly.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification (HTTP 403 duplicate content)
+// ---------------------------------------------------------------------------
+
+describe("xProvider contract — permanent-failure", () => {
+  it("classifies a real 403 duplicate-content rejection as bad-body", async () => {
+    server.use(
+      http.post(TWEETS_URL, () =>
+        HttpResponse.json(
+          {
+            title: "Forbidden",
+            detail:
+              "You are not allowed to create a Tweet with duplicate content.",
+            type: "about:blank",
+            errors: [
+              { message: "You are not allowed to create a Tweet with duplicate content." },
+            ],
+          },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = xProvider.classifyError(error);
+
+    expect(classified.type).toBe("bad-body");
+  });
+});

--- a/src/test/msw/README.md
+++ b/src/test/msw/README.md
@@ -1,0 +1,120 @@
+# Social-provider contract tests (MSW)
+
+This directory holds the **opt-in** MSW (Mock Service Worker) harness used to
+contract-test the social provider adapters in
+`src/lib/social/providers/*.ts` against **mocked platform HTTP** instead of
+`vi.mock` stubs.
+
+- **Harness:** [`server.ts`](./server.ts) — `setupMswServer(...handlers)`
+- **Reference implementation:** [`../../lib/social/providers/__tests__/x.contract.test.ts`](../../lib/social/providers/__tests__/x.contract.test.ts)
+
+Issue #112 replicates this pattern for the eight remaining providers. Follow the
+recipe below — it is intentionally mechanical.
+
+---
+
+## Why a second, separate test style?
+
+Each provider already has a `*.test.ts` that replaces the vendor SDK wholesale
+(`vi.mock("twitter-api-v2")`, `vi.mock("googleapis")`, …). Those are fast unit
+tests but they assert against a **hand-written fake** of the platform, so they
+can't catch a mismatch between what the SDK actually sends/receives and what the
+provider expects.
+
+The **contract** tests fill that gap. They run the *real* SDK / `fetch` code and
+intercept HTTP at the network boundary, so the request signing, URL building,
+JSON (de)serialisation, and — most importantly — the **real error objects** fed
+into `classifyError()` are all exercised. When the platform SDK is upgraded, or
+an API returns a shape we didn't expect, these tests are what break.
+
+The two styles live side by side; the contract file is always named
+`*.contract.test.ts`.
+
+---
+
+## Why the harness is opt-in (not global)
+
+`vitest.config.ts` `setupFiles` is deliberately **not** touched. ~2,460 existing
+tests mock the network with `vi.stubGlobal("fetch", ...)` / `vi.mock(...)`, and a
+globally-active MSW interceptor would fight those stubs. Instead each contract
+file calls `setupMswServer(...)`, which scopes MSW's `beforeAll`/`afterEach`/
+`afterAll` lifecycle to that file only. Nothing outside a `*.contract.test.ts`
+is affected.
+
+`setupMswServer` starts with `onUnhandledRequest: "error"`, so any outbound
+request that isn't explicitly mocked **fails the test** — a contract test can
+never silently reach the real platform.
+
+---
+
+## The four scenario classes (the contract)
+
+Every provider contract file must cover these four, because they map 1:1 to the
+publish pipeline's retry semantics (`SocialErrorType` in `provider-interface.ts`):
+
+| # | Scenario                  | What it proves                                              | Expected `classifyError().type` |
+|---|---------------------------|------------------------------------------------------------|---------------------------------|
+| 1 | **successful post publish** | A happy-path `post()` returns the right `PublishResult`.   | — (no error)                    |
+| 2 | **token-refresh trigger**   | A real `401`/auth error is classified for re-auth.         | `refresh-token`                 |
+| 3 | **rate-limit retry**        | A real `429` is classified as transient + retried.         | `retry`                         |
+| 4 | **permanent-failure**       | A real content rejection (duplicate/policy) fails fast.    | `bad-body`                      |
+
+For scenarios 2–4 the pattern is always: **drive `post()` → let the real SDK
+throw → hand the caught error to `classifyError()` → assert the type.** Never
+construct a synthetic `new Error("429 ...")`; the whole point is to feed
+`classifyError()` the *real* error the platform produces.
+
+> Guard against false positives: the default `classifyError()` bucket is also
+> `"retry"`, so the rate-limit test additionally asserts the error text contains
+> the status and that the returned `message` is the distinct rate-limit copy —
+> otherwise an unrelated failure could pass as "rate-limit handling".
+
+---
+
+## Recipe for a new provider (issue #112)
+
+1. **Find the platform's real base URLs and endpoints.** Read the SDK the
+   provider imports (or its `fetch` calls). For SDKs, grep the package for its
+   URL constants, e.g. for X:
+   ```bash
+   grep -rn "PREFIX\|api\." node_modules/<sdk>/dist/**/globals.js
+   ```
+   Note the create-post endpoint, the "who am I" endpoint (if used for the post
+   URL), and any media-upload endpoints.
+
+2. **Learn the SDK's error shape.** Find where it throws on non-2xx and what the
+   `.message` looks like — that string is what `classifyError()` pattern-matches.
+   For `twitter-api-v2` it is `"Request failed with code <status> - <title>: <detail>"`.
+   Craft your error-response bodies so the resulting message contains the tokens
+   the provider's `classifyError()` looks for (`429`, `401`, `duplicate`, …).
+
+3. **Copy `x.contract.test.ts`** to `<provider>.contract.test.ts` and adapt:
+   - Keep the `// @vitest-environment node` docblock on line 1. Providers use
+     Node HTTP/SDKs; the `node` environment avoids jsdom's `fetch`/DOM
+     interfering with interception. (Providers that are pure `fetch` also work
+     in `node`.)
+   - Replace the endpoint constants and the happy-path default handlers passed
+     to `setupMswServer(...)`.
+   - Set whatever env vars the provider reads (API keys/secrets) in
+     `beforeEach`, and `clearRegistry()` so module-load registration is clean.
+   - Override per-scenario with `server.use(http.<method>(URL, () => HttpResponse.json(..., { status }))))`.
+
+4. **Do NOT modify provider code.** If a contract test can only pass by changing
+   the provider, you've found a real defect — report it, don't paper over it.
+
+5. **Run just your file while iterating**, then the whole suite before finishing:
+   ```bash
+   npx vitest run src/lib/social/providers/__tests__/<provider>.contract.test.ts
+   pnpm test:run
+   ```
+
+## Notes / gotchas
+
+- **Media uploads** (X `v2.uploadMedia`, etc.) use multi-step *chunked* upload
+  endpoints (`media/upload/initialize|append|finalize`) and require the real
+  image bytes to survive `sharp`. The X contract file covers the text-only happy
+  path (no `sharp`, single `tweets` call) plus the three error paths, which is
+  sufficient for the four contract classes. If you add a media happy-path test,
+  mock every step of the chunked flow and feed `sharp` a real (tiny) image.
+- `onUnhandledRequest: "error"` means you must mock **every** endpoint the flow
+  touches (e.g. X's post path also calls `users/me` for the post URL).

--- a/src/test/msw/server.ts
+++ b/src/test/msw/server.ts
@@ -1,0 +1,51 @@
+/**
+ * MSW (Mock Service Worker) Node harness for social-provider contract tests.
+ *
+ * This is deliberately OPT-IN: it is NOT wired into the global Vitest
+ * `setupFiles` (see `vitest.config.ts`). The vast majority of the suite mocks
+ * the network with `vi.mock` / `vi.stubGlobal("fetch", ...)`, and a globally
+ * active request interceptor would fight those stubs. Contract tests that want
+ * real request/response handling call `setupMswServer()` from inside their own
+ * file, which scopes the interceptor to that file's lifecycle only.
+ *
+ * See `src/test/msw/README.md` for the per-provider contract-test pattern.
+ */
+
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { setupServer, type SetupServerApi } from "msw/node";
+import type { RequestHandler } from "msw";
+
+/**
+ * Create a scoped MSW server for the calling test file and register its
+ * Vitest lifecycle hooks.
+ *
+ * - `beforeAll`  → start intercepting; `onUnhandledRequest: "error"` makes any
+ *                  un-mocked outbound request fail the test loudly, so a
+ *                  contract test can never accidentally hit the real platform.
+ * - `afterEach`  → reset to the default handlers so per-test `server.use(...)`
+ *                  overrides do not leak between tests.
+ * - `afterAll`   → stop intercepting and restore the network.
+ *
+ * @param defaultHandlers Handlers applied to every test in the file. Individual
+ *   tests layer scenario-specific overrides with `server.use(...)`.
+ * @returns The MSW server instance (for `server.use(...)` overrides).
+ */
+export function setupMswServer(
+  ...defaultHandlers: RequestHandler[]
+): SetupServerApi {
+  const server = setupServer(...defaultHandlers);
+
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: "error" });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  return server;
+}


### PR DESCRIPTION
Closes #111. Part of PRD #100.

Adds opt-in MSW Node contract-testing infrastructure (`src/test/msw/server.ts` + pattern README) and proves it on the X provider: 4 contract tests (successful publish, token-refresh on 401, rate-limit retry on 429, permanent-failure classification on 403) exercising the real twitter-api-v2 SDK end-to-end against MSW-intercepted HTTP. Provider code unmodified; no defects found.

MSW is deliberately NOT global — existing suites stub the network with vi.mock and would fight a global interceptor. Each contract file scopes MSW to its own lifecycle.

Verified: full suite green; contract tests re-run by reviewer.

Note: `pnpm lint` is broken at the develop base (Next 16 removed `next lint`, no ESLint config) — unrelated, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)