### PR TITLE
feat: workspace-scoped API tokens + first public API endpoint (#101)

### DIFF
--- a/drizzle/0015_harsh_energizer.sql
+++ b/drizzle/0015_harsh_energizer.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "api_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"name" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"token_prefix" text NOT NULL,
+	"revoked" boolean DEFAULT false NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"last_used_at" timestamp with time zone,
+	"created_by_user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "api_tokens" ADD CONSTRAINT "api_tokens_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_tokens" ADD CONSTRAINT "api_tokens_created_by_user_id_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."user"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "api_tokens_token_hash_unique" ON "api_tokens" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX "api_tokens_workspace_idx" ON "api_tokens" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "api_tokens_created_at_idx" ON "api_tokens" USING btree ("created_at");

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,5478 @@
+{
+  "id": "68f3b187-73ad-4e07-a499-10d1e311da14",
+  "prevId": "5875b696-7d8c-41e7-a7ed-8ba9ad8cbc1a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_workspace_idx": {
+          "name": "api_tokens_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_created_at_idx": {
+          "name": "api_tokens_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_workspace_id_workspaces_id_fk": {
+          "name": "api_tokens_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_tokens_created_by_user_id_user_id_fk": {
+          "name": "api_tokens_created_by_user_id_user_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "storage_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "assets_workspace_idx": {
+          "name": "assets_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_idx": {
+          "name": "assets_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_storage_provider_key_unique": {
+          "name": "assets_storage_provider_key_unique",
+          "columns": [
+            {
+              "expression": "storage_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_created_at_idx": {
+          "name": "assets_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_workspace_id_workspaces_id_fk": {
+          "name": "assets_workspace_id_workspaces_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assets_created_by_user_id_user_id_fk": {
+          "name": "assets_created_by_user_id_user_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_jobs": {
+      "name": "generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "generation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_asset_id": {
+          "name": "result_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "generation_jobs_workspace_idx": {
+          "name": "generation_jobs_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_project_idx": {
+          "name": "generation_jobs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_status_idx": {
+          "name": "generation_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_created_at_idx": {
+          "name": "generation_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_jobs_workspace_id_workspaces_id_fk": {
+          "name": "generation_jobs_workspace_id_workspaces_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_project_id_projects_id_fk": {
+          "name": "generation_jobs_project_id_projects_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_result_asset_id_assets_id_fk": {
+          "name": "generation_jobs_result_asset_id_assets_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "result_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_created_by_user_id_user_id_fk": {
+          "name": "generation_jobs_created_by_user_id_user_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_idx": {
+          "name": "invitation_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_user_unique": {
+          "name": "member_organization_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_idx": {
+          "name": "member_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_idx": {
+          "name": "member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_directory_path": {
+          "name": "source_directory_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_json": {
+          "name": "workflow_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_workspace_slug_unique": {
+          "name": "projects_workspace_slug_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_workspace_idx": {
+          "name": "projects_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_workspaces_id_fk": {
+          "name": "projects_workspace_id_workspaces_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_user_id_fk": {
+          "name": "projects_created_by_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_prompts": {
+      "name": "saved_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "saved_prompt_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_config": {
+          "name": "form_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "saved_prompts_workspace_deleted_idx": {
+          "name": "saved_prompts_workspace_deleted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_prompts_public_mode_deleted_idx": {
+          "name": "saved_prompts_public_mode_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_prompts_created_at_idx": {
+          "name": "saved_prompts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_prompts_workspace_id_workspaces_id_fk": {
+          "name": "saved_prompts_workspace_id_workspaces_id_fk",
+          "tableFrom": "saved_prompts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_accounts": {
+      "name": "social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_secret": {
+          "name": "access_token_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_settings": {
+          "name": "additional_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_reauth": {
+          "name": "requires_reauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_accounts_workspace_platform_user_unique": {
+          "name": "social_accounts_workspace_platform_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_workspace_idx": {
+          "name": "social_accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_created_at_idx": {
+          "name": "social_accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_accounts_workspace_id_workspaces_id_fk": {
+          "name": "social_accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_accounts_created_by_user_id_user_id_fk": {
+          "name": "social_accounts_created_by_user_id_user_id_fk",
+          "tableFrom": "social_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_automation_rules": {
+      "name": "social_automation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_filters": {
+          "name": "trigger_filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repeat_interval_seconds": {
+          "name": "repeat_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_runs": {
+          "name": "max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'create_social_post'"
+        },
+        "action_config": {
+          "name": "action_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_automation_rules_workspace_idx": {
+          "name": "social_automation_rules_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_enabled_idx": {
+          "name": "social_automation_rules_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_trigger_source_idx": {
+          "name": "social_automation_rules_trigger_source_idx",
+          "columns": [
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_created_at_idx": {
+          "name": "social_automation_rules_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_automation_rules_workspace_id_workspaces_id_fk": {
+          "name": "social_automation_rules_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_automation_rules",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_rules_created_by_user_id_user_id_fk": {
+          "name": "social_automation_rules_created_by_user_id_user_id_fk",
+          "tableFrom": "social_automation_rules",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_automation_tasks": {
+      "name": "social_automation_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_index": {
+          "name": "run_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "state": {
+          "name": "state",
+          "type": "automation_task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_post_id": {
+          "name": "source_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_automation_tasks_workspace_idx": {
+          "name": "social_automation_tasks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_rule_idx": {
+          "name": "social_automation_tasks_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_task_key_unique": {
+          "name": "social_automation_tasks_task_key_unique",
+          "columns": [
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_rule_run_index_unique": {
+          "name": "social_automation_tasks_rule_run_index_unique",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_state_idx": {
+          "name": "social_automation_tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_due_at_idx": {
+          "name": "social_automation_tasks_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_run_index_idx": {
+          "name": "social_automation_tasks_run_index_idx",
+          "columns": [
+            {
+              "expression": "run_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_claimed_at_idx": {
+          "name": "social_automation_tasks_claimed_at_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_created_at_idx": {
+          "name": "social_automation_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_automation_tasks_workspace_id_workspaces_id_fk": {
+          "name": "social_automation_tasks_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_rule_id_social_automation_rules_id_fk": {
+          "name": "social_automation_tasks_rule_id_social_automation_rules_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_automation_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_source_post_id_social_posts_id_fk": {
+          "name": "social_automation_tasks_source_post_id_social_posts_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "source_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_source_event_id_social_events_id_fk": {
+          "name": "social_automation_tasks_source_event_id_social_events_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_dispatch_runs": {
+      "name": "social_dispatch_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "social_dispatch_run_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_dispatch_runs_dispatch_key_unique": {
+          "name": "social_dispatch_runs_dispatch_key_unique",
+          "columns": [
+            {
+              "expression": "dispatch_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_workspace_idx": {
+          "name": "social_dispatch_runs_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_state_idx": {
+          "name": "social_dispatch_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_created_at_idx": {
+          "name": "social_dispatch_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_dispatch_runs_workspace_id_workspaces_id_fk": {
+          "name": "social_dispatch_runs_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_post_id_social_posts_id_fk": {
+          "name": "social_dispatch_runs_post_id_social_posts_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_event_id_social_events_id_fk": {
+          "name": "social_dispatch_runs_event_id_social_events_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_account_id_social_accounts_id_fk": {
+          "name": "social_dispatch_runs_account_id_social_accounts_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_event_reads": {
+      "name": "social_event_reads",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_event_reads_workspace_idx": {
+          "name": "social_event_reads_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_event_reads_user_idx": {
+          "name": "social_event_reads_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_event_reads_read_at_idx": {
+          "name": "social_event_reads_read_at_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_event_reads_event_id_social_events_id_fk": {
+          "name": "social_event_reads_event_id_social_events_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_event_reads_workspace_id_workspaces_id_fk": {
+          "name": "social_event_reads_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_event_reads_user_id_user_id_fk": {
+          "name": "social_event_reads_user_id_user_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "social_event_reads_pk": {
+          "name": "social_event_reads_pk",
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_events": {
+      "name": "social_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "social_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "social_event_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_facing": {
+          "name": "user_facing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_ref": {
+          "name": "workflow_run_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_events_workspace_idx": {
+          "name": "social_events_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_event_type_idx": {
+          "name": "social_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_user_facing_idx": {
+          "name": "social_events_user_facing_idx",
+          "columns": [
+            {
+              "expression": "user_facing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_read_at_idx": {
+          "name": "social_events_read_at_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_post_idx": {
+          "name": "social_events_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_account_idx": {
+          "name": "social_events_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_created_at_idx": {
+          "name": "social_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_events_workspace_id_workspaces_id_fk": {
+          "name": "social_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_events_post_id_social_posts_id_fk": {
+          "name": "social_events_post_id_social_posts_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_events_account_id_social_accounts_id_fk": {
+          "name": "social_events_account_id_social_accounts_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_events_created_by_user_id_user_id_fk": {
+          "name": "social_events_created_by_user_id_user_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_mastodon_instances": {
+      "name": "social_mastodon_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_characters": {
+          "name": "max_characters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_mastodon_instances_url_unique": {
+          "name": "social_mastodon_instances_url_unique",
+          "columns": [
+            {
+              "expression": "instance_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_notification_preferences": {
+      "name": "social_notification_preferences",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_app_enabled": {
+          "name": "in_app_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mute_all": {
+          "name": "mute_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_notification_preferences_user_idx": {
+          "name": "social_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_notification_preferences_workspace_id_workspaces_id_fk": {
+          "name": "social_notification_preferences_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_notification_preferences",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_notification_preferences_user_id_user_id_fk": {
+          "name": "social_notification_preferences_user_id_user_id_fk",
+          "tableFrom": "social_notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "social_notification_preferences_pk": {
+          "name": "social_notification_preferences_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_oauth_selection_sessions": {
+      "name": "social_oauth_selection_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_secret": {
+          "name": "access_token_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_oauth_selection_sessions_workspace_idx": {
+          "name": "social_oauth_selection_sessions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_oauth_selection_sessions_expires_at_idx": {
+          "name": "social_oauth_selection_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_oauth_selection_sessions_workspace_id_workspaces_id_fk": {
+          "name": "social_oauth_selection_sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_oauth_selection_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_oauth_selection_sessions_created_by_user_id_user_id_fk": {
+          "name": "social_oauth_selection_sessions_created_by_user_id_user_id_fk",
+          "tableFrom": "social_oauth_selection_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_oauth_states": {
+      "name": "social_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_oauth_states_state_unique": {
+          "name": "social_oauth_states_state_unique",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_oauth_states_expires_at_idx": {
+          "name": "social_oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_account_id": {
+          "name": "social_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "root_post_id": {
+          "name": "root_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_status": {
+          "name": "dispatch_status",
+          "type": "social_dispatch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workflow_run_ref": {
+          "name": "workflow_run_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "delay_seconds": {
+          "name": "delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_template_post_id": {
+          "name": "source_template_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_settings": {
+          "name": "platform_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_url": {
+          "name": "platform_post_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parent_post_id": {
+          "name": "parent_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "studio_asset_id": {
+          "name": "studio_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_posts_workspace_idx": {
+          "name": "social_posts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_account_idx": {
+          "name": "social_posts_account_idx",
+          "columns": [
+            {
+              "expression": "social_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_root_post_idx": {
+          "name": "social_posts_root_post_idx",
+          "columns": [
+            {
+              "expression": "root_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_source_template_post_idx": {
+          "name": "social_posts_source_template_post_idx",
+          "columns": [
+            {
+              "expression": "source_template_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_kind_idx": {
+          "name": "social_posts_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_trigger_source_idx": {
+          "name": "social_posts_trigger_source_idx",
+          "columns": [
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_dispatch_status_idx": {
+          "name": "social_posts_dispatch_status_idx",
+          "columns": [
+            {
+              "expression": "dispatch_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_next_dispatch_at_idx": {
+          "name": "social_posts_next_dispatch_at_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_scheduled_at_idx": {
+          "name": "social_posts_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_posts_workspace_id_workspaces_id_fk": {
+          "name": "social_posts_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_posts_social_account_id_social_accounts_id_fk": {
+          "name": "social_posts_social_account_id_social_accounts_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "social_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_posts_studio_asset_id_assets_id_fk": {
+          "name": "social_posts_studio_asset_id_assets_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "studio_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_posts_created_by_user_id_user_id_fk": {
+          "name": "social_posts_created_by_user_id_user_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_token_refresh_leases": {
+      "name": "social_token_refresh_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_account_id": {
+          "name": "social_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "social_token_refresh_lease_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "leased_at": {
+          "name": "leased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_token_refresh_leases_social_account_unique": {
+          "name": "social_token_refresh_leases_social_account_unique",
+          "columns": [
+            {
+              "expression": "social_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_workspace_idx": {
+          "name": "social_token_refresh_leases_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_state_idx": {
+          "name": "social_token_refresh_leases_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_expires_at_idx": {
+          "name": "social_token_refresh_leases_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_token_refresh_leases_workspace_id_workspaces_id_fk": {
+          "name": "social_token_refresh_leases_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_token_refresh_leases",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_token_refresh_leases_social_account_id_social_accounts_id_fk": {
+          "name": "social_token_refresh_leases_social_account_id_social_accounts_id_fk",
+          "tableFrom": "social_token_refresh_leases",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "social_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_deliveries": {
+      "name": "social_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_webhook_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_deliveries_workspace_idx": {
+          "name": "social_webhook_deliveries_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_webhook_idx": {
+          "name": "social_webhook_deliveries_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_event_idx": {
+          "name": "social_webhook_deliveries_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_status_idx": {
+          "name": "social_webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_next_attempt_at_idx": {
+          "name": "social_webhook_deliveries_next_attempt_at_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_locked_at_idx": {
+          "name": "social_webhook_deliveries_locked_at_idx",
+          "columns": [
+            {
+              "expression": "locked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_created_at_idx": {
+          "name": "social_webhook_deliveries_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_deliveries_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_deliveries_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_deliveries_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_deliveries_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_deliveries_event_id_social_events_id_fk": {
+          "name": "social_webhook_deliveries_event_id_social_events_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_delivery_dead_letters": {
+      "name": "social_webhook_delivery_dead_letters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dead_letter_reason": {
+          "name": "dead_letter_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_state": {
+          "name": "replay_state",
+          "type": "social_webhook_dead_letter_replay_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dead_lettered'"
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "replay_requested_at": {
+          "name": "replay_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_requested_by_user_id": {
+          "name": "replay_requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_metadata": {
+          "name": "replay_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_delivery_id": {
+          "name": "replay_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replayed_at": {
+          "name": "replayed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_error": {
+          "name": "replay_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_delivery_dead_letters_delivery_unique": {
+          "name": "social_webhook_delivery_dead_letters_delivery_unique",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_workspace_idx": {
+          "name": "social_webhook_delivery_dead_letters_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_replay_state_idx": {
+          "name": "social_webhook_delivery_dead_letters_replay_state_idx",
+          "columns": [
+            {
+              "expression": "replay_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_created_at_idx": {
+          "name": "social_webhook_delivery_dead_letters_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_delivery_dead_letters_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_delivery_id_social_webhook_deliveries_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_delivery_id_social_webhook_deliveries_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhook_deliveries",
+          "columnsFrom": [
+            "delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_event_id_social_events_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_event_id_social_events_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_replay_requested_by_user_id_user_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_replay_requested_by_user_id_user_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "user",
+          "columnsFrom": [
+            "replay_requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_replay_delivery_id_social_webhook_deliveries_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_replay_delivery_id_social_webhook_deliveries_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhook_deliveries",
+          "columnsFrom": [
+            "replay_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_subscriptions": {
+      "name": "social_webhook_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_subscriptions_workspace_idx": {
+          "name": "social_webhook_subscriptions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_webhook_idx": {
+          "name": "social_webhook_subscriptions_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_enabled_idx": {
+          "name": "social_webhook_subscriptions_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_created_at_idx": {
+          "name": "social_webhook_subscriptions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_subscriptions_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_subscriptions_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_subscriptions_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_subscriptions_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_subscriptions_created_by_user_id_user_id_fk": {
+          "name": "social_webhook_subscriptions_created_by_user_id_user_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhooks": {
+      "name": "social_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret_encrypted": {
+          "name": "signing_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhooks_workspace_idx": {
+          "name": "social_webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhooks_enabled_idx": {
+          "name": "social_webhooks_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhooks_created_at_idx": {
+          "name": "social_webhooks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhooks_workspace_id_workspaces_id_fk": {
+          "name": "social_webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhooks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhooks_created_by_user_id_user_id_fk": {
+          "name": "social_webhooks_created_by_user_id_user_id_fk",
+          "tableFrom": "social_webhooks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_value_unique": {
+          "name": "verification_identifier_value_unique",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_members_user_idx": {
+          "name": "workspace_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_user_id_fk": {
+          "name": "workspace_members_user_id_user_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_pk": {
+          "name": "workspace_members_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_settings": {
+      "name": "workspace_settings",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "brand_kit": {
+          "name": "brand_kit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_customer_id": {
+          "name": "billing_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_subscription_id": {
+          "name": "billing_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_metadata": {
+          "name": "billing_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_settings_organization_unique": {
+          "name": "workspace_settings_organization_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_settings_plan_tier_idx": {
+          "name": "workspace_settings_plan_tier_idx",
+          "columns": [
+            {
+              "expression": "plan_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_settings_workspace_id_workspaces_id_fk": {
+          "name": "workspace_settings_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_settings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_settings_organization_id_organization_id_fk": {
+          "name": "workspace_settings_organization_id_organization_id_fk",
+          "tableFrom": "workspace_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_storage_limits": {
+      "name": "workspace_storage_limits",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quota_bytes": {
+          "name": "quota_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_storage_limits_workspace_id_workspaces_id_fk": {
+          "name": "workspace_storage_limits_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_storage_limits",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_kit": {
+          "name": "brand_kit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspaces_slug_unique": {
+          "name": "workspaces_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_owner_idx": {
+          "name": "workspaces_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_user_id_user_id_fk": {
+          "name": "workspaces_owner_user_id_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "video",
+        "audio",
+        "model3d",
+        "workflow"
+      ]
+    },
+    "public.automation_task_state": {
+      "name": "automation_task_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.generation_status": {
+      "name": "generation_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "enterprise"
+      ]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.saved_prompt_mode": {
+      "name": "saved_prompt_mode",
+      "schema": "public",
+      "values": [
+        "photo",
+        "video",
+        "copy"
+      ]
+    },
+    "public.social_dispatch_run_state": {
+      "name": "social_dispatch_run_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.social_dispatch_status": {
+      "name": "social_dispatch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "dispatched",
+        "retry_scheduled",
+        "failed"
+      ]
+    },
+    "public.social_event_severity": {
+      "name": "social_event_severity",
+      "schema": "public",
+      "values": [
+        "info",
+        "warn",
+        "error"
+      ]
+    },
+    "public.social_event_type": {
+      "name": "social_event_type",
+      "schema": "public",
+      "values": [
+        "post.queued",
+        "post.publishing",
+        "post.published",
+        "post.failed",
+        "account.reauth_required",
+        "token.refreshed",
+        "dispatch.failed"
+      ]
+    },
+    "public.social_platform": {
+      "name": "social_platform",
+      "schema": "public",
+      "values": [
+        "x",
+        "linkedin",
+        "instagram",
+        "tiktok",
+        "threads",
+        "pinterest",
+        "facebook",
+        "youtube",
+        "reddit",
+        "bluesky",
+        "mastodon"
+      ]
+    },
+    "public.social_post_status": {
+      "name": "social_post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "queued",
+        "publishing",
+        "published",
+        "failed"
+      ]
+    },
+    "public.social_token_refresh_lease_state": {
+      "name": "social_token_refresh_lease_state",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired"
+      ]
+    },
+    "public.social_webhook_dead_letter_replay_state": {
+      "name": "social_webhook_dead_letter_replay_state",
+      "schema": "public",
+      "values": [
+        "dead_lettered",
+        "replay_requested",
+        "replayed",
+        "failed"
+      ]
+    },
+    "public.social_webhook_delivery_status": {
+      "name": "social_webhook_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed"
+      ]
+    },
+    "public.storage_provider": {
+      "name": "storage_provider",
+      "schema": "public",
+      "values": [
+        "local",
+        "s3",
+        "r2"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1779708283658,
       "tag": "0014_left_snowbird",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1783656055936,
+      "tag": "0015_harsh_energizer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/tokens/[tokenId]/route.ts
+++ b/src/app/api/tokens/[tokenId]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { revokeApiToken } from "@/lib/api-tokens/repository";
-import { isDatabaseConfigured } from "@/lib/db";
-import { withApiPermission } from "@/lib/studio/authz";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 const ROUTE = "/api/tokens/[tokenId]";
 
@@ -11,35 +10,20 @@ interface RevokeResponse {
   error?: string;
 }
 
+type TokenIdContext = { params: Promise<{ tokenId: string }> };
+
 /** Revoke a token. Scoped to the caller's workspace; takes effect immediately. */
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ tokenId: string }> },
-): Promise<NextResponse<RevokeResponse>> {
-  if (!isDatabaseConfigured()) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "DATABASE_URL is not configured. Configure Postgres to use API tokens.",
-      },
-      { status: 503 },
-    );
-  }
+export const DELETE = withStudioAuth<TokenIdContext>(
+  { route: ROUTE, action: "delete" },
+  async (
+    _request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<RevokeResponse>> => {
+    const { tokenId } = await context.params;
 
-  const auth = await withApiPermission(request, {
-    route: ROUTE,
-    permission: "workspaces:write",
-  });
-  if (!auth.authorized) {
-    return auth.response;
-  }
-
-  const { tokenId } = await params;
-
-  try {
     const revoked = await revokeApiToken({
-      workspaceId: auth.session.workspace.id,
+      workspaceId: authz.workspaceId,
       tokenId,
     });
 
@@ -51,14 +35,5 @@ export async function DELETE(
     }
 
     return NextResponse.json({ success: true });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          error instanceof Error ? error.message : "Failed to revoke API token",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/tokens/[tokenId]/route.ts
+++ b/src/app/api/tokens/[tokenId]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { revokeApiToken } from "@/lib/api-tokens/repository";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+
+const ROUTE = "/api/tokens/[tokenId]";
+
+interface RevokeResponse {
+  success: boolean;
+  error?: string;
+}
+
+/** Revoke a token. Scoped to the caller's workspace; takes effect immediately. */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ tokenId: string }> },
+): Promise<NextResponse<RevokeResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use API tokens.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const auth = await withApiPermission(request, {
+    route: ROUTE,
+    permission: "workspaces:write",
+  });
+  if (!auth.authorized) {
+    return auth.response;
+  }
+
+  const { tokenId } = await params;
+
+  try {
+    const revoked = await revokeApiToken({
+      workspaceId: auth.session.workspace.id,
+      tokenId,
+    });
+
+    if (!revoked) {
+      return NextResponse.json(
+        { success: false, error: "Token not found." },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to revoke API token",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/tokens/__tests__/route.test.ts
+++ b/src/app/api/tokens/__tests__/route.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const {
+  mockIsDatabaseConfigured,
+  mockWithApiPermission,
+  mockCreateApiToken,
+  mockListApiTokens,
+} = vi.hoisted(() => ({
+  mockIsDatabaseConfigured: vi.fn(() => true),
+  mockWithApiPermission: vi.fn(),
+  mockCreateApiToken: vi.fn(),
+  mockListApiTokens: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+  getDb: vi.fn(),
+}));
+
+vi.mock("@/lib/studio/authz", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/studio/authz")>(
+    "@/lib/studio/authz",
+  );
+  return {
+    ...actual,
+    withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
+  };
+});
+
+vi.mock("@/lib/api-tokens/repository", () => ({
+  createApiToken: (...args: unknown[]) => mockCreateApiToken(...args),
+  listApiTokens: (...args: unknown[]) => mockListApiTokens(...args),
+}));
+
+import { GET, POST } from "../route";
+
+function createRequest(body?: unknown): NextRequest {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL("http://localhost:3000/api/tokens"),
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+function authorizedAs(workspaceId: string, userId = "user_1") {
+  mockWithApiPermission.mockResolvedValue({
+    authorized: true,
+    session: {
+      user: { id: userId, name: null, email: null },
+      workspace: { id: workspaceId, organizationId: null },
+      role: "owner",
+      planTier: "free",
+      permissions: ["workspaces:read", "workspaces:write"],
+    },
+  });
+}
+
+function unauthorized(status: 401 | 403, error: string) {
+  mockWithApiPermission.mockResolvedValue({
+    authorized: false,
+    response: NextResponse.json({ success: false, error }, { status }),
+  });
+}
+
+describe("/api/tokens", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsDatabaseConfigured.mockReturnValue(true);
+  });
+
+  describe("POST (create)", () => {
+    it("creates a token and returns the raw secret exactly once", async () => {
+      authorizedAs("ws_1");
+      mockCreateApiToken.mockResolvedValue({
+        id: "apitok_1",
+        name: "CI pipeline",
+        token: "nb_rawsecretshownonce",
+        prefix: "nb_rawsecre",
+        createdAt: new Date("2026-07-10T00:00:00.000Z"),
+      });
+
+      const response = await POST(createRequest({ name: "CI pipeline" }));
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+      expect(data.token).toEqual(
+        expect.objectContaining({
+          id: "apitok_1",
+          name: "CI pipeline",
+          token: "nb_rawsecretshownonce",
+          prefix: "nb_rawsecre",
+        }),
+      );
+      expect(mockCreateApiToken).toHaveBeenCalledWith({
+        workspaceId: "ws_1",
+        name: "CI pipeline",
+        createdByUserId: "user_1",
+      });
+    });
+
+    it("rejects a missing or blank name with 400", async () => {
+      authorizedAs("ws_1");
+
+      const response = await POST(createRequest({ name: "   " }));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(mockCreateApiToken).not.toHaveBeenCalled();
+    });
+
+    it("propagates the authz failure for non-writers", async () => {
+      unauthorized(403, "You do not have access to this workspace.");
+
+      const response = await POST(createRequest({ name: "CI" }));
+
+      expect(response.status).toBe(403);
+      expect(mockCreateApiToken).not.toHaveBeenCalled();
+    });
+
+    it("returns 503 when the database is not configured", async () => {
+      mockIsDatabaseConfigured.mockReturnValue(false);
+
+      const response = await POST(createRequest({ name: "CI" }));
+
+      expect(response.status).toBe(503);
+    });
+  });
+
+  describe("GET (list)", () => {
+    it("lists the workspace's tokens without exposing hashes", async () => {
+      authorizedAs("ws_1");
+      mockListApiTokens.mockResolvedValue([
+        {
+          id: "apitok_1",
+          name: "CI pipeline",
+          prefix: "nb_rawsecre",
+          revoked: false,
+          lastUsedAt: null,
+          createdAt: new Date("2026-07-10T00:00:00.000Z"),
+        },
+      ]);
+
+      const response = await GET(createRequest());
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.tokens).toHaveLength(1);
+      expect(data.tokens[0]).toEqual(
+        expect.objectContaining({
+          id: "apitok_1",
+          name: "CI pipeline",
+          prefix: "nb_rawsecre",
+          revoked: false,
+          lastUsedAt: null,
+        }),
+      );
+      expect(JSON.stringify(data)).not.toContain("tokenHash");
+      expect(mockListApiTokens).toHaveBeenCalledWith("ws_1");
+    });
+
+    it("propagates the authz failure when unauthenticated", async () => {
+      unauthorized(401, "Please sign in.");
+
+      const response = await GET(createRequest());
+
+      expect(response.status).toBe(401);
+      expect(mockListApiTokens).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/tokens/__tests__/route.test.ts
+++ b/src/app/api/tokens/__tests__/route.test.ts
@@ -3,34 +3,29 @@ import { NextRequest, NextResponse } from "next/server";
 
 const {
   mockIsDatabaseConfigured,
-  mockWithApiPermission,
+  mockAuthorizeStudioRequest,
   mockCreateApiToken,
   mockListApiTokens,
 } = vi.hoisted(() => ({
   mockIsDatabaseConfigured: vi.fn(() => true),
-  mockWithApiPermission: vi.fn(),
+  mockAuthorizeStudioRequest: vi.fn(),
   mockCreateApiToken: vi.fn(),
   mockListApiTokens: vi.fn(),
 }));
 
-vi.mock("@/lib/auth/server", () => ({
-  auth: { api: { getSession: vi.fn() } },
-}));
-
 vi.mock("@/lib/db", () => ({
   isDatabaseConfigured: () => mockIsDatabaseConfigured(),
-  getDb: vi.fn(),
 }));
 
-vi.mock("@/lib/studio/authz", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/studio/authz")>(
-    "@/lib/studio/authz",
-  );
-  return {
-    ...actual,
-    withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
-  };
-});
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) =>
+    mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json(
+      { success: false, error: result.error },
+      { status: result.status },
+    ),
+}));
 
 vi.mock("@/lib/api-tokens/repository", () => ({
   createApiToken: (...args: unknown[]) => mockCreateApiToken(...args),
@@ -48,22 +43,22 @@ function createRequest(body?: unknown): NextRequest {
 }
 
 function authorizedAs(workspaceId: string, userId = "user_1") {
-  mockWithApiPermission.mockResolvedValue({
+  mockAuthorizeStudioRequest.mockResolvedValue({
     authorized: true,
-    session: {
-      user: { id: userId, name: null, email: null },
-      workspace: { id: workspaceId, organizationId: null },
-      role: "owner",
-      planTier: "free",
-      permissions: ["workspaces:read", "workspaces:write"],
-    },
+    userId,
+    workspaceId,
+    role: "owner",
+    permissions: ["workspaces:read", "workspaces:write"],
+    contentSession: {},
   });
 }
 
 function unauthorized(status: 401 | 403, error: string) {
-  mockWithApiPermission.mockResolvedValue({
+  mockAuthorizeStudioRequest.mockResolvedValue({
     authorized: false,
-    response: NextResponse.json({ success: false, error }, { status }),
+    status,
+    error,
+    reason: status === 401 ? "unauthenticated" : "forbidden",
   });
 }
 

--- a/src/app/api/tokens/__tests__/tokenId.route.test.ts
+++ b/src/app/api/tokens/__tests__/tokenId.route.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { mockIsDatabaseConfigured, mockWithApiPermission, mockRevokeApiToken } =
+  vi.hoisted(() => ({
+    mockIsDatabaseConfigured: vi.fn(() => true),
+    mockWithApiPermission: vi.fn(),
+    mockRevokeApiToken: vi.fn(),
+  }));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+  getDb: vi.fn(),
+}));
+
+vi.mock("@/lib/studio/authz", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/studio/authz")>(
+    "@/lib/studio/authz",
+  );
+  return {
+    ...actual,
+    withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
+  };
+});
+
+vi.mock("@/lib/api-tokens/repository", () => ({
+  revokeApiToken: (...args: unknown[]) => mockRevokeApiToken(...args),
+}));
+
+import { DELETE } from "../[tokenId]/route";
+
+function createRequest(): NextRequest {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL("http://localhost:3000/api/tokens/apitok_1"),
+  } as unknown as NextRequest;
+}
+
+function paramsFor(tokenId: string) {
+  return { params: Promise.resolve({ tokenId }) };
+}
+
+function authorizedAs(workspaceId: string) {
+  mockWithApiPermission.mockResolvedValue({
+    authorized: true,
+    session: {
+      user: { id: "user_1", name: null, email: null },
+      workspace: { id: workspaceId, organizationId: null },
+      role: "owner",
+      planTier: "free",
+      permissions: ["workspaces:read", "workspaces:write"],
+    },
+  });
+}
+
+describe("/api/tokens/[tokenId] DELETE (revoke)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsDatabaseConfigured.mockReturnValue(true);
+  });
+
+  it("revokes a token scoped to the caller's workspace", async () => {
+    authorizedAs("ws_1");
+    mockRevokeApiToken.mockResolvedValue(true);
+
+    const response = await DELETE(createRequest(), paramsFor("apitok_1"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockRevokeApiToken).toHaveBeenCalledWith({
+      workspaceId: "ws_1",
+      tokenId: "apitok_1",
+    });
+  });
+
+  it("returns 404 when the token does not belong to the workspace", async () => {
+    authorizedAs("ws_1");
+    mockRevokeApiToken.mockResolvedValue(false);
+
+    const response = await DELETE(
+      createRequest(),
+      paramsFor("apitok_other_tenant"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+  });
+
+  it("propagates the authz failure for non-writers", async () => {
+    mockWithApiPermission.mockResolvedValue({
+      authorized: false,
+      response: NextResponse.json(
+        { success: false, error: "forbidden" },
+        { status: 403 },
+      ),
+    });
+
+    const response = await DELETE(createRequest(), paramsFor("apitok_1"));
+
+    expect(response.status).toBe(403);
+    expect(mockRevokeApiToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when the database is not configured", async () => {
+    mockIsDatabaseConfigured.mockReturnValue(false);
+
+    const response = await DELETE(createRequest(), paramsFor("apitok_1"));
+
+    expect(response.status).toBe(503);
+  });
+});

--- a/src/app/api/tokens/__tests__/tokenId.route.test.ts
+++ b/src/app/api/tokens/__tests__/tokenId.route.test.ts
@@ -1,31 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
 
-const { mockIsDatabaseConfigured, mockWithApiPermission, mockRevokeApiToken } =
+const { mockIsDatabaseConfigured, mockAuthorizeStudioRequest, mockRevokeApiToken } =
   vi.hoisted(() => ({
     mockIsDatabaseConfigured: vi.fn(() => true),
-    mockWithApiPermission: vi.fn(),
+    mockAuthorizeStudioRequest: vi.fn(),
     mockRevokeApiToken: vi.fn(),
   }));
 
-vi.mock("@/lib/auth/server", () => ({
-  auth: { api: { getSession: vi.fn() } },
-}));
-
 vi.mock("@/lib/db", () => ({
   isDatabaseConfigured: () => mockIsDatabaseConfigured(),
-  getDb: vi.fn(),
 }));
 
-vi.mock("@/lib/studio/authz", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/studio/authz")>(
-    "@/lib/studio/authz",
-  );
-  return {
-    ...actual,
-    withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
-  };
-});
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) =>
+    mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json(
+      { success: false, error: result.error },
+      { status: result.status },
+    ),
+}));
 
 vi.mock("@/lib/api-tokens/repository", () => ({
   revokeApiToken: (...args: unknown[]) => mockRevokeApiToken(...args),
@@ -45,15 +40,13 @@ function paramsFor(tokenId: string) {
 }
 
 function authorizedAs(workspaceId: string) {
-  mockWithApiPermission.mockResolvedValue({
+  mockAuthorizeStudioRequest.mockResolvedValue({
     authorized: true,
-    session: {
-      user: { id: "user_1", name: null, email: null },
-      workspace: { id: workspaceId, organizationId: null },
-      role: "owner",
-      planTier: "free",
-      permissions: ["workspaces:read", "workspaces:write"],
-    },
+    userId: "user_1",
+    workspaceId,
+    role: "owner",
+    permissions: ["workspaces:read", "workspaces:write", "workspaces:delete"],
+    contentSession: {},
   });
 }
 
@@ -93,12 +86,11 @@ describe("/api/tokens/[tokenId] DELETE (revoke)", () => {
   });
 
   it("propagates the authz failure for non-writers", async () => {
-    mockWithApiPermission.mockResolvedValue({
+    mockAuthorizeStudioRequest.mockResolvedValue({
       authorized: false,
-      response: NextResponse.json(
-        { success: false, error: "forbidden" },
-        { status: 403 },
-      ),
+      status: 403,
+      error: "forbidden",
+      reason: "forbidden",
     });
 
     const response = await DELETE(createRequest(), paramsFor("apitok_1"));

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -6,8 +6,7 @@ import {
   type ApiTokenSummary,
   type CreatedApiToken,
 } from "@/lib/api-tokens/repository";
-import { isDatabaseConfigured } from "@/lib/db";
-import { withApiPermission } from "@/lib/studio/authz";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
 
 const ROUTE = "/api/tokens";
 
@@ -23,101 +22,51 @@ interface TokenCreateResponse {
   error?: string;
 }
 
-function databaseUnavailable(): NextResponse<{
-  success: false;
-  error: string;
-}> {
-  return NextResponse.json(
-    {
-      success: false,
-      error: "DATABASE_URL is not configured. Configure Postgres to use API tokens.",
-    },
-    { status: 503 },
-  );
-}
-
 /** List the current workspace's API tokens (hashes never exposed). */
-export async function GET(
-  request: NextRequest,
-): Promise<NextResponse<TokensListResponse>> {
-  if (!isDatabaseConfigured()) {
-    return databaseUnavailable();
-  }
-
-  const auth = await withApiPermission(request, {
-    route: ROUTE,
-    permission: "workspaces:read",
-  });
-  if (!auth.authorized) {
-    return auth.response;
-  }
-
-  try {
-    const tokens = await listApiTokens(auth.session.workspace.id);
+export const GET = withStudioAuth<undefined>(
+  { route: ROUTE, action: "read" },
+  async (
+    _request: NextRequest,
+    authz,
+  ): Promise<NextResponse<TokensListResponse>> => {
+    const tokens = await listApiTokens(authz.workspaceId);
     return NextResponse.json({ success: true, tokens });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          error instanceof Error ? error.message : "Failed to list API tokens",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);
 
 /** Create a new API token; the raw secret is returned exactly once. */
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<TokenCreateResponse>> {
-  if (!isDatabaseConfigured()) {
-    return databaseUnavailable();
-  }
+export const POST = withStudioAuth<undefined>(
+  { route: ROUTE, action: "write" },
+  async (
+    request: NextRequest,
+    authz,
+  ): Promise<NextResponse<TokenCreateResponse>> => {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      body = null;
+    }
 
-  const auth = await withApiPermission(request, {
-    route: ROUTE,
-    permission: "workspaces:write",
-  });
-  if (!auth.authorized) {
-    return auth.response;
-  }
+    const rawName =
+      body && typeof body === "object" && "name" in body
+        ? (body as { name?: unknown }).name
+        : undefined;
+    const name = typeof rawName === "string" ? rawName.trim() : "";
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    body = null;
-  }
+    if (!name) {
+      return NextResponse.json(
+        { success: false, error: "A token name is required." },
+        { status: 400 },
+      );
+    }
 
-  const rawName =
-    body && typeof body === "object" && "name" in body
-      ? (body as { name?: unknown }).name
-      : undefined;
-  const name = typeof rawName === "string" ? rawName.trim() : "";
-
-  if (!name) {
-    return NextResponse.json(
-      { success: false, error: "A token name is required." },
-      { status: 400 },
-    );
-  }
-
-  try {
     const token = await createApiToken({
-      workspaceId: auth.session.workspace.id,
+      workspaceId: authz.workspaceId,
       name,
-      createdByUserId: auth.session.user.id,
+      createdByUserId: authz.userId,
     });
+
     return NextResponse.json({ success: true, token }, { status: 201 });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          error instanceof Error ? error.message : "Failed to create API token",
-      },
-      { status: 500 },
-    );
-  }
-}
+  },
+);

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  createApiToken,
+  listApiTokens,
+  type ApiTokenSummary,
+  type CreatedApiToken,
+} from "@/lib/api-tokens/repository";
+import { isDatabaseConfigured } from "@/lib/db";
+import { withApiPermission } from "@/lib/studio/authz";
+
+const ROUTE = "/api/tokens";
+
+interface TokensListResponse {
+  success: boolean;
+  tokens?: ApiTokenSummary[];
+  error?: string;
+}
+
+interface TokenCreateResponse {
+  success: boolean;
+  token?: CreatedApiToken;
+  error?: string;
+}
+
+function databaseUnavailable(): NextResponse<{
+  success: false;
+  error: string;
+}> {
+  return NextResponse.json(
+    {
+      success: false,
+      error: "DATABASE_URL is not configured. Configure Postgres to use API tokens.",
+    },
+    { status: 503 },
+  );
+}
+
+/** List the current workspace's API tokens (hashes never exposed). */
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<TokensListResponse>> {
+  if (!isDatabaseConfigured()) {
+    return databaseUnavailable();
+  }
+
+  const auth = await withApiPermission(request, {
+    route: ROUTE,
+    permission: "workspaces:read",
+  });
+  if (!auth.authorized) {
+    return auth.response;
+  }
+
+  try {
+    const tokens = await listApiTokens(auth.session.workspace.id);
+    return NextResponse.json({ success: true, tokens });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to list API tokens",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/** Create a new API token; the raw secret is returned exactly once. */
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<TokenCreateResponse>> {
+  if (!isDatabaseConfigured()) {
+    return databaseUnavailable();
+  }
+
+  const auth = await withApiPermission(request, {
+    route: ROUTE,
+    permission: "workspaces:write",
+  });
+  if (!auth.authorized) {
+    return auth.response;
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = null;
+  }
+
+  const rawName =
+    body && typeof body === "object" && "name" in body
+      ? (body as { name?: unknown }).name
+      : undefined;
+  const name = typeof rawName === "string" ? rawName.trim() : "";
+
+  if (!name) {
+    return NextResponse.json(
+      { success: false, error: "A token name is required." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const token = await createApiToken({
+      workspaceId: auth.session.workspace.id,
+      name,
+      createdByUserId: auth.session.user.id,
+    });
+    return NextResponse.json({ success: true, token }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to create API token",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/v1/workspaces/__tests__/route.test.ts
+++ b/src/app/api/v1/workspaces/__tests__/route.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockResolveWorkspaceIdByRawToken,
+  mockIsDatabaseConfigured,
+  mockSelectRows,
+  mockWithApiPermission,
+} = vi.hoisted(() => ({
+  mockResolveWorkspaceIdByRawToken: vi.fn(),
+  mockIsDatabaseConfigured: vi.fn(() => true),
+  mockSelectRows: vi.fn(),
+  mockWithApiPermission: vi.fn(),
+}));
+
+const mockDb = {
+  select: vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => mockSelectRows()),
+    })),
+  })),
+};
+
+// Prevent Better Auth's server module (and its DB probe) from loading eagerly
+// when the real authz layer is imported.
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+  getDb: vi.fn(() => mockDb),
+}));
+
+vi.mock("@/lib/api-tokens/repository", () => ({
+  resolveWorkspaceIdByRawToken: (...args: unknown[]) =>
+    mockResolveWorkspaceIdByRawToken(...args),
+}));
+
+// Session-auth fallback lives in the studio authz layer; the public route
+// delegates to it when no Bearer token is present.
+vi.mock("@/lib/studio/authz", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/studio/authz")>(
+    "@/lib/studio/authz",
+  );
+  return {
+    ...actual,
+    withApiPermission: (...args: unknown[]) => mockWithApiPermission(...args),
+  };
+});
+
+import { GET } from "../route";
+
+function createRequest(headers?: HeadersInit): NextRequest {
+  return {
+    headers: new Headers(headers),
+    nextUrl: new URL("http://localhost:3000/api/v1/workspaces"),
+  } as unknown as NextRequest;
+}
+
+describe("/api/v1/workspaces GET (Bearer token path)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsDatabaseConfigured.mockReturnValue(true);
+  });
+
+  it("returns 503 when the database is not configured", async () => {
+    mockIsDatabaseConfigured.mockReturnValue(false);
+
+    const response = await GET(
+      createRequest({ authorization: "Bearer nb_validtoken" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(data.success).toBe(false);
+  });
+
+  it("returns exactly the workspace the token is scoped to", async () => {
+    mockResolveWorkspaceIdByRawToken.mockResolvedValue("ws_scoped");
+    mockSelectRows.mockResolvedValueOnce([
+      { id: "ws_scoped", name: "Scoped Workspace", slug: "scoped-workspace" },
+    ]);
+
+    const response = await GET(
+      createRequest({ authorization: "Bearer nb_validtoken" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      workspaces: [
+        { id: "ws_scoped", name: "Scoped Workspace", slug: "scoped-workspace" },
+      ],
+    });
+    expect(mockResolveWorkspaceIdByRawToken).toHaveBeenCalledWith(
+      "nb_validtoken",
+    );
+    // Token path must never fall through to session auth.
+    expect(mockWithApiPermission).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a missing/invalid token (unknown hash)", async () => {
+    mockResolveWorkspaceIdByRawToken.mockResolvedValue(null);
+
+    const response = await GET(
+      createRequest({ authorization: "Bearer nb_bogus" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(mockSelectRows).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a revoked token (resolves to null)", async () => {
+    mockResolveWorkspaceIdByRawToken.mockResolvedValue(null);
+
+    const response = await GET(
+      createRequest({ authorization: "Bearer nb_revoked" }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a malformed Bearer value that is not an nb_ token with 401", async () => {
+    const response = await GET(
+      createRequest({ authorization: "Bearer not-an-nb-token" }),
+    );
+
+    expect(response.status).toBe(401);
+    // A non-nb_ bearer must not be treated as a session request.
+    expect(mockWithApiPermission).not.toHaveBeenCalled();
+    expect(mockResolveWorkspaceIdByRawToken).not.toHaveBeenCalled();
+  });
+
+  it("falls back to session auth when no Authorization header is present", async () => {
+    mockWithApiPermission.mockResolvedValue({
+      authorized: true,
+      session: {
+        user: { id: "user_1", name: null, email: null },
+        workspace: { id: "ws_session", organizationId: null },
+        role: "owner",
+        planTier: "free",
+        permissions: ["workspaces:read"],
+      },
+    });
+    mockSelectRows.mockResolvedValueOnce([
+      { id: "ws_session", name: "Session Workspace", slug: "session-workspace" },
+    ]);
+
+    const response = await GET(createRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.workspaces).toEqual([
+      {
+        id: "ws_session",
+        name: "Session Workspace",
+        slug: "session-workspace",
+      },
+    ]);
+    expect(mockWithApiPermission).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/workspaces/route.ts
+++ b/src/app/api/v1/workspaces/route.ts
@@ -1,0 +1,86 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+import { authorizePublicApiRequest } from "@/lib/api-tokens/auth";
+import { getDb, isDatabaseConfigured } from "@/lib/db";
+import { workspaces } from "@/lib/db/schema";
+
+const ROUTE = "/api/v1/workspaces";
+
+interface WorkspaceItem {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface WorkspacesResponse {
+  success: boolean;
+  workspaces?: WorkspaceItem[];
+  error?: string;
+}
+
+/**
+ * Public API v1: list the workspace(s) the caller can reach.
+ *
+ * Accepts either an `Authorization: Bearer nb_...` API token (scoped to exactly
+ * one workspace) or an app session. This is the first endpoint proving the
+ * Bearer path end-to-end.
+ */
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<WorkspacesResponse>> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use the API.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const auth = await authorizePublicApiRequest(request, {
+    route: ROUTE,
+    permission: "workspaces:read",
+  });
+
+  if (!auth.authorized) {
+    return auth.response;
+  }
+
+  try {
+    const db = getDb();
+    const rows = await db
+      .select({
+        id: workspaces.id,
+        name: workspaces.name,
+        slug: workspaces.slug,
+      })
+      .from(workspaces)
+      .where(
+        and(
+          eq(workspaces.id, auth.session.workspace.id),
+          isNull(workspaces.deletedAt),
+        ),
+      );
+
+    return NextResponse.json({
+      success: true,
+      workspaces: rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        slug: row.slug,
+      })),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to list workspaces",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/social/settings/page.tsx
+++ b/src/app/social/settings/page.tsx
@@ -1,0 +1,5 @@
+import { ApiTokensSettings } from "@/components/social/ApiTokensSettings"
+
+export default function SettingsPage() {
+  return <ApiTokensSettings />
+}

--- a/src/components/social/ApiTokensSettings.tsx
+++ b/src/components/social/ApiTokensSettings.tsx
@@ -1,0 +1,254 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { CopyIcon, KeyRoundIcon, Loader2Icon, PlusIcon } from "lucide-react"
+import { useToast } from "@/components/Toast"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { StudioApiError } from "@/lib/studio/client"
+import {
+  createApiTokenRequest,
+  listApiTokensRequest,
+  revokeApiTokenRequest,
+  type ApiTokenSummaryView,
+  type CreatedApiTokenView,
+} from "@/lib/api-tokens/client"
+
+function formatDate(value: string | null): string {
+  if (!value) return "Never"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "—"
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+export function ApiTokensSettings() {
+  const { show: showToast } = useToast()
+  const [tokens, setTokens] = useState<ApiTokenSummaryView[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [name, setName] = useState("")
+  const [isCreating, setIsCreating] = useState(false)
+  const [revokingId, setRevokingId] = useState<string | null>(null)
+  const [createdToken, setCreatedToken] = useState<CreatedApiTokenView | null>(
+    null,
+  )
+  const initialized = useRef(false)
+
+  async function loadTokens() {
+    setIsLoading(true)
+    try {
+      setTokens(await listApiTokensRequest())
+    } catch (error) {
+      showToast(
+        error instanceof StudioApiError
+          ? error.message
+          : "Failed to load API tokens",
+        "error",
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // Load once on first render — no useEffect (matches repo convention).
+  if (!initialized.current) {
+    initialized.current = true
+    loadTokens()
+  }
+
+  async function handleCreate(event: React.FormEvent) {
+    event.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed || isCreating) return
+
+    setIsCreating(true)
+    try {
+      const created = await createApiTokenRequest(trimmed)
+      setCreatedToken(created)
+      setName("")
+      showToast("API token created", "success")
+      await loadTokens()
+    } catch (error) {
+      showToast(
+        error instanceof StudioApiError
+          ? error.message
+          : "Failed to create API token",
+        "error",
+      )
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  async function handleRevoke(tokenId: string) {
+    setRevokingId(tokenId)
+    try {
+      await revokeApiTokenRequest(tokenId)
+      setTokens((prev) =>
+        prev.map((token) =>
+          token.id === tokenId ? { ...token, revoked: true } : token,
+        ),
+      )
+      showToast("Token revoked", "success")
+    } catch (error) {
+      showToast(
+        error instanceof StudioApiError
+          ? error.message
+          : "Failed to revoke token",
+        "error",
+      )
+    } finally {
+      setRevokingId(null)
+    }
+  }
+
+  async function copySecret() {
+    if (!createdToken) return
+    try {
+      await navigator.clipboard.writeText(createdToken.token)
+      showToast("Token copied to clipboard", "success")
+    } catch {
+      showToast("Could not copy — copy it manually", "warning")
+    }
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-4 md:p-6">
+      <div>
+        <h2 className="flex items-center gap-2 text-lg font-semibold">
+          <KeyRoundIcon className="size-5" />
+          API Tokens
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Create workspace-scoped tokens for the public API, MCP server, and
+          CLI. Tokens are shown once at creation and can be revoked at any time.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleCreate}
+        className="flex flex-col gap-2 sm:flex-row sm:items-end"
+      >
+        <div className="flex-1">
+          <Label htmlFor="token-name">Token name</Label>
+          <Input
+            id="token-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="e.g. CI pipeline, Claude agent"
+            maxLength={80}
+          />
+        </div>
+        <Button type="submit" disabled={!name.trim() || isCreating}>
+          {isCreating ? (
+            <Loader2Icon className="size-4 animate-spin" />
+          ) : (
+            <PlusIcon className="size-4" />
+          )}
+          Create token
+        </Button>
+      </form>
+
+      <div className="rounded-lg border">
+        <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 border-b px-4 py-2.5 text-xs font-medium text-muted-foreground">
+          <span>Name</span>
+          <span className="hidden sm:block">Created</span>
+          <span className="hidden sm:block">Last used</span>
+          <span className="text-end">Actions</span>
+        </div>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center gap-2 px-4 py-8 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Loading tokens…
+          </div>
+        ) : tokens.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No API tokens yet. Create one to start driving this workspace
+            programmatically.
+          </div>
+        ) : (
+          tokens.map((token) => (
+            <div
+              key={token.id}
+              className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 border-b px-4 py-3 text-sm last:border-b-0"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium">
+                  {token.name}
+                  {token.revoked && (
+                    <span className="ms-2 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                      revoked
+                    </span>
+                  )}
+                </p>
+                <p className="truncate font-mono text-xs text-muted-foreground">
+                  {token.prefix}…
+                </p>
+              </div>
+              <span className="hidden text-muted-foreground sm:block">
+                {formatDate(token.createdAt)}
+              </span>
+              <span className="hidden text-muted-foreground sm:block">
+                {formatDate(token.lastUsedAt)}
+              </span>
+              <div className="text-end">
+                {!token.revoked && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={revokingId === token.id}
+                    onClick={() => handleRevoke(token.id)}
+                  >
+                    {revokingId === token.id ? (
+                      <Loader2Icon className="size-3.5 animate-spin" />
+                    ) : (
+                      "Revoke"
+                    )}
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <Dialog
+        open={!!createdToken}
+        onOpenChange={(open) => {
+          if (!open) setCreatedToken(null)
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Copy your API token</DialogTitle>
+            <DialogDescription>
+              This is the only time the full token is shown. Store it somewhere
+              safe — you can revoke it later, but you can’t view it again.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-center gap-2">
+            <code className="min-w-0 flex-1 truncate rounded-md bg-muted px-3 py-2 font-mono text-sm">
+              {createdToken?.token}
+            </code>
+            <Button variant="outline" size="sm" onClick={copySecret}>
+              <CopyIcon className="size-4" />
+              Copy
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/social/SocialAppSidebar.tsx
+++ b/src/components/social/SocialAppSidebar.tsx
@@ -17,6 +17,7 @@ import {
   PuzzleIcon,
   BellIcon,
   SparklesIcon,
+  KeyRoundIcon,
 } from "lucide-react"
 import { useSocialAccountsStore } from "@/store/socialAccountsStore"
 import { PlatformIcon } from "./shared/PlatformIcon"
@@ -52,6 +53,7 @@ const NAV_ITEMS = [
   { href: "/social/integrations", label: "Integrations", icon: PuzzleIcon },
   { href: "/social/plugs", label: "Plugs", icon: PlugIcon },
   { href: "/social/agents", label: "Agents", icon: BotIcon },
+  { href: "/social/settings", label: "Settings", icon: KeyRoundIcon },
 ]
 
 

--- a/src/lib/api-tokens/__tests__/client.test.ts
+++ b/src/lib/api-tokens/__tests__/client.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createApiTokenRequest,
+  listApiTokensRequest,
+  revokeApiTokenRequest,
+} from "../client";
+import { setActiveWorkspaceId } from "@/lib/studio/client";
+
+function mockFetchOnce(status: number, body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("api-tokens client", () => {
+  beforeEach(() => {
+    setActiveWorkspaceId("ws_1");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setActiveWorkspaceId(null);
+  });
+
+  it("lists tokens from GET /api/tokens with the workspace header", async () => {
+    const fetchMock = mockFetchOnce(200, {
+      success: true,
+      tokens: [
+        {
+          id: "apitok_1",
+          name: "CI",
+          prefix: "nb_abc",
+          revoked: false,
+          lastUsedAt: null,
+          createdAt: "2026-07-10T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const tokens = await listApiTokensRequest();
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].name).toBe("CI");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/tokens");
+    expect(new Headers(init.headers).get("x-workspace-id")).toBe("ws_1");
+  });
+
+  it("creates a token via POST and returns the raw secret", async () => {
+    const fetchMock = mockFetchOnce(201, {
+      success: true,
+      token: {
+        id: "apitok_1",
+        name: "CI",
+        token: "nb_rawsecret",
+        prefix: "nb_rawse",
+        createdAt: "2026-07-10T00:00:00.000Z",
+      },
+    });
+
+    const created = await createApiTokenRequest("CI");
+
+    expect(created.token).toBe("nb_rawsecret");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/tokens");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ name: "CI" });
+  });
+
+  it("revokes a token via DELETE to the id-scoped path", async () => {
+    const fetchMock = mockFetchOnce(200, { success: true });
+
+    await revokeApiTokenRequest("apitok_1");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/tokens/apitok_1");
+    expect(init.method).toBe("DELETE");
+  });
+});

--- a/src/lib/api-tokens/__tests__/tokens.test.ts
+++ b/src/lib/api-tokens/__tests__/tokens.test.ts
@@ -1,0 +1,46 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  API_TOKEN_PREFIX,
+  generateApiToken,
+  hashApiToken,
+} from "../tokens";
+
+describe("api token crypto", () => {
+  it("generates a raw token carrying the recognizable nb_ prefix", () => {
+    const token = generateApiToken();
+
+    expect(token.raw.startsWith(API_TOKEN_PREFIX)).toBe(true);
+    expect(API_TOKEN_PREFIX).toBe("nb_");
+    // Non-trivial secret material beyond the prefix.
+    expect(token.raw.length).toBeGreaterThan(API_TOKEN_PREFIX.length + 20);
+  });
+
+  it("never returns the raw token as its own hash", () => {
+    const token = generateApiToken();
+
+    expect(token.hash).not.toBe(token.raw);
+    expect(token.hash).toHaveLength(64); // sha-256 hex digest
+  });
+
+  it("stores a non-secret display prefix that matches the head of the raw token", () => {
+    const token = generateApiToken();
+
+    expect(token.raw.startsWith(token.prefix)).toBe(true);
+    expect(token.prefix.startsWith(API_TOKEN_PREFIX)).toBe(true);
+    expect(token.prefix.length).toBeLessThan(token.raw.length);
+  });
+
+  it("produces two different tokens on consecutive calls", () => {
+    expect(generateApiToken().raw).not.toBe(generateApiToken().raw);
+  });
+
+  it("hashes deterministically with SHA-256 so lookups can match by hash", () => {
+    const token = generateApiToken();
+    const expected = createHash("sha256").update(token.raw).digest("hex");
+
+    expect(hashApiToken(token.raw)).toBe(expected);
+    expect(hashApiToken(token.raw)).toBe(token.hash);
+  });
+});

--- a/src/lib/api-tokens/auth.ts
+++ b/src/lib/api-tokens/auth.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server";
+
+import {
+  authzErrorResponse,
+  getPermissionsForRole,
+  withApiPermission,
+  type ContentOSPermission,
+  type ContentOSSession,
+} from "@/lib/studio/authz";
+
+import { resolveWorkspaceIdByRawToken } from "./repository";
+import { API_TOKEN_PREFIX } from "./tokens";
+
+const BEARER_SCHEME = "Bearer ";
+
+/**
+ * Permissions granted to a workspace-scoped API token. A token acts with owner
+ * permissions *within its single workspace* — enough for agents to drive the
+ * full surface, while tenant isolation is guaranteed by the fixed workspace id.
+ *
+ * Tradeoff: this is coarse (all-or-nothing per workspace). Per-token scopes /
+ * least-privilege roles would require a `scopes` column and are deliberately
+ * deferred; the workspace boundary is the security-critical guarantee here.
+ */
+const API_TOKEN_ROLE = "owner" as const;
+
+/**
+ * Extract a raw Node Banana API token from an `Authorization: Bearer nb_...`
+ * header. Returns null when the header is absent, uses another scheme, or the
+ * value does not carry the `nb_` prefix.
+ */
+export function extractBearerToken(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header || !header.startsWith(BEARER_SCHEME)) return null;
+
+  const token = header.slice(BEARER_SCHEME.length).trim();
+  if (!token.startsWith(API_TOKEN_PREFIX)) return null;
+
+  return token;
+}
+
+/** True when the request presents any `Authorization: Bearer` credential. */
+export function hasBearerCredential(request: Request): boolean {
+  const header = request.headers.get("authorization");
+  return Boolean(header && header.startsWith(BEARER_SCHEME));
+}
+
+/**
+ * Resolve a Bearer token to a ContentOS session scoped to the token's
+ * workspace. Reuses the studio authz permission model so downstream handlers
+ * behave identically to session-authenticated requests. Returns null for
+ * missing, malformed, unknown, or revoked tokens.
+ */
+export async function resolveApiTokenSession(
+  request: Request,
+): Promise<ContentOSSession | null> {
+  const raw = extractBearerToken(request);
+  if (!raw) return null;
+
+  const workspaceId = await resolveWorkspaceIdByRawToken(raw);
+  if (!workspaceId) return null;
+
+  return {
+    user: {
+      id: `apitoken:${workspaceId}`,
+      name: null,
+      email: null,
+    },
+    workspace: {
+      id: workspaceId,
+      organizationId: null,
+    },
+    role: API_TOKEN_ROLE,
+    planTier: "free",
+    permissions: getPermissionsForRole(API_TOKEN_ROLE),
+  };
+}
+
+type PublicApiAuthResult =
+  | { authorized: true; session: ContentOSSession }
+  | {
+      authorized: false;
+      response: NextResponse<{ success: false; error: string }>;
+    };
+
+/**
+ * Authorize a public API v1 request. If an `Authorization: Bearer` header is
+ * present, it is resolved through the token path exclusively (an invalid token
+ * yields 401 rather than silently falling back). Otherwise the request is
+ * delegated to the existing session-based studio authz layer, so both entry
+ * points share one tenant-isolation implementation.
+ */
+export async function authorizePublicApiRequest(
+  request: Request,
+  options: { route: string; permission: ContentOSPermission },
+): Promise<PublicApiAuthResult> {
+  if (hasBearerCredential(request)) {
+    const session = await resolveApiTokenSession(request);
+    if (!session) {
+      return {
+        authorized: false,
+        response: NextResponse.json(
+          { success: false, error: "Invalid or revoked API token." },
+          { status: 401 },
+        ),
+      };
+    }
+
+    if (!session.permissions.includes(options.permission)) {
+      return {
+        authorized: false,
+        response: NextResponse.json(
+          { success: false, error: "This token cannot access this resource." },
+          { status: 403 },
+        ),
+      };
+    }
+
+    return { authorized: true, session };
+  }
+
+  const result = await withApiPermission(request, {
+    route: options.route,
+    permission: options.permission,
+  });
+
+  if (!result.authorized) {
+    return result;
+  }
+
+  return { authorized: true, session: result.session };
+}
+
+export { authzErrorResponse };

--- a/src/lib/api-tokens/client.ts
+++ b/src/lib/api-tokens/client.ts
@@ -1,0 +1,96 @@
+/**
+ * API tokens client — frontend helpers for the workspace-settings UI.
+ * Reuses the studio client's workspace scoping and error type.
+ */
+
+import { getActiveWorkspaceId, StudioApiError } from "@/lib/studio/client";
+
+export interface ApiTokenSummaryView {
+  id: string;
+  name: string;
+  prefix: string;
+  revoked: boolean;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+export interface CreatedApiTokenView {
+  id: string;
+  name: string;
+  /** Raw secret — shown to the user exactly once. */
+  token: string;
+  prefix: string;
+  createdAt: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function mergeHeaders(init?: RequestInit): Headers {
+  const headers = new Headers(init?.headers || {});
+  const workspaceId = getActiveWorkspaceId();
+  if (workspaceId) {
+    headers.set("x-workspace-id", workspaceId);
+  }
+  return headers;
+}
+
+async function tokensFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<JsonRecord> {
+  const workspaceId = getActiveWorkspaceId();
+  if (!workspaceId) {
+    throw new StudioApiError(403, "Select a workspace to continue.");
+  }
+
+  const response = await fetch(path, {
+    ...init,
+    headers: mergeHeaders(init),
+  });
+
+  let data: unknown = null;
+  try {
+    data = await response.json();
+  } catch {
+    throw new StudioApiError(
+      response.status,
+      `Request failed with status ${response.status}`,
+    );
+  }
+
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new StudioApiError(response.status, "Invalid API response");
+  }
+
+  const record = data as JsonRecord;
+  if (!response.ok || record.success === false) {
+    const message =
+      typeof record.error === "string" ? record.error : "Request failed";
+    throw new StudioApiError(response.status, message);
+  }
+
+  return record;
+}
+
+export async function listApiTokensRequest(): Promise<ApiTokenSummaryView[]> {
+  const record = await tokensFetch("/api/tokens");
+  const tokens = record.tokens;
+  return Array.isArray(tokens) ? (tokens as ApiTokenSummaryView[]) : [];
+}
+
+export async function createApiTokenRequest(
+  name: string,
+): Promise<CreatedApiTokenView> {
+  const record = await tokensFetch("/api/tokens", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  return record.token as CreatedApiTokenView;
+}
+
+export async function revokeApiTokenRequest(tokenId: string): Promise<void> {
+  await tokensFetch(`/api/tokens/${encodeURIComponent(tokenId)}`, {
+    method: "DELETE",
+  });
+}

--- a/src/lib/api-tokens/repository.ts
+++ b/src/lib/api-tokens/repository.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import { and, desc, eq } from "drizzle-orm";
+
+import { getDb } from "@/lib/db";
+import { apiTokens } from "@/lib/db/schema";
+
+import { generateApiToken, hashApiToken } from "./tokens";
+
+export interface CreatedApiToken {
+  id: string;
+  name: string;
+  /** Raw secret — returned exactly once, never persisted. */
+  token: string;
+  prefix: string;
+  createdAt: Date;
+}
+
+export interface ApiTokenSummary {
+  id: string;
+  name: string;
+  prefix: string;
+  revoked: boolean;
+  lastUsedAt: Date | null;
+  createdAt: Date;
+}
+
+/**
+ * Mint and persist a new workspace-scoped API token. Only the SHA-256 hash and
+ * a non-secret display prefix are stored; the raw token is returned to the
+ * caller once.
+ */
+export async function createApiToken(input: {
+  workspaceId: string;
+  name: string;
+  createdByUserId: string;
+}): Promise<CreatedApiToken> {
+  const db = getDb();
+  const generated = generateApiToken();
+  const id = `apitok_${randomUUID()}`;
+
+  const [row] = await db
+    .insert(apiTokens)
+    .values({
+      id,
+      workspaceId: input.workspaceId,
+      name: input.name,
+      tokenHash: generated.hash,
+      tokenPrefix: generated.prefix,
+      createdByUserId: input.createdByUserId,
+    })
+    .returning();
+
+  return {
+    id: row.id,
+    name: row.name,
+    token: generated.raw,
+    prefix: row.tokenPrefix,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * List a workspace's tokens (newest first). Never returns the hash.
+ */
+export async function listApiTokens(
+  workspaceId: string,
+): Promise<ApiTokenSummary[]> {
+  const db = getDb();
+
+  const rows = await db
+    .select({
+      id: apiTokens.id,
+      name: apiTokens.name,
+      prefix: apiTokens.tokenPrefix,
+      revoked: apiTokens.revoked,
+      lastUsedAt: apiTokens.lastUsedAt,
+      createdAt: apiTokens.createdAt,
+    })
+    .from(apiTokens)
+    .where(eq(apiTokens.workspaceId, workspaceId))
+    .orderBy(desc(apiTokens.createdAt));
+
+  return rows;
+}
+
+/**
+ * Revoke a token within a workspace. Scoped by workspaceId so a token in
+ * another tenant can never be revoked through this call. Returns true when a
+ * matching, not-already-revoked token was updated.
+ */
+export async function revokeApiToken(input: {
+  workspaceId: string;
+  tokenId: string;
+}): Promise<boolean> {
+  const db = getDb();
+
+  const rows = await db
+    .update(apiTokens)
+    .set({ revoked: true, revokedAt: new Date(), updatedAt: new Date() })
+    .where(
+      and(
+        eq(apiTokens.id, input.tokenId),
+        eq(apiTokens.workspaceId, input.workspaceId),
+        eq(apiTokens.revoked, false),
+      ),
+    )
+    .returning({ id: apiTokens.id });
+
+  return rows.length > 0;
+}
+
+/**
+ * Resolve a raw Bearer token to the workspace it can reach. Matches by hash,
+ * ignores revoked tokens, and records last-used. Returns null for unknown or
+ * revoked tokens so callers can respond with 401.
+ */
+export async function resolveWorkspaceIdByRawToken(
+  rawToken: string,
+): Promise<string | null> {
+  const db = getDb();
+  const hash = hashApiToken(rawToken);
+
+  const [row] = await db
+    .select({ id: apiTokens.id, workspaceId: apiTokens.workspaceId })
+    .from(apiTokens)
+    .where(and(eq(apiTokens.tokenHash, hash), eq(apiTokens.revoked, false)))
+    .limit(1);
+
+  if (!row) return null;
+
+  await db
+    .update(apiTokens)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(apiTokens.id, row.id));
+
+  return row.workspaceId;
+}

--- a/src/lib/api-tokens/tokens.ts
+++ b/src/lib/api-tokens/tokens.ts
@@ -1,0 +1,48 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Recognizable, non-secret prefix on every raw API token. Lets humans and
+ * tooling spot a Node Banana token at a glance (mirrors `ghp_`, `sk-`, ...).
+ */
+export const API_TOKEN_PREFIX = "nb_";
+
+/**
+ * Number of characters (including the prefix) retained as a non-secret display
+ * hint. Enough to disambiguate tokens in a list without revealing the secret.
+ */
+const DISPLAY_PREFIX_LENGTH = 11;
+
+/** Random secret bytes appended after the prefix. 32 bytes = 256 bits. */
+const SECRET_BYTES = 32;
+
+export interface GeneratedApiToken {
+  /** Full secret, shown to the user exactly once. */
+  raw: string;
+  /** SHA-256 hex digest of the raw token — the only value persisted. */
+  hash: string;
+  /** Non-secret leading slice, safe to store and display for identification. */
+  prefix: string;
+}
+
+/**
+ * SHA-256 hex digest of a raw token. Deterministic so a presented Bearer token
+ * can be matched against the stored hash without ever persisting the secret.
+ */
+export function hashApiToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+/**
+ * Mint a new API token. Returns the raw secret (shown once), its hash (stored),
+ * and a short non-secret display prefix.
+ */
+export function generateApiToken(): GeneratedApiToken {
+  const secret = randomBytes(SECRET_BYTES).toString("base64url");
+  const raw = `${API_TOKEN_PREFIX}${secret}`;
+
+  return {
+    raw,
+    hash: hashApiToken(raw),
+    prefix: raw.slice(0, DISPLAY_PREFIX_LENGTH),
+  };
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -315,6 +315,43 @@ export const workspaceMembers = pgTable(
   }),
 );
 
+/**
+ * Workspace-scoped API tokens for programmatic (Bearer) access.
+ * Only a SHA-256 hash of the raw token is persisted; the raw value (carrying
+ * the `nb_` prefix) is shown to the user exactly once at creation.
+ */
+export const apiTokens = pgTable(
+  "api_tokens",
+  {
+    id: text("id").primaryKey(),
+    workspaceId: text("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    tokenHash: text("token_hash").notNull(),
+    tokenPrefix: text("token_prefix").notNull(),
+    revoked: boolean("revoked").default(false).notNull(),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    createdByUserId: text("created_by_user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "restrict" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    tokenHashUnique: uniqueIndex("api_tokens_token_hash_unique").on(
+      table.tokenHash,
+    ),
+    workspaceIdx: index("api_tokens_workspace_idx").on(table.workspaceId),
+    createdAtIdx: index("api_tokens_created_at_idx").on(table.createdAt),
+  }),
+);
+
 export const projects = pgTable(
   "projects",
   {
@@ -1209,6 +1246,8 @@ export const savedPrompts = pgTable(
   }),
 );
 
+export type ApiToken = typeof apiTokens.$inferSelect;
+export type NewApiToken = typeof apiTokens.$inferInsert;
 export type WorkspaceRole = typeof workspaceRoleEnum.enumValues[number];
 export type ProjectStatus = typeof projectStatusEnum.enumValues[number];
 export type AssetType = typeof assetTypeEnum.enumValues[number];


### PR DESCRIPTION
Closes #101. Part of PRD #100 — this is the foundation of the agent surface (MCP + CLI stack on it).

- `api_tokens` table (migration `0015`, clean against origin's reconciled snapshots): SHA-256 hash only, `nb_` prefix, name/created/last-used/revoked.
- Bearer auth path (`authorizePublicApiRequest`) reusing the studio authz layer — token = owner-level within exactly one workspace; tenant isolation via fixed workspaceId. Per-token least-privilege scopes deliberately deferred (documented).
- First public endpoint: `GET /api/v1/workspaces` (Bearer or session).
- Token create/list/revoke endpoints using the `withStudioAuth` convention from PR #92 (revoke maps to `workspaces:delete`).
- Workspace-settings UI (create shows token once, list, revoke) under Social Hub sidebar → Settings.

Verified: 24 new tests green (re-run by reviewer); full suite matches origin/develop baseline (only the 2 tracked pre-existing failures, fixed in #121/#122); `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)