### PR TITLE
feat: cleanly gate social platforms without configured credentials (#114)

### DIFF
--- a/src/app/api/social/accounts/__tests__/route.test.ts
+++ b/src/app/api/social/accounts/__tests__/route.test.ts
@@ -17,6 +17,7 @@ const mockCountActiveSocialAccounts = vi.fn();
 const mockUpsertSocialAccount = vi.fn();
 const mockGetProvider = vi.fn();
 const mockIsProviderRegistered = vi.fn();
+const mockIsPlatformConfigured = vi.fn();
 const mockEncryptToken = vi.fn();
 const mockDecryptToken = vi.fn();
 
@@ -68,6 +69,10 @@ vi.mock("@/lib/social/provider-registry", () => ({
   clearRegistry: vi.fn(),
   getProvider: (...args: unknown[]) => mockGetProvider(...args),
   isProviderRegistered: (...args: unknown[]) => mockIsProviderRegistered(...args),
+}));
+
+vi.mock("@/lib/social/platform-config", () => ({
+  isPlatformConfigured: (...args: unknown[]) => mockIsPlatformConfigured(...args),
 }));
 
 vi.mock("@/lib/social/crypto", () => ({
@@ -153,6 +158,7 @@ describe("/api/social/accounts GET", () => {
 describe("/api/social/accounts/connect POST", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsPlatformConfigured.mockReturnValue(true);
   });
 
   it("returns 401 for unauthenticated requests", async () => {
@@ -196,6 +202,30 @@ describe("/api/social/accounts/connect POST", () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toContain("not available");
+  });
+
+  it("returns 400 for a registered but unconfigured platform, without leaking env var names", async () => {
+    authorized();
+    mockIsProviderRegistered.mockReturnValue(true);
+    mockIsPlatformConfigured.mockReturnValue(false);
+
+    const { POST } = await import("../../accounts/connect/route");
+    const response = await POST(
+      createRequest("http://localhost:3000/api/social/accounts/connect", {
+        method: "POST",
+        body: JSON.stringify({ platform: "x" }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.code).toBe("platform_not_configured");
+    expect(data.error).toContain("not configured");
+    expect(JSON.stringify(data)).not.toMatch(/X_API_KEY|X_API_SECRET|_CLIENT_ID|_CLIENT_SECRET/);
+    // Must never reach the provider (no dead-end mid-OAuth attempt)
+    expect(mockGetProvider).not.toHaveBeenCalled();
+    expect(mockCreateOAuthState).not.toHaveBeenCalled();
   });
 
   it("returns authUrl for valid platform", async () => {

--- a/src/app/api/social/accounts/connect/route.ts
+++ b/src/app/api/social/accounts/connect/route.ts
@@ -4,6 +4,7 @@ import { isDatabaseConfigured } from "@/lib/db";
 import { withApiPermission } from "@/lib/studio/authz";
 import "@/lib/social/runtime-bootstrap";
 import { getProvider, isProviderRegistered } from "@/lib/social/provider-registry";
+import { isPlatformConfigured } from "@/lib/social/platform-config";
 import { getSocialPlanLimits, quotaExceededPayload } from "@/lib/social/limits";
 import {
   countActiveSocialAccounts,
@@ -61,6 +62,17 @@ export async function POST(
     if (!isProviderRegistered(body.platform)) {
       return NextResponse.json(
         { success: false, error: `Platform "${body.platform}" is not available.` },
+        { status: 400 },
+      );
+    }
+
+    if (!isPlatformConfigured(body.platform as SocialPlatform)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Platform "${body.platform}" is not configured on this server. Contact your administrator to enable it.`,
+          code: "platform_not_configured",
+        },
         { status: 400 },
       );
     }

--- a/src/app/api/social/providers/__tests__/route.test.ts
+++ b/src/app/api/social/providers/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import type { ProviderCapabilities } from "@/lib/social/provider-interface";
+
+const mockListProviderCapabilities = vi.fn<() => ProviderCapabilities[]>();
+
+vi.mock("@/lib/social/provider-registry", () => ({
+  registerProvider: vi.fn(),
+  clearRegistry: vi.fn(),
+  listProviderCapabilities: (...args: unknown[]) =>
+    mockListProviderCapabilities(...(args as [])),
+}));
+
+function createRequest(): NextRequest {
+  return new NextRequest("http://localhost:3000/api/social/providers");
+}
+
+describe("GET /api/social/providers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports configured: true when a platform's env vars are set", async () => {
+    mockListProviderCapabilities.mockReturnValue([
+      {
+        identifier: "x",
+        displayName: "X (Twitter)",
+        maxContentLength: 280,
+        supportsImages: true,
+        supportsVideo: false,
+        supportsCarousel: false,
+        requiresPageSelection: false,
+        configured: true,
+      },
+    ]);
+
+    const { GET } = await import("../route");
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.providers).toHaveLength(1);
+    expect(data.providers[0]).toMatchObject({ identifier: "x", configured: true });
+  });
+
+  it("reports configured: false for a platform missing its env vars, without leaking var names or values", async () => {
+    mockListProviderCapabilities.mockReturnValue([
+      {
+        identifier: "x",
+        displayName: "X (Twitter)",
+        maxContentLength: 280,
+        supportsImages: true,
+        supportsVideo: false,
+        supportsCarousel: false,
+        requiresPageSelection: false,
+        configured: false,
+      },
+    ]);
+
+    const { GET } = await import("../route");
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.providers[0]).toMatchObject({ identifier: "x", configured: false });
+    expect(JSON.stringify(data)).not.toMatch(/X_API_KEY|X_API_SECRET|_CLIENT_ID|_CLIENT_SECRET/);
+  });
+
+  it("reports platforms with no server credential requirement as always configured", async () => {
+    mockListProviderCapabilities.mockReturnValue([
+      {
+        identifier: "bluesky",
+        displayName: "Bluesky",
+        maxContentLength: 300,
+        supportsImages: true,
+        supportsVideo: false,
+        supportsCarousel: false,
+        requiresPageSelection: false,
+        configured: true,
+      },
+    ]);
+
+    const { GET } = await import("../route");
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(data.providers[0]).toMatchObject({ identifier: "bluesky", configured: true });
+  });
+
+  it("returns 500 with an error message if listing providers throws", async () => {
+    mockListProviderCapabilities.mockImplementation(() => {
+      throw new Error("registry exploded");
+    });
+
+    const { GET } = await import("../route");
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toContain("registry exploded");
+  });
+});

--- a/src/components/social/PlatformPicker.tsx
+++ b/src/components/social/PlatformPicker.tsx
@@ -105,7 +105,9 @@ export function PlatformPicker({ open, onOpenChange }: PlatformPickerProps) {
     }
   }, [open, providers.length, showToast])
 
-  async function handleConnect(platform: string) {
+  async function handleConnect(platform: string, configured: boolean) {
+    if (!configured) return
+
     if (platform === "bluesky") {
       setBlueskyModalOpen(true)
       return
@@ -152,15 +154,22 @@ export function PlatformPicker({ open, onOpenChange }: PlatformPickerProps) {
     }
   }
 
-  const platforms: Array<{ identifier: SocialPlatform; name: string }> =
+  const platforms: Array<{
+    identifier: SocialPlatform
+    name: string
+    configured: boolean
+  }> =
     providers.length > 0
       ? providers.map((p) => ({
           identifier: p.identifier,
           name: p.displayName,
+          // Non-standard-OAuth platforms (bluesky, mastodon) and any
+          // provider that doesn't report a status default to connectable.
+          configured: p.configured !== false,
         }))
       : (
           ["linkedin", "instagram", "x", "tiktok", "facebook", "youtube"] as const
-        ).map((id) => ({ identifier: id, name: PLATFORM_LABELS[id] }))
+        ).map((id) => ({ identifier: id, name: PLATFORM_LABELS[id], configured: true }))
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -177,8 +186,13 @@ export function PlatformPicker({ open, onOpenChange }: PlatformPickerProps) {
             return (
               <button
                 key={platform.identifier}
-                onClick={() => handleConnect(platform.identifier)}
-                disabled={!!connectingPlatform}
+                onClick={() => handleConnect(platform.identifier, platform.configured)}
+                disabled={!platform.configured || !!connectingPlatform}
+                title={
+                  platform.configured
+                    ? undefined
+                    : `${platform.name} is not configured on this server. Contact your administrator to enable it.`
+                }
                 className="flex flex-col items-center gap-2 rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <div className="flex size-9 items-center justify-center rounded-lg bg-muted">
@@ -187,6 +201,11 @@ export function PlatformPicker({ open, onOpenChange }: PlatformPickerProps) {
                 <span className="text-xs font-medium">
                   {isConnecting ? "Connecting..." : platform.name}
                 </span>
+                {!platform.configured && (
+                  <span className="text-[10px] leading-none text-muted-foreground">
+                    Not configured
+                  </span>
+                )}
               </button>
             )
           })}

--- a/src/components/social/__tests__/PlatformPicker.test.tsx
+++ b/src/components/social/__tests__/PlatformPicker.test.tsx
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { ProviderCapabilities } from "@/lib/social/provider-interface";
+
+const mockListSocialProviders = vi.fn<() => Promise<ProviderCapabilities[]>>();
+const mockConnectSocialAccount = vi.fn();
+const mockFetchAccounts = vi.fn();
+
+vi.mock("@/lib/social/client", () => ({
+  listSocialProviders: (...args: unknown[]) =>
+    mockListSocialProviders(...(args as [])),
+  connectSocialAccount: (...args: unknown[]) =>
+    mockConnectSocialAccount(...(args as [])),
+}));
+
+vi.mock("@/store/socialAccountsStore", () => ({
+  useSocialAccountsStore: () => ({ fetchAccounts: mockFetchAccounts }),
+}));
+
+function twoProviders(): ProviderCapabilities[] {
+  return [
+    {
+      identifier: "x",
+      displayName: "X",
+      maxContentLength: 280,
+      supportsImages: true,
+      supportsVideo: false,
+      supportsCarousel: false,
+      requiresPageSelection: false,
+      configured: true,
+    },
+    {
+      identifier: "linkedin",
+      displayName: "LinkedIn",
+      maxContentLength: 3000,
+      supportsImages: true,
+      supportsVideo: true,
+      supportsCarousel: true,
+      requiresPageSelection: true,
+      configured: false,
+    },
+  ];
+}
+
+describe("PlatformPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a configured platform as connectable", async () => {
+    mockListSocialProviders.mockResolvedValue(twoProviders());
+    const { PlatformPicker } = await import("@/components/social/PlatformPicker");
+
+    render(<PlatformPicker open={true} onOpenChange={() => {}} />);
+
+    const xButton = await screen.findByRole("button", { name: /^X$/ });
+    expect(xButton).not.toBeDisabled();
+  });
+
+  it("renders an unconfigured platform as disabled with an explanatory state", async () => {
+    mockListSocialProviders.mockResolvedValue(twoProviders());
+    const { PlatformPicker } = await import("@/components/social/PlatformPicker");
+
+    render(<PlatformPicker open={true} onOpenChange={() => {}} />);
+
+    const linkedinButton = await screen.findByRole("button", { name: /LinkedIn/ });
+    expect(linkedinButton).toBeDisabled();
+    expect(screen.getByText(/not configured/i)).toBeInTheDocument();
+  });
+
+  it("never starts an OAuth connect for an unconfigured platform", async () => {
+    mockListSocialProviders.mockResolvedValue(twoProviders());
+    const { PlatformPicker } = await import("@/components/social/PlatformPicker");
+
+    render(<PlatformPicker open={true} onOpenChange={() => {}} />);
+
+    const linkedinButton = await screen.findByRole("button", { name: /LinkedIn/ });
+    fireEvent.click(linkedinButton);
+
+    await waitFor(() => {
+      expect(mockConnectSocialAccount).not.toHaveBeenCalled();
+    });
+  });
+
+  it("starts an OAuth connect when a configured platform is clicked", async () => {
+    mockListSocialProviders.mockResolvedValue(twoProviders());
+    mockConnectSocialAccount.mockResolvedValue({ authUrl: "https://x.com/oauth" });
+    const { PlatformPicker } = await import("@/components/social/PlatformPicker");
+
+    render(<PlatformPicker open={true} onOpenChange={() => {}} />);
+
+    const xButton = await screen.findByRole("button", { name: /^X$/ });
+    fireEvent.click(xButton);
+
+    await waitFor(() => {
+      expect(mockConnectSocialAccount).toHaveBeenCalledWith("x");
+    });
+  });
+});

--- a/src/lib/social/__tests__/platform-config.test.ts
+++ b/src/lib/social/__tests__/platform-config.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for per-platform server OAuth credential configuration checks.
+ *
+ * These never assert on env var *values* — only presence — since the whole
+ * point of this module is to report configured status without leaking
+ * secrets.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isPlatformConfigured } from "@/lib/social/platform-config";
+
+describe("isPlatformConfigured", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns false for x when X_API_KEY / X_API_SECRET are unset", () => {
+    expect(isPlatformConfigured("x")).toBe(false);
+  });
+
+  it("returns true for x when both X_API_KEY and X_API_SECRET are set", () => {
+    vi.stubEnv("X_API_KEY", "key");
+    vi.stubEnv("X_API_SECRET", "secret");
+    expect(isPlatformConfigured("x")).toBe(true);
+  });
+
+  it("returns false when only one of two required vars is set", () => {
+    vi.stubEnv("LINKEDIN_CLIENT_ID", "id");
+    // LINKEDIN_CLIENT_SECRET intentionally left unset
+    expect(isPlatformConfigured("linkedin")).toBe(false);
+  });
+
+  it("treats blank/whitespace-only env vars as not configured", () => {
+    vi.stubEnv("PINTEREST_CLIENT_ID", "   ");
+    vi.stubEnv("PINTEREST_CLIENT_SECRET", "secret");
+    expect(isPlatformConfigured("pinterest")).toBe(false);
+  });
+
+  it("shares META_APP_ID/META_APP_SECRET across instagram, facebook, and threads", () => {
+    vi.stubEnv("META_APP_ID", "id");
+    vi.stubEnv("META_APP_SECRET", "secret");
+    expect(isPlatformConfigured("instagram")).toBe(true);
+    expect(isPlatformConfigured("facebook")).toBe(true);
+    expect(isPlatformConfigured("threads")).toBe(true);
+  });
+
+  it("returns true for bluesky and mastodon regardless of env (no server credentials required)", () => {
+    expect(isPlatformConfigured("bluesky")).toBe(true);
+    expect(isPlatformConfigured("mastodon")).toBe(true);
+  });
+});

--- a/src/lib/social/__tests__/provider-registry.test.ts
+++ b/src/lib/social/__tests__/provider-registry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearRegistry,
   getProvider,
@@ -59,6 +59,7 @@ function createMockProvider(
 describe("provider-registry", () => {
   afterEach(() => {
     clearRegistry();
+    vi.unstubAllEnvs();
   });
 
   describe("registerProvider", () => {
@@ -117,7 +118,9 @@ describe("provider-registry", () => {
   });
 
   describe("listProviderCapabilities", () => {
-    it("returns capabilities for all providers", () => {
+    it("returns capabilities for all providers, annotated with configured status", () => {
+      vi.stubEnv("LINKEDIN_CLIENT_ID", "id");
+      vi.stubEnv("LINKEDIN_CLIENT_SECRET", "secret");
       registerProvider(createMockProvider());
       const capabilities = listProviderCapabilities();
       expect(capabilities).toHaveLength(1);
@@ -129,7 +132,33 @@ describe("provider-registry", () => {
         supportsVideo: true,
         supportsCarousel: true,
         requiresPageSelection: true,
+        configured: true,
       });
+    });
+
+    it("marks a platform as not configured when its env vars are unset", () => {
+      registerProvider(createMockProvider());
+      const capabilities = listProviderCapabilities();
+      expect(capabilities[0].configured).toBe(false);
+    });
+
+    it("always reports bluesky and mastodon as configured (no server credentials needed)", () => {
+      registerProvider(
+        createMockProvider({
+          identifier: "bluesky",
+          getCapabilities: () => ({
+            identifier: "bluesky" as const,
+            displayName: "Bluesky",
+            maxContentLength: 300,
+            supportsImages: true,
+            supportsVideo: false,
+            supportsCarousel: false,
+            requiresPageSelection: false,
+          }),
+        }),
+      );
+      const capabilities = listProviderCapabilities();
+      expect(capabilities[0].configured).toBe(true);
     });
   });
 

--- a/src/lib/social/platform-config.ts
+++ b/src/lib/social/platform-config.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-platform server OAuth credential configuration.
+ *
+ * Some social platforms (X, LinkedIn, Meta, TikTok, YouTube/Google, Reddit,
+ * Pinterest) require a developer app registered by the operator, whose
+ * client id/secret are supplied via environment variables (see
+ * .env.example). Others (Bluesky, Mastodon) never need server-side
+ * credentials — the user supplies their own at connect time.
+ *
+ * This module only ever checks *presence* of the required env vars. It
+ * never reads, logs, or exposes their values — callers get a boolean.
+ */
+import type { SocialPlatform } from "@/lib/db/schema";
+
+/**
+ * Env var names required for each platform's server-side OAuth app
+ * credentials. Instagram, Facebook, and Threads share a single Meta app
+ * (META_APP_ID / META_APP_SECRET). Platforms absent from this map (bluesky,
+ * mastodon) don't require any server credentials and are always considered
+ * configured.
+ */
+const PLATFORM_REQUIRED_ENV_VARS: Partial<
+  Record<SocialPlatform, readonly string[]>
+> = {
+  x: ["X_API_KEY", "X_API_SECRET"],
+  linkedin: ["LINKEDIN_CLIENT_ID", "LINKEDIN_CLIENT_SECRET"],
+  instagram: ["META_APP_ID", "META_APP_SECRET"],
+  facebook: ["META_APP_ID", "META_APP_SECRET"],
+  threads: ["META_APP_ID", "META_APP_SECRET"],
+  tiktok: ["TIKTOK_CLIENT_KEY", "TIKTOK_CLIENT_SECRET"],
+  youtube: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+  reddit: ["REDDIT_CLIENT_ID", "REDDIT_CLIENT_SECRET"],
+  pinterest: ["PINTEREST_CLIENT_ID", "PINTEREST_CLIENT_SECRET"],
+};
+
+/**
+ * Whether a platform's server-side OAuth app credentials are configured.
+ * Returns true for platforms that don't require any (bluesky, mastodon).
+ */
+export function isPlatformConfigured(platform: SocialPlatform): boolean {
+  const requiredVars = PLATFORM_REQUIRED_ENV_VARS[platform];
+  if (!requiredVars) return true;
+  return requiredVars.every((name) => Boolean(process.env[name]?.trim()));
+}
+
+/**
+ * List the env var names required for a platform (for error messages /
+ * diagnostics). Never returns values — only the var names.
+ */
+export function getRequiredEnvVarNames(
+  platform: SocialPlatform,
+): readonly string[] {
+  return PLATFORM_REQUIRED_ENV_VARS[platform] ?? [];
+}

--- a/src/lib/social/provider-interface.ts
+++ b/src/lib/social/provider-interface.ts
@@ -108,6 +108,12 @@ export interface PublishStatusResult {
 
 /**
  * Provider capabilities exposed to the UI (e.g., provider list endpoint).
+ *
+ * `configured` is NOT set by individual adapters' `getCapabilities()` —
+ * it's computed and injected by `listProviderCapabilities()` in
+ * provider-registry.ts, based on whether the platform's required server
+ * OAuth env vars are present (see platform-config.ts). It's optional here
+ * only so adapter implementations don't need to set it themselves.
  */
 export interface ProviderCapabilities {
   identifier: SocialPlatform;
@@ -117,6 +123,7 @@ export interface ProviderCapabilities {
   supportsVideo: boolean;
   supportsCarousel: boolean;
   requiresPageSelection: boolean;
+  configured?: boolean;
 }
 
 /**

--- a/src/lib/social/provider-registry.ts
+++ b/src/lib/social/provider-registry.ts
@@ -3,6 +3,7 @@ import type {
   ProviderCapabilities,
   SocialProviderAdapter,
 } from "@/lib/social/provider-interface";
+import { isPlatformConfigured } from "@/lib/social/platform-config";
 
 const registry = new Map<string, SocialProviderAdapter>();
 
@@ -40,9 +41,15 @@ export function listProviders(): SocialProviderAdapter[] {
 
 /**
  * List capabilities of all registered providers (for API responses).
+ * Each entry is annotated with `configured`, reflecting whether the
+ * platform's required server OAuth credentials are present in the
+ * environment. Never exposes credential values — only a boolean.
  */
 export function listProviderCapabilities(): ProviderCapabilities[] {
-  return listProviders().map((provider) => provider.getCapabilities());
+  return listProviders().map((provider) => ({
+    ...provider.getCapabilities(),
+    configured: isPlatformConfigured(provider.identifier),
+  }));
 }
 
 /**


### PR DESCRIPTION
Closes #114. Part of PRD #100.

Platforms whose OAuth app credentials aren't configured now show as cleanly gated instead of dead-ending mid-OAuth:

- `src/lib/social/platform-config.ts`: presence-only env checks per platform (Meta trio shares META_APP_*; bluesky/mastodon need no server app → always configured).
- `GET /api/social/providers` now returns `configured` per platform (computed in the registry; adapters untouched; no env names/values leak — covered by tests).
- Bug fix: `accounts/connect` previously threw a 500 that echoed the missing env var name (e.g. "X_API_KEY environment variable is not set"); now returns 400 `platform_not_configured` before any OAuth start.
- `PlatformPicker` renders unconfigured platforms disabled with a "Not configured" badge; connect short-circuits client-side too. Composer targeting needs no change (it lists only connected accounts, which can no longer exist for unconfigured platforms).

Verified: 18 new/updated tests green; full suite matches origin/develop baseline (2 pre-existing failures untouched, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)