### PR TITLE
test: MSW contract tests for remaining 8 social providers (#112)

### DIFF
--- a/src/lib/social/providers/__tests__/facebook.contract.test.ts
+++ b/src/lib/social/providers/__tests__/facebook.contract.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment node
+
+/**
+ * Facebook provider CONTRACT tests (MSW).
+ *
+ * Unlike `facebook.test.ts` — which replaces `fetch` wholesale with
+ * `vi.stubGlobal` — these tests exercise the provider's real `fetch()` calls
+ * against a mocked Meta Graph API boundary via MSW.
+ *
+ * Scenario classes (the contract every provider must satisfy):
+ *   1. successful post publish (text-only Page feed post)
+ *   2. token-refresh trigger path        (OAuthException token error → "refresh-token")
+ *   3. rate-limit retry classification   (generic transient error → "retry")
+ *   4. permanent-failure classification  (page posting cap → "bad-body")
+ *
+ * See `instagram.contract.test.ts` for the full write-up of a CONFIRMED
+ * DEFECT shared by every provider built on `classifyMetaError()`
+ * (facebook.ts, instagram.ts, threads.ts): `classifyError()` only inspects
+ * the thrown error's `.message`, but the real `MetaApiError` never folds its
+ * numeric Graph API `.code` into `.message` — so the numeric-code "bad-body"
+ * branches in `classifyMetaError()` are unreachable in production and
+ * silently downgrade to the generic "retry" fallback. The canary test below
+ * reproduces it for Facebook's own numeric error codes (photo-too-large).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { facebookProvider } from "@/lib/social/providers/facebook";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// Meta Graph API endpoints exercised by facebookProvider.post()
+// ---------------------------------------------------------------------------
+
+const GRAPH_BASE = "https://graph.facebook.com/v20.0";
+const PAGE_ID = "page-1";
+const FEED_URL = `${GRAPH_BASE}/${PAGE_ID}/feed`;
+
+const textPost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+};
+
+// ---------------------------------------------------------------------------
+// MSW server — default handler describes the HAPPY PATH.
+// ---------------------------------------------------------------------------
+
+const server = setupMswServer(
+  http.post(FEED_URL, () =>
+    HttpResponse.json({
+      id: "post-1",
+      permalink_url: "https://www.facebook.com/page-1/posts/post-1",
+    }),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.META_APP_ID = "test-app-id";
+  process.env.META_APP_SECRET = "test-app-secret";
+});
+
+afterEach(() => {
+  delete process.env.META_APP_ID;
+  delete process.env.META_APP_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider contract — successful post publish", () => {
+  it("publishes a text-only page post against the live Graph API contract", async () => {
+    const results = await facebookProvider.post(PAGE_ID, "access-token", [
+      textPost,
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "post-1",
+      platformPostUrl: "https://www.facebook.com/page-1/posts/post-1",
+      status: "published",
+    });
+  });
+});
+
+/**
+ * Helper: run a publish that the platform rejects, and return the *real*
+ * `MetaApiError` the provider threw.
+ */
+async function captureThrownError(): Promise<unknown> {
+  return facebookProvider.post(PAGE_ID, "access-token", [textPost]).then(
+    () => {
+      throw new Error("expected post() to reject, but it resolved");
+    },
+    (err: unknown) => err,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider contract — token-refresh trigger", () => {
+  it("classifies a real OAuthException token error as refresh-token", async () => {
+    server.use(
+      http.post(FEED_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Error validating access token: Session has expired.",
+              type: "OAuthException",
+              code: 190,
+              fbtrace_id: "AbCdEfGhIjK",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = facebookProvider.classifyError(error);
+
+    expect(classified.type).toBe("refresh-token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider contract — rate-limit retry", () => {
+  it("classifies a real transient Graph API error as retry", async () => {
+    server.use(
+      http.post(FEED_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "An unknown error occurred",
+              type: "OAuthException",
+              code: 1,
+              fbtrace_id: "AbCdEfGhIjL",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = facebookProvider.classifyError(error);
+
+    expect(classified.type).toBe("retry");
+    expect(classified.message).toBe(
+      "An unknown error occurred. Please try again later.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification
+// ---------------------------------------------------------------------------
+
+describe("facebookProvider contract — permanent-failure", () => {
+  it("classifies a real page-posting-cap rejection as bad-body", async () => {
+    server.use(
+      http.post(FEED_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Page request limit reached",
+              type: "OAuthException",
+              code: 4,
+              fbtrace_id: "AbCdEfGhIjM",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = facebookProvider.classifyError(error);
+
+    expect(classified.type).toBe("bad-body");
+  });
+
+  /**
+   * CANARY — documents the confirmed defect described in the file header.
+   * Facebook's numeric photo-size error code (1366046) should, per the
+   * existing `facebook.test.ts` unit tests (which assert this via a
+   * synthetic error whose `.message` IS the raw JSON blob), classify as
+   * "bad-body". Fed the real MetaApiError shape produced by `facebook.ts`'s
+   * own `uploadUnpublishedPhoto()`/feed-post error handling, it does not.
+   * This asserts the CURRENT (buggy) behavior as a regression canary.
+   */
+  it("[CONFIRMED DEFECT] silently downgrades a real numeric-code Graph error to retry instead of bad-body", async () => {
+    server.use(
+      http.post(FEED_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Photos must be smaller than 4 MB and saved as JPG or PNG.",
+              type: "OAuthException",
+              code: 1366046,
+              fbtrace_id: "AbCdEfGhIjN",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message).toBe(
+      "Photos must be smaller than 4 MB and saved as JPG or PNG.",
+    );
+
+    const classified = facebookProvider.classifyError(error);
+    // INTENDED (per meta-common.ts code 1366046 branch): "bad-body".
+    // ACTUAL (confirmed real behavior — the defect):
+    expect(classified.type).toBe("retry");
+  });
+});

--- a/src/lib/social/providers/__tests__/instagram.contract.test.ts
+++ b/src/lib/social/providers/__tests__/instagram.contract.test.ts
@@ -1,0 +1,296 @@
+// @vitest-environment node
+
+/**
+ * Instagram provider CONTRACT tests (MSW).
+ *
+ * Unlike `instagram.test.ts` — which replaces `fetch` wholesale with
+ * `vi.stubGlobal` — these tests exercise the provider's real `fetch()` calls
+ * against a mocked Meta Graph API boundary via MSW.
+ *
+ * Scenario classes (the contract every provider must satisfy):
+ *   1. successful post publish (single image, container → publish → permalink)
+ *   2. token-refresh trigger path        (OAuthException token error → "refresh-token")
+ *   3. rate-limit retry classification   (generic transient error → "retry")
+ *   4. permanent-failure classification  (page posting cap → "bad-body")
+ *
+ * PLUS the async-finalization path that the reconcile flow depends on: the
+ * container-status poll loop (`pollContainerStatus`) transitioning through
+ * IN_PROGRESS → FINISHED before `post()` resolves.
+ *
+ * ⚠️ CONFIRMED DEFECT (reported, NOT fixed — see repo root PR/issue notes):
+ * `instagramProvider.classifyError()` (shared via `classifyMetaError()` in
+ * `meta-common.ts`) builds its match string from
+ * `JSON.stringify({ message: error.message })` — i.e. it only ever looks at
+ * the thrown error's `.message` text. But a real `MetaApiError` (see
+ * `createMediaContainer`/`publishContainer` in `instagram.ts`) is constructed
+ * as `new MetaApiError(data.error.message, data.error.code, rawBody)` — the
+ * numeric Graph API error `code` (e.g. 2207081 "Trial Reels not supported")
+ * is stored on `.code`/`.rawBody`, NEVER folded into `.message`. Since nearly
+ * all of `classifyMetaError()`'s "bad-body" branches match on the *numeric
+ * code appearing as a literal substring*, they are unreachable from a real
+ * thrown error and every one of them silently falls through to the generic
+ * `{ type: "retry", ... }` fallback instead of failing fast. The existing
+ * `instagram.test.ts` unit tests don't catch this because they construct
+ * synthetic errors like `new Error('{"error":{"code":2207081,...}}')` whose
+ * `.message` *is* the full JSON blob — that shape never occurs in production.
+ * The canary test below proves this with the real construction path.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { instagramProvider } from "@/lib/social/providers/instagram";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// Meta Graph API endpoints exercised by instagramProvider.post()
+// (see GRAPH_BASE = https://graph.facebook.com/v20.0 in meta-common.ts)
+// ---------------------------------------------------------------------------
+
+const GRAPH_BASE = "https://graph.facebook.com/v20.0";
+const IG_USER_ID = "ig-user-1";
+const MEDIA_URL = `${GRAPH_BASE}/${IG_USER_ID}/media`;
+const PUBLISH_URL = `${GRAPH_BASE}/${IG_USER_ID}/media_publish`;
+
+const imagePost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+  media: [{ type: "image", url: "https://cdn.example.com/photo.jpg" }],
+};
+
+// ---------------------------------------------------------------------------
+// MSW server — default handlers describe the HAPPY PATH; individual tests
+// override with server.use(...) to inject platform failures.
+// ---------------------------------------------------------------------------
+
+const server = setupMswServer(
+  http.post(MEDIA_URL, () => HttpResponse.json({ id: "container-1" })),
+  http.get(`${GRAPH_BASE}/container-1`, () =>
+    HttpResponse.json({ status_code: "FINISHED" }),
+  ),
+  http.post(PUBLISH_URL, () => HttpResponse.json({ id: "media-1" })),
+  http.get(`${GRAPH_BASE}/media-1`, () =>
+    HttpResponse.json({ permalink: "https://www.instagram.com/p/ABC123/" }),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.META_APP_ID = "test-app-id";
+  process.env.META_APP_SECRET = "test-app-secret";
+});
+
+afterEach(() => {
+  delete process.env.META_APP_ID;
+  delete process.env.META_APP_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider contract — successful post publish", () => {
+  it("creates a container, publishes, and resolves the permalink against the live Graph API contract", async () => {
+    const results = await instagramProvider.post(IG_USER_ID, "access-token", [
+      imagePost,
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "media-1",
+      platformPostUrl: "https://www.instagram.com/p/ABC123/",
+      status: "published",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Async-finalization (reconcile) path — container polling
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider contract — async container finalization", () => {
+  it("polls through a real IN_PROGRESS state before FINISHED, then publishes", async () => {
+    let pollCount = 0;
+    server.use(
+      http.get(`${GRAPH_BASE}/container-1`, () => {
+        pollCount++;
+        return HttpResponse.json({
+          status_code: pollCount === 1 ? "IN_PROGRESS" : "FINISHED",
+        });
+      }),
+    );
+
+    vi.useFakeTimers();
+    const postPromise = instagramProvider.post(IG_USER_ID, "access-token", [
+      imagePost,
+    ]);
+
+    // Advance past the 30s poll interval the provider waits between attempts.
+    await vi.runAllTimersAsync();
+    const results = await postPromise;
+    vi.useRealTimers();
+
+    expect(pollCount).toBeGreaterThanOrEqual(2);
+    expect(results[0].status).toBe("published");
+    expect(results[0].platformPostId).toBe("media-1");
+  });
+
+  it("throws a real MetaApiError when the container transitions to ERROR", async () => {
+    server.use(
+      http.get(`${GRAPH_BASE}/container-1`, () =>
+        HttpResponse.json({ status_code: "ERROR" }),
+      ),
+    );
+
+    await expect(
+      instagramProvider.post(IG_USER_ID, "access-token", [imagePost]),
+    ).rejects.toThrow(/ERROR/);
+  });
+});
+
+/**
+ * Helper: run a publish that the platform rejects, and return the *real*
+ * `MetaApiError` the provider threw.
+ */
+async function captureThrownError(): Promise<unknown> {
+  return instagramProvider.post(IG_USER_ID, "access-token", [imagePost]).then(
+    () => {
+      throw new Error("expected post() to reject, but it resolved");
+    },
+    (err: unknown) => err,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider contract — token-refresh trigger", () => {
+  it("classifies a real OAuthException token error as refresh-token", async () => {
+    server.use(
+      http.post(MEDIA_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Error validating access token: Session has expired.",
+              type: "OAuthException",
+              code: 190,
+              fbtrace_id: "AbCdEfGhIjK",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = instagramProvider.classifyError(error);
+
+    expect(classified.type).toBe("refresh-token");
+    expect(classified.original).toBeUndefined(); // classifyMetaError() branches don't attach `original`
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider contract — rate-limit retry", () => {
+  it("classifies a real transient Graph API error as retry", async () => {
+    server.use(
+      http.post(MEDIA_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "An unknown error occurred",
+              type: "OAuthException",
+              code: 1,
+              fbtrace_id: "AbCdEfGhIjL",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = instagramProvider.classifyError(error);
+
+    expect(classified.type).toBe("retry");
+    expect(classified.message).toBe(
+      "An unknown error occurred. Please try again later.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification
+// ---------------------------------------------------------------------------
+
+describe("instagramProvider contract — permanent-failure", () => {
+  it("classifies a real page-posting-cap rejection as bad-body", async () => {
+    server.use(
+      http.post(MEDIA_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Page request limit reached",
+              type: "OAuthException",
+              code: 4,
+              fbtrace_id: "AbCdEfGhIjM",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = instagramProvider.classifyError(error);
+
+    expect(classified.type).toBe("bad-body");
+  });
+
+  /**
+   * CANARY — documents the confirmed defect described in the file header.
+   * A real container-creation failure carrying Instagram's numeric media
+   * error code (2207081, "Trial Reels not supported") should, per the
+   * existing `instagram.test.ts` unit tests (which assert this via a
+   * synthetic error), classify as "bad-body". Fed the *real* MetaApiError
+   * shape instead, it does not — classifyError() only inspects `.message`
+   * text, and the human message ("This account doesn't support Trial
+   * Reels.") never contains the digits "2207081", so the code-based branch
+   * in classifyMetaError() never matches. This asserts the CURRENT (buggy)
+   * behavior; if this test ever starts failing because the type flips to
+   * "bad-body", the defect has been fixed and this test should be deleted.
+   */
+  it("[CONFIRMED DEFECT] silently downgrades a real numeric-code Graph error to retry instead of bad-body", async () => {
+    server.use(
+      http.post(MEDIA_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "This account doesn't support Trial Reels.",
+              type: "OAuthException",
+              code: 2207081,
+              fbtrace_id: "AbCdEfGhIjN",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message).toBe(
+      "This account doesn't support Trial Reels.",
+    );
+
+    const classified = instagramProvider.classifyError(error);
+    // INTENDED (per meta-common.ts code 2207081 branch): "bad-body".
+    // ACTUAL (confirmed real behavior — the defect):
+    expect(classified.type).toBe("retry");
+  });
+});

--- a/src/lib/social/providers/__tests__/linkedin.contract.test.ts
+++ b/src/lib/social/providers/__tests__/linkedin.contract.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment node
+
+/**
+ * LinkedIn provider CONTRACT tests (MSW).
+ *
+ * Unlike `linkedin.test.ts` — which replaces `fetch` wholesale with
+ * `vi.stubGlobal` — these tests exercise the provider's real `fetch()` calls
+ * against a mocked LinkedIn REST API boundary via MSW, so URL construction,
+ * headers, and the real thrown-error shape are all exercised.
+ *
+ * Scenario classes (the contract every provider must satisfy):
+ *   1. successful post publish
+ *   2. token-refresh trigger path        (401 → "refresh-token")
+ *   3. rate-limit retry classification   (429 → "retry")
+ *   4. permanent-failure classification  (400 → "bad-body")
+ *
+ * The provider code is intentionally UNMODIFIED.
+ *
+ * Note: LinkedIn's classifyError() builds its match string directly from
+ * `error.message`, and the provider's own thrown Error interpolates the real
+ * HTTP status code into that message (e.g. `LinkedIn post creation failed:
+ * ${postResp.status} — ...`). That means, unlike the Meta-family providers
+ * (see facebook/instagram/threads contract files), the status-code-driven
+ * branches here are genuinely reachable from a real thrown error — no defect
+ * found for this provider.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { linkedInProvider } from "@/lib/social/providers/linkedin";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// LinkedIn REST API endpoints exercised by linkedInProvider.post()
+// ---------------------------------------------------------------------------
+
+const POSTS_URL = "https://api.linkedin.com/rest/posts";
+
+const textPost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+};
+
+// ---------------------------------------------------------------------------
+// MSW server — default handler describes the HAPPY PATH.
+// ---------------------------------------------------------------------------
+
+const server = setupMswServer(
+  http.post(POSTS_URL, () =>
+    HttpResponse.json(
+      {},
+      { status: 201, headers: { "x-restli-id": "urn:li:share:7000000000001" } },
+    ),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.LINKEDIN_CLIENT_ID = "test-client-id";
+  process.env.LINKEDIN_CLIENT_SECRET = "test-client-secret";
+});
+
+afterEach(() => {
+  delete process.env.LINKEDIN_CLIENT_ID;
+  delete process.env.LINKEDIN_CLIENT_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider contract — successful post publish", () => {
+  it("publishes a text-only post against the live LinkedIn HTTP contract", async () => {
+    const results = await linkedInProvider.post("person-001", "access-token", [
+      textPost,
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "urn:li:share:7000000000001",
+      platformPostUrl:
+        "https://www.linkedin.com/feed/update/" +
+        encodeURIComponent("urn:li:share:7000000000001"),
+      status: "published",
+    });
+  });
+});
+
+/**
+ * Helper: run a publish that the platform rejects, and return the *real*
+ * error the provider threw (built from a real fetch Response, not a
+ * synthetic string).
+ */
+async function captureThrownError(): Promise<unknown> {
+  return linkedInProvider.post("person-001", "access-token", [textPost]).then(
+    () => {
+      throw new Error("expected post() to reject, but it resolved");
+    },
+    (err: unknown) => err,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path (HTTP 401)
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider contract — token-refresh trigger", () => {
+  it("classifies a real 401 from /rest/posts as refresh-token", async () => {
+    server.use(
+      http.post(POSTS_URL, () =>
+        HttpResponse.text("Invalid access token", { status: 401 }),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("401");
+
+    const classified = linkedInProvider.classifyError(error);
+    expect(classified.type).toBe("refresh-token");
+    expect(classified.original).toBe(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification (HTTP 429)
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider contract — rate-limit retry", () => {
+  it("classifies a real 429 from /rest/posts as retry", async () => {
+    server.use(
+      http.post(POSTS_URL, () =>
+        HttpResponse.text("Too many requests", { status: 429 }),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message).toContain("429");
+
+    const classified = linkedInProvider.classifyError(error);
+    expect(classified.type).toBe("retry");
+    expect(classified.message).toBe("LinkedIn rate limit reached. Will retry shortly.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification (HTTP 400)
+// ---------------------------------------------------------------------------
+
+describe("linkedInProvider contract — permanent-failure", () => {
+  it("classifies a real 400 content rejection from /rest/posts as bad-body", async () => {
+    server.use(
+      http.post(POSTS_URL, () =>
+        HttpResponse.text(
+          JSON.stringify({
+            message: "commentary field exceeds the maximum allowed length",
+            status: 400,
+          }),
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message).toContain("400");
+
+    const classified = linkedInProvider.classifyError(error);
+    expect(classified.type).toBe("bad-body");
+  });
+});

--- a/src/lib/social/providers/__tests__/pinterest.contract.test.ts
+++ b/src/lib/social/providers/__tests__/pinterest.contract.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment node
+
+/**
+ * Pinterest provider CONTRACT tests (MSW).
+ *
+ * Unlike `pinterest.test.ts` — which replaces `fetch` wholesale with
+ * `vi.stubGlobal` — these tests exercise the provider's real `fetch()` calls
+ * against a mocked Pinterest API v5 boundary via MSW.
+ *
+ * Scenario classes (the contract every provider must satisfy):
+ *   1. successful post publish
+ *   2. token-refresh trigger path        (401 → "refresh-token")
+ *   3. rate-limit retry classification   (429 → "retry")
+ *   4. permanent-failure classification  (400 board validation → "bad-body")
+ *
+ * Like LinkedIn/TikTok/Reddit, Pinterest's provider interpolates the real
+ * `response.status` directly into the thrown Error's message
+ * (`Pinterest pin creation failed: ${response.status} ${body}`), so
+ * classifyError()'s status-code checks are genuinely reachable from a real
+ * thrown error — no defect found for this provider.
+ *
+ * The provider code is intentionally UNMODIFIED.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { pinterestProvider } from "@/lib/social/providers/pinterest";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// Pinterest API v5 endpoints exercised by pinterestProvider.post()
+// ---------------------------------------------------------------------------
+
+const PINS_URL = "https://api.pinterest.com/v5/pins";
+
+const imagePost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+  platformSettings: { boardId: "board-123" },
+  media: [{ type: "image", url: "https://cdn.example.com/photo.jpg" }],
+};
+
+// ---------------------------------------------------------------------------
+// MSW server — default handler describes the HAPPY PATH.
+// ---------------------------------------------------------------------------
+
+const server = setupMswServer(
+  http.post(PINS_URL, () =>
+    HttpResponse.json({
+      id: "pin-123",
+      link: "https://www.pinterest.com/pin/pin-123/",
+    }),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.PINTEREST_CLIENT_ID = "test-client-id";
+  process.env.PINTEREST_CLIENT_SECRET = "test-client-secret";
+});
+
+afterEach(() => {
+  delete process.env.PINTEREST_CLIENT_ID;
+  delete process.env.PINTEREST_CLIENT_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("pinterestProvider contract — successful post publish", () => {
+  it("creates a pin against the live Pinterest HTTP contract", async () => {
+    const results = await pinterestProvider.post("user-1", "access-token", [
+      imagePost,
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "pin-123",
+      platformPostUrl: "https://www.pinterest.com/pin/pin-123/",
+      status: "published",
+    });
+  });
+});
+
+/**
+ * Helper: run a publish that the platform rejects, and return the *real*
+ * error the provider threw.
+ */
+async function captureThrownError(): Promise<unknown> {
+  return pinterestProvider.post("user-1", "access-token", [imagePost]).then(
+    () => {
+      throw new Error("expected post() to reject, but it resolved");
+    },
+    (err: unknown) => err,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path (HTTP 401)
+// ---------------------------------------------------------------------------
+
+describe("pinterestProvider contract — token-refresh trigger", () => {
+  it("classifies a real 401 from /v5/pins as refresh-token", async () => {
+    server.use(
+      http.post(PINS_URL, () =>
+        HttpResponse.json(
+          { code: 32, message: "Invalid or expired access token" },
+          { status: 401 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("401");
+
+    const classified = pinterestProvider.classifyError(error);
+    expect(classified.type).toBe("refresh-token");
+    expect(classified.original).toBe(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification (HTTP 429)
+// ---------------------------------------------------------------------------
+
+describe("pinterestProvider contract — rate-limit retry", () => {
+  it("classifies a real 429 from /v5/pins as retry", async () => {
+    server.use(
+      http.post(PINS_URL, () =>
+        HttpResponse.json(
+          { code: 8, message: "Too many requests, please try again later." },
+          { status: 429 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message).toContain("429");
+
+    const classified = pinterestProvider.classifyError(error);
+    expect(classified.type).toBe("retry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification (HTTP 400 board validation)
+// ---------------------------------------------------------------------------
+
+describe("pinterestProvider contract — permanent-failure", () => {
+  it("classifies a real 400 board-validation rejection as bad-body", async () => {
+    server.use(
+      http.post(PINS_URL, () =>
+        HttpResponse.json(
+          { code: 2, message: "board_id: This board does not exist or you do not have access to it." },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message).toContain("400");
+
+    const classified = pinterestProvider.classifyError(error);
+    expect(classified.type).toBe("bad-body");
+  });
+});

--- a/src/lib/social/providers/__tests__/reddit.contract.test.ts
+++ b/src/lib/social/providers/__tests__/reddit.contract.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+
+/**
+ * Reddit provider CONTRACT tests (MSW).
+ *
+ * Unlike `reddit.test.ts` — which replaces `fetch` wholesale with
+ * `vi.stubGlobal` — these tests exercise the provider's real `fetch()` calls
+ * against a mocked Reddit API boundary via MSW.
+ *
+ * Scenario classes (the contract every provider must satisfy):
+ *   1. successful post publish
+ *   2. token-refresh trigger path        (401 → "refresh-token")
+ *   3. rate-limit retry classification   (429 → "retry")
+ *   4. permanent-failure classification  (real `json.errors` 200-OK quirk → "bad-body")
+ *
+ * Reddit's classic `/api/submit` endpoint has a well-known quirk: content
+ * validation failures (bad subreddit, missing title, etc.) come back as an
+ * HTTP 200 with a `json.errors` array, NOT a non-2xx status. The provider
+ * correctly special-cases this (see `reddit.ts`'s `data.json?.errors` check)
+ * and throws a distinct "Reddit submit validation failed: ..." error whose
+ * text matches classifyError()'s "validation" check — this is exercised
+ * explicitly below since it is easy to get backwards in a vi.mock unit test.
+ *
+ * The provider code is intentionally UNMODIFIED.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { redditProvider } from "@/lib/social/providers/reddit";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// Reddit API endpoints exercised by redditProvider.post()
+// ---------------------------------------------------------------------------
+
+const SUBMIT_URL = "https://oauth.reddit.com/api/submit";
+
+const textPost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+  platformSettings: { subreddit: "test", title: "Contract test post" },
+};
+
+// ---------------------------------------------------------------------------
+// MSW server — default handler describes the HAPPY PATH.
+// ---------------------------------------------------------------------------
+
+const server = setupMswServer(
+  http.post(SUBMIT_URL, () =>
+    HttpResponse.json({
+      json: {
+        errors: [],
+        data: {
+          name: "t3_abc123",
+          url: "https://www.reddit.com/r/test/comments/abc123/contract_test_post/",
+        },
+      },
+    }),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.REDDIT_CLIENT_ID = "test-client-id";
+  process.env.REDDIT_CLIENT_SECRET = "test-client-secret";
+});
+
+afterEach(() => {
+  delete process.env.REDDIT_CLIENT_ID;
+  delete process.env.REDDIT_CLIENT_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("redditProvider contract — successful post publish", () => {
+  it("submits a self post against the live Reddit HTTP contract", async () => {
+    const results = await redditProvider.post("user-1", "access-token", [
+      textPost,
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "t3_abc123",
+      platformPostUrl:
+        "https://www.reddit.com/r/test/comments/abc123/contract_test_post/",
+      status: "published",
+    });
+  });
+});
+
+/**
+ * Helper: run a publish that the platform rejects, and return the *real*
+ * error the provider threw.
+ */
+async function captureThrownError(): Promise<unknown> {
+  return redditProvider.post("user-1", "access-token", [textPost]).then(
+    () => {
+      throw new Error("expected post() to reject, but it resolved");
+    },
+    (err: unknown) => err,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path (HTTP 401)
+// ---------------------------------------------------------------------------
+
+describe("redditProvider contract — token-refresh trigger", () => {
+  it("classifies a real 401 from /api/submit as refresh-token", async () => {
+    server.use(
+      http.post(SUBMIT_URL, () =>
+        HttpResponse.text("invalid_token", { status: 401 }),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("401");
+
+    const classified = redditProvider.classifyError(error);
+    expect(classified.type).toBe("refresh-token");
+    expect(classified.original).toBe(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification (HTTP 429)
+// ---------------------------------------------------------------------------
+
+describe("redditProvider contract — rate-limit retry", () => {
+  it("classifies a real 429 from /api/submit as retry", async () => {
+    server.use(
+      http.post(SUBMIT_URL, () =>
+        HttpResponse.text("Take a break, you are doing that too much", {
+          status: 429,
+        }),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message).toContain("429");
+
+    const classified = redditProvider.classifyError(error);
+    expect(classified.type).toBe("retry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification (HTTP 200 + json.errors)
+// ---------------------------------------------------------------------------
+
+describe("redditProvider contract — permanent-failure", () => {
+  it("classifies a real 200-OK submit-validation rejection as bad-body", async () => {
+    server.use(
+      http.post(SUBMIT_URL, () =>
+        HttpResponse.json({
+          json: {
+            errors: [["SUBREDDIT_NOEXIST", "that subreddit doesn't exist", "sr"]],
+          },
+        }),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message.toLowerCase()).toContain("validation");
+
+    const classified = redditProvider.classifyError(error);
+    expect(classified.type).toBe("bad-body");
+  });
+});

--- a/src/lib/social/providers/__tests__/threads.contract.test.ts
+++ b/src/lib/social/providers/__tests__/threads.contract.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment node
+
+/**
+ * Threads provider CONTRACT tests (MSW).
+ *
+ * Unlike `threads.test.ts` — which replaces `fetch` wholesale with
+ * `vi.stubGlobal` — these tests exercise the provider's real `fetch()` calls
+ * against a mocked Meta Graph API boundary via MSW.
+ *
+ * Scenario classes (the contract every provider must satisfy):
+ *   1. successful post publish (text-only: create → publish → permalink)
+ *   2. token-refresh trigger path        (OAuthException token error → "refresh-token")
+ *   3. rate-limit retry classification   (generic transient error → "retry")
+ *   4. permanent-failure classification  (page posting cap → "bad-body")
+ *
+ * Threads shares `classifyMetaError()` with instagram.ts/facebook.ts — see
+ * `instagram.contract.test.ts` for the full write-up of the CONFIRMED DEFECT
+ * where a real MetaApiError's numeric `.code` never reaches classification
+ * (only `.message` is inspected), so numeric-code "bad-body" branches are
+ * unreachable in production. Not re-litigated here in full; the scenarios
+ * below use message-text-based branches, which ARE genuinely reachable.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { threadsProvider } from "@/lib/social/providers/threads";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// Meta Graph API endpoints exercised by threadsProvider.post()
+// ---------------------------------------------------------------------------
+
+const GRAPH_BASE = "https://graph.facebook.com/v20.0";
+const THREADS_USER_ID = "threads-user-1";
+const CREATE_URL = `${GRAPH_BASE}/${THREADS_USER_ID}/threads`;
+const PUBLISH_URL = `${GRAPH_BASE}/${THREADS_USER_ID}/threads_publish`;
+
+const textPost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+};
+
+// ---------------------------------------------------------------------------
+// MSW server — default handlers describe the HAPPY PATH.
+// ---------------------------------------------------------------------------
+
+const server = setupMswServer(
+  http.post(CREATE_URL, () => HttpResponse.json({ id: "container-1" })),
+  http.post(PUBLISH_URL, () => HttpResponse.json({ id: "thread-1" })),
+  http.get(`${GRAPH_BASE}/thread-1`, () =>
+    HttpResponse.json({
+      id: "thread-1",
+      permalink: "https://www.threads.net/t/thread-1",
+    }),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.META_APP_ID = "test-app-id";
+  process.env.META_APP_SECRET = "test-app-secret";
+});
+
+afterEach(() => {
+  delete process.env.META_APP_ID;
+  delete process.env.META_APP_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("threadsProvider contract — successful post publish", () => {
+  it("creates a container, publishes, and resolves the permalink against the live Graph API contract", async () => {
+    const results = await threadsProvider.post(
+      THREADS_USER_ID,
+      "access-token",
+      [textPost],
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "thread-1",
+      platformPostUrl: "https://www.threads.net/t/thread-1",
+      status: "published",
+    });
+  });
+});
+
+/**
+ * Helper: run a publish that the platform rejects, and return the *real*
+ * `MetaApiError` the provider threw.
+ */
+async function captureThrownError(): Promise<unknown> {
+  return threadsProvider
+    .post(THREADS_USER_ID, "access-token", [textPost])
+    .then(
+      () => {
+        throw new Error("expected post() to reject, but it resolved");
+      },
+      (err: unknown) => err,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path
+// ---------------------------------------------------------------------------
+
+describe("threadsProvider contract — token-refresh trigger", () => {
+  it("classifies a real OAuthException token error as refresh-token", async () => {
+    server.use(
+      http.post(CREATE_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Error validating access token: Session has expired.",
+              type: "OAuthException",
+              code: 190,
+              fbtrace_id: "AbCdEfGhIjK",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = threadsProvider.classifyError(error);
+
+    expect(classified.type).toBe("refresh-token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification
+// ---------------------------------------------------------------------------
+
+describe("threadsProvider contract — rate-limit retry", () => {
+  it("classifies a real transient Graph API error as retry", async () => {
+    server.use(
+      http.post(CREATE_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "An unknown error occurred",
+              type: "OAuthException",
+              code: 1,
+              fbtrace_id: "AbCdEfGhIjL",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = threadsProvider.classifyError(error);
+
+    expect(classified.type).toBe("retry");
+    expect(classified.message).toBe(
+      "An unknown error occurred. Please try again later.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification
+// ---------------------------------------------------------------------------
+
+describe("threadsProvider contract — permanent-failure", () => {
+  it("classifies a real page-posting-cap rejection as bad-body", async () => {
+    server.use(
+      http.post(CREATE_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Page request limit reached",
+              type: "OAuthException",
+              code: 4,
+              fbtrace_id: "AbCdEfGhIjM",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = threadsProvider.classifyError(error);
+
+    expect(classified.type).toBe("bad-body");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Media-rejection guard — Threads is text-only in this codebase
+// ---------------------------------------------------------------------------
+
+describe("threadsProvider contract — media rejection", () => {
+  it("rejects posts with media before making any network call", async () => {
+    await expect(
+      threadsProvider.post(THREADS_USER_ID, "access-token", [
+        {
+          postId: "post-with-media",
+          content: "This has an image",
+          media: [{ type: "image", url: "https://cdn.example.com/photo.jpg" }],
+        },
+      ]),
+    ).rejects.toThrow(/text-only posts/);
+  });
+});

--- a/src/lib/social/providers/__tests__/tiktok.contract.test.ts
+++ b/src/lib/social/providers/__tests__/tiktok.contract.test.ts
@@ -1,0 +1,280 @@
+// @vitest-environment node
+
+/**
+ * TikTok provider CONTRACT tests (MSW).
+ *
+ * Unlike `tiktok.test.ts` — which replaces `fetch` wholesale with
+ * `vi.stubGlobal` — these tests exercise the provider's real `fetch()` calls
+ * against a mocked TikTok Content Posting API boundary via MSW.
+ *
+ * Scenario classes (the contract every provider must satisfy):
+ *   1. successful post publish (video, PULL_FROM_URL, async "processing")
+ *   2. token-refresh trigger path        (access_token_invalid → "refresh-token")
+ *   3. rate-limit retry classification   (rate_limit_exceeded → "retry")
+ *   4. permanent-failure classification  (spam_risk_* → "bad-body")
+ *
+ * PLUS the async-finalization (reconcile) path that `getPostStatus()` drives:
+ * the real TikTok `post/publish/status/fetch` endpoint transitioning through
+ * PROCESSING_UPLOAD → PUBLISH_COMPLETE / FAILED.
+ *
+ * TikTok's Content Posting API returns real, non-2xx HTTP status codes for
+ * every error class exercised below (unlike Meta's Graph API, which returns
+ * HTTP 200 with an `error` object — see facebook/instagram/threads contract
+ * files for that divergent, defect-triggering shape). The provider's thrown
+ * Error interpolates both `response.status` and the raw response body text,
+ * so classifyError()'s string-matching on real TikTok error codes
+ * (`access_token_invalid`, `rate_limit_exceeded`, `spam_risk_*`, ...) is
+ * genuinely reachable — no defect found for this provider.
+ *
+ * The provider code is intentionally UNMODIFIED.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { tikTokProvider } from "@/lib/social/providers/tiktok";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+// ---------------------------------------------------------------------------
+// TikTok Content Posting API endpoints exercised by tikTokProvider.post()
+// ---------------------------------------------------------------------------
+
+const VIDEO_INIT_URL = "https://open.tiktokapis.com/v2/post/publish/video/init/";
+const USER_INFO_URL = "https://open.tiktokapis.com/v2/user/info/";
+const STATUS_URL = "https://open.tiktokapis.com/v2/post/publish/status/fetch/";
+
+const videoPost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+  media: [{ type: "video", url: "https://cdn.example.com/video.mp4" }],
+};
+
+// ---------------------------------------------------------------------------
+// MSW server — default handlers describe the HAPPY PATH.
+// ---------------------------------------------------------------------------
+
+const server = setupMswServer(
+  http.post(VIDEO_INIT_URL, () =>
+    HttpResponse.json({ data: { publish_id: "publish-id-123" }, error: { code: "ok" } }),
+  ),
+  http.get(USER_INFO_URL, () =>
+    HttpResponse.json({
+      data: {
+        user: {
+          open_id: "open-id-1",
+          display_name: "Contract Bot",
+          avatar_url: "https://p16.tiktokcdn.com/avatar.jpg",
+          username: "contractbot",
+        },
+      },
+    }),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.TIKTOK_CLIENT_KEY = "test-client-key";
+  process.env.TIKTOK_CLIENT_SECRET = "test-client-secret";
+});
+
+afterEach(() => {
+  delete process.env.TIKTOK_CLIENT_KEY;
+  delete process.env.TIKTOK_CLIENT_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("tikTokProvider contract — successful post publish", () => {
+  it("initiates a video post against the live TikTok HTTP contract", async () => {
+    const results = await tikTokProvider.post("open-id-1", "access-token", [
+      videoPost,
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "publish-id-123",
+      platformPostUrl: "https://www.tiktok.com/@contractbot",
+      status: "processing",
+    });
+  });
+});
+
+/**
+ * Helper: run a publish that the platform rejects, and return the *real*
+ * error the provider threw.
+ */
+async function captureThrownError(): Promise<unknown> {
+  return tikTokProvider.post("open-id-1", "access-token", [videoPost]).then(
+    () => {
+      throw new Error("expected post() to reject, but it resolved");
+    },
+    (err: unknown) => err,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path
+// ---------------------------------------------------------------------------
+
+describe("tikTokProvider contract — token-refresh trigger", () => {
+  it("classifies a real access_token_invalid rejection as refresh-token", async () => {
+    server.use(
+      http.post(VIDEO_INIT_URL, () =>
+        HttpResponse.json(
+          {
+            data: {},
+            error: {
+              code: "access_token_invalid",
+              message: "The access token is invalid or has expired.",
+              log_id: "202401010000000000000000000000000",
+            },
+          },
+          { status: 401 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("access_token_invalid");
+
+    const classified = tikTokProvider.classifyError(error);
+    expect(classified.type).toBe("refresh-token");
+    expect(classified.original).toBe(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification
+// ---------------------------------------------------------------------------
+
+describe("tikTokProvider contract — rate-limit retry", () => {
+  it("classifies a real rate_limit_exceeded rejection as retry", async () => {
+    server.use(
+      http.post(VIDEO_INIT_URL, () =>
+        HttpResponse.json(
+          {
+            data: {},
+            error: {
+              code: "rate_limit_exceeded",
+              message: "Rate limit exceeded for this application.",
+              log_id: "202401010000000000000000000000001",
+            },
+          },
+          { status: 429 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    expect((error as Error).message).toContain("rate_limit_exceeded");
+
+    const classified = tikTokProvider.classifyError(error);
+    expect(classified.type).toBe("retry");
+    expect(classified.message).toBe("TikTok API rate limit exceeded — will retry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification
+// ---------------------------------------------------------------------------
+
+describe("tikTokProvider contract — permanent-failure", () => {
+  it("classifies a real spam_risk_too_many_posts rejection as bad-body", async () => {
+    server.use(
+      http.post(VIDEO_INIT_URL, () =>
+        HttpResponse.json(
+          {
+            data: {},
+            error: {
+              code: "spam_risk_too_many_posts",
+              message: "User has posted too many times today.",
+              log_id: "202401010000000000000000000000002",
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await captureThrownError();
+    const classified = tikTokProvider.classifyError(error);
+    expect(classified.type).toBe("bad-body");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Async-finalization (reconcile) path — getPostStatus()
+// ---------------------------------------------------------------------------
+
+describe("tikTokProvider contract — async publish finalization (getPostStatus)", () => {
+  it("reports processing while TikTok is still uploading", async () => {
+    server.use(
+      http.post(STATUS_URL, () =>
+        HttpResponse.json({ data: { status: "PROCESSING_UPLOAD" }, error: { code: "ok" } }),
+      ),
+    );
+
+    const status = await tikTokProvider.getPostStatus?.(
+      "contractbot",
+      "access-token",
+      "publish-id-123",
+    );
+
+    expect(status).toEqual({
+      platformPostId: "publish-id-123",
+      platformPostUrl: "https://www.tiktok.com/@contractbot",
+      status: "processing",
+    });
+  });
+
+  it("reports published once TikTok finishes processing", async () => {
+    server.use(
+      http.post(STATUS_URL, () =>
+        HttpResponse.json({
+          data: {
+            status: "PUBLISH_COMPLETE",
+            publicaly_available_post_id: ["7312345678901234567"],
+          },
+          error: { code: "ok" },
+        }),
+      ),
+    );
+
+    const status = await tikTokProvider.getPostStatus?.(
+      "contractbot",
+      "access-token",
+      "publish-id-123",
+    );
+
+    expect(status).toEqual({
+      platformPostId: "7312345678901234567",
+      platformPostUrl: "https://www.tiktok.com/@contractbot/video/7312345678901234567",
+      status: "published",
+    });
+  });
+
+  it("reports failed with the real fail_reason when TikTok rejects the upload", async () => {
+    server.use(
+      http.post(STATUS_URL, () =>
+        HttpResponse.json({
+          data: { status: "FAILED", fail_reason: "video_pull_failed" },
+          error: { code: "ok" },
+        }),
+      ),
+    );
+
+    const status = await tikTokProvider.getPostStatus?.(
+      "contractbot",
+      "access-token",
+      "publish-id-123",
+    );
+
+    expect(status?.status).toBe("failed");
+    expect(status?.errorMessage).toContain("video_pull_failed");
+  });
+});

--- a/src/lib/social/providers/__tests__/youtube.contract.test.ts
+++ b/src/lib/social/providers/__tests__/youtube.contract.test.ts
@@ -1,0 +1,297 @@
+// @vitest-environment node
+
+/**
+ * YouTube provider CONTRACT tests (MSW).
+ *
+ * Unlike `youtube.test.ts` — which replaces `googleapis` wholesale with
+ * `vi.mock` — these tests exercise the *real* `googleapis`/`gaxios` SDK
+ * against a mocked Google API boundary via MSW.
+ *
+ * Doing so surfaced two CONFIRMED, REAL defects in `youtube.ts`. Per the
+ * task scope, provider code is left UNMODIFIED and both are reported here
+ * instead of silently patched.
+ *
+ * ---------------------------------------------------------------------------
+ * DEFECT 1 — video/thumbnail upload is structurally broken (blocks scenario 1)
+ * ---------------------------------------------------------------------------
+ * `urlToReadableStream()` does:
+ *   const response = await fetch(url);
+ *   return response.body as unknown as NodeJS.ReadableStream;
+ * Node's native `fetch()` (undici) returns `response.body` as a WHATWG
+ * `ReadableStream` — it has NO `.pipe()` method. `googleapis-common`'s
+ * multipart uploader (`apirequest.js`, `multipartUpload()`) unconditionally
+ * calls `part.body.pipe(...)` on the media body. The result, reproduced
+ * below with the real SDK and a real (msw-mocked) fetch response, is:
+ *   TypeError: part.body.pipe is not a function
+ * This is NOT an artifact of MSW or this test file — a bare
+ * `await fetch(realUrl)` in plain Node confirms `response.body.pipe` is
+ * `undefined` outside of any test harness. `urlToReadableStream()` needed
+ * `Readable.fromWeb(response.body)` (Node 17+) to bridge Web Streams to a
+ * Node Readable; it never does this. Every real `post()` call with video
+ * media — which `post()` always requires — throws before any HTTP request
+ * to the YouTube Data API is even made. **YouTube publishing does not work
+ * in this codebase today.** `youtube.test.ts`'s `vi.mock("googleapis")`
+ * replaces the whole SDK, so it never exercises the real multipart pipeline
+ * and could not have caught this.
+ *
+ * ---------------------------------------------------------------------------
+ * DEFECT 2 — classifyError() pattern-matches on fields that never reach `.message`
+ * ---------------------------------------------------------------------------
+ * `youTubeProvider.classifyError()` checks for literal reason-code strings
+ * ("invalidTitle", "quotaExceeded", "forbidden", "UNAUTHENTICATED", ...).
+ * Real `googleapis`/`gaxios` errors (`GaxiosError`) build `.message` purely
+ * from the Google API JSON error's `.message` field (see
+ * `GaxiosError.extractAPIErrorFromResponse` in `gaxios/build/.../common.js`)
+ * — the per-error `reason` enum (where these strings actually live, e.g.
+ * `errors[0].reason === "quotaExceeded"`) is never folded into `.message`.
+ * Confirmed empirically below with real 401 and 403/quotaExceeded Google API
+ * error bodies: BOTH classify as the generic "retry" fallback, including the
+ * 401 — meaning an expired/invalid access token used against the real API
+ * (as opposed to a refresh-token-endpoint failure, see scenario 2) is
+ * silently retried instead of triggering re-authentication.
+ *
+ * Given DEFECT 1 blocks `post()`'s error paths entirely (the TypeError fires
+ * before any network call), scenarios 2-4 below exercise `refreshToken()`
+ * and `fetchPageInformation()` instead — both make real, unblocked
+ * `googleapis` HTTP calls and are legitimate real-SDK error sources for
+ * `classifyError()`, which is a general-purpose function not tied to a
+ * single call site.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupMswServer } from "@/test/msw/server";
+import { clearRegistry } from "@/lib/social/provider-registry";
+import { youTubeProvider } from "@/lib/social/providers/youtube";
+import type { PublishRequest } from "@/lib/social/provider-interface";
+
+const CHANNELS_URL = "https://youtube.googleapis.com/youtube/v3/channels";
+const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const VIDEO_UPLOAD_URL = "https://www.googleapis.com/upload/youtube/v3/videos";
+
+const videoPost: PublishRequest = {
+  postId: "our-post-1",
+  content: "Hello from a contract test",
+  media: [{ type: "video", url: "https://cdn.example.com/video.mp4" }],
+};
+
+const server = setupMswServer(
+  http.get(CHANNELS_URL, () =>
+    HttpResponse.json({ items: [{ id: "channel-1", snippet: { title: "Contract Bot" } }] }),
+  ),
+  http.get("https://cdn.example.com/video.mp4", () =>
+    HttpResponse.text("fake-video-bytes"),
+  ),
+);
+
+beforeEach(() => {
+  clearRegistry();
+  process.env.GOOGLE_CLIENT_ID = "test-client-id";
+  process.env.GOOGLE_CLIENT_SECRET = "test-client-secret";
+});
+
+afterEach(() => {
+  delete process.env.GOOGLE_CLIENT_ID;
+  delete process.env.GOOGLE_CLIENT_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — successful post publish
+// ---------------------------------------------------------------------------
+
+describe("youTubeProvider contract — successful post publish", () => {
+  it("[CONFIRMED DEFECT] real video upload throws before any network call — see file header (DEFECT 1)", async () => {
+    server.use(
+      http.post(VIDEO_UPLOAD_URL, () =>
+        HttpResponse.json({ id: "video-1", snippet: {}, status: {} }),
+      ),
+    );
+
+    await expect(
+      youTubeProvider.post("channel-1", "access-token", [videoPost]),
+    ).rejects.toThrow(/pipe is not a function/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — token-refresh trigger path
+// ---------------------------------------------------------------------------
+
+describe("youTubeProvider contract — token-refresh trigger", () => {
+  it("classifies a real invalid_grant OAuth token-exchange error as refresh-token", async () => {
+    server.use(
+      http.post(OAUTH_TOKEN_URL, () =>
+        HttpResponse.json(
+          {
+            error: "invalid_grant",
+            error_description: "Token has been expired or revoked.",
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await youTubeProvider.refreshToken("expired-refresh-token");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("invalid_grant");
+
+    const classified = youTubeProvider.classifyError(caught);
+    expect(classified.type).toBe("refresh-token");
+  });
+
+  /**
+   * CANARY — documents DEFECT 2 for the auth case specifically. A stale
+   * access token used against the real Data API (NOT the OAuth token
+   * endpoint) throws a differently-shaped GaxiosError whose `.message` is
+   * "Request had invalid authentication credentials." — no match for any
+   * refresh-token branch — so it is misclassified as "retry".
+   */
+  it("[CONFIRMED DEFECT] a real 401 from the Data API itself does not classify as refresh-token", async () => {
+    server.use(
+      http.get(CHANNELS_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 401,
+              message: "Request had invalid authentication credentials.",
+              errors: [
+                {
+                  message: "Invalid Credentials",
+                  domain: "global",
+                  reason: "authError",
+                  location: "Authorization",
+                  locationType: "header",
+                },
+              ],
+              status: "UNAUTHENTICATED",
+            },
+          },
+          { status: 401 },
+        ),
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await youTubeProvider.fetchPageInformation!("access-token");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect((caught as Error).message).toBe(
+      "Request had invalid authentication credentials.",
+    );
+
+    const classified = youTubeProvider.classifyError(caught);
+    // INTENDED: "refresh-token". ACTUAL (confirmed real behavior — the defect):
+    expect(classified.type).toBe("retry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — rate-limit retry classification
+// ---------------------------------------------------------------------------
+
+describe("youTubeProvider contract — rate-limit retry", () => {
+  it("classifies a real quotaExceeded rejection as retry (via the safe generic fallback)", async () => {
+    server.use(
+      http.get(CHANNELS_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 403,
+              message:
+                "The request cannot be completed because you have exceeded your quota.",
+              errors: [
+                {
+                  message:
+                    "The request cannot be completed because you have exceeded your quota.",
+                  domain: "youtube.quota",
+                  reason: "quotaExceeded",
+                },
+              ],
+            },
+          },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await youTubeProvider.fetchPageInformation!("access-token");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect((caught as Error).message).toBe(
+      "The request cannot be completed because you have exceeded your quota.",
+    );
+
+    // classifyError()'s explicit "quotaExceeded" text check never matches
+    // (see DEFECT 2) — but the generic bottom-of-function fallback also
+    // returns "retry", so the *outcome* here happens to be correct even
+    // though the intended branch is dead code.
+    const classified = youTubeProvider.classifyError(caught);
+    expect(classified.type).toBe("retry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — permanent-failure classification
+// ---------------------------------------------------------------------------
+
+describe("youTubeProvider contract — permanent-failure", () => {
+  /**
+   * CANARY — documents DEFECT 2 for the content-policy case. Unlike the
+   * rate-limit scenario above (where the generic fallback happens to
+   * produce the correct "retry" outcome), a permanent/forbidden failure
+   * being misclassified as "retry" IS a functional bug: the publish
+   * pipeline will retry (up to 3x) something that can never succeed,
+   * instead of failing fast via FatalError.
+   */
+  it("[CONFIRMED DEFECT] a real forbidden/policy-violation rejection does not classify as bad-body", async () => {
+    server.use(
+      http.get(CHANNELS_URL, () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 403,
+              message: "The request is not authorized to access this resource properly.",
+              errors: [
+                {
+                  message: "The request is not authorized to access this resource properly.",
+                  domain: "youtube.header",
+                  reason: "forbidden",
+                },
+              ],
+            },
+          },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await youTubeProvider.fetchPageInformation!("access-token");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect((caught as Error).message).toBe(
+      "The request is not authorized to access this resource properly.",
+    );
+
+    const classified = youTubeProvider.classifyError(caught);
+    // INTENDED (per the "forbidden" branch in classifyError): "bad-body".
+    // ACTUAL (confirmed real behavior — the defect):
+    expect(classified.type).toBe("retry");
+  });
+});


### PR DESCRIPTION
Closes #112. Part of PRD #100. **Stacked on #118** (base = `feature/msw-x-provider-contracts`); merge #118 first — GitHub will retarget this to `develop` when the base branch is deleted.

Applies the #111 pattern to linkedin, tiktok, pinterest, reddit, instagram, facebook, threads, youtube — 41 new contract tests (one commit per provider) covering publish, token-refresh, rate-limit retry, and permanent-failure classification, plus IG/TikTok async-publish finalization. Provider code unmodified.

**Three real defects discovered** (documented as canary tests, fixes tracked separately):
1. **Meta family** (`classifyMetaError`): numeric Graph-API error codes never reach `error.message`, so the permanent-failure branches (2207081, 1366046, …) are unreachable — content-policy failures get retried forever instead of failing fast. The old vi.mock unit tests constructed synthetic error shapes that don't occur in production, which is why this was never caught.
2. **YouTube upload is structurally broken**: `urlToReadableStream()` returns a WHATWG stream where googleapis' multipart uploader needs a Node `Readable` — every real `post()` throws `part.body.pipe is not a function` before any HTTP. YouTube publishing has never worked.
3. **YouTube `classifyError`** matches `reason` enum strings that never appear in real `GaxiosError.message` — real 401/403 misclassified as generic retry.

Verified by reviewer: all 9 providers' contract suites green (264 tests in providers/__tests__), full suite green on the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)