### PR TITLE
feat: per-workspace BYOK provider-key vault (#107)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,17 @@ SOCIAL_TOKEN_ENCRYPTION_KEY=
 # (e.g., /api/social/internal/cleanup). Generate with: openssl rand -hex 32
 SOCIAL_INTERNAL_API_SECRET=
 
+# ------------------------------------------------------------------------------
+# BYOK Provider Key Vault
+# ------------------------------------------------------------------------------
+
+# AES-256-GCM encryption key for per-workspace AI provider keys (Gemini, OpenAI,
+# Anthropic, Kie, Fal, Replicate, WaveSpeed) at rest. Separate from
+# SOCIAL_TOKEN_ENCRYPTION_KEY so rotating one never invalidates the other.
+# Generate with: openssl rand -hex 32
+# Required in production. In dev with DEV_AUTH_BYPASS=true, keys are stored in plaintext.
+BYOK_KEY_ENCRYPTION_KEY=
+
 # Optional internal scheduler tuning
 SOCIAL_DISPATCH_BATCH_SIZE=20
 SOCIAL_DISPATCH_MAX_ATTEMPTS=5

--- a/drizzle/0016_dusty_vanisher.sql
+++ b/drizzle/0016_dusty_vanisher.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "public"."byok_provider" AS ENUM('gemini', 'openai', 'anthropic', 'kie', 'fal', 'replicate', 'wavespeed');--> statement-breakpoint
+CREATE TABLE "workspace_provider_keys" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"provider" "byok_provider" NOT NULL,
+	"key_encrypted" text NOT NULL,
+	"key_hint" text NOT NULL,
+	"last_validated_at" timestamp with time zone,
+	"created_by_user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "workspace_provider_keys" ADD CONSTRAINT "workspace_provider_keys_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "workspace_provider_keys" ADD CONSTRAINT "workspace_provider_keys_created_by_user_id_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."user"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "workspace_provider_keys_workspace_provider_unique" ON "workspace_provider_keys" USING btree ("workspace_id","provider");--> statement-breakpoint
+CREATE INDEX "workspace_provider_keys_workspace_idx" ON "workspace_provider_keys" USING btree ("workspace_id");

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,5625 @@
+{
+  "id": "3abf4da1-f48d-4c44-a964-1879f81cf01b",
+  "prevId": "68f3b187-73ad-4e07-a499-10d1e311da14",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_workspace_idx": {
+          "name": "api_tokens_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_created_at_idx": {
+          "name": "api_tokens_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_workspace_id_workspaces_id_fk": {
+          "name": "api_tokens_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_tokens_created_by_user_id_user_id_fk": {
+          "name": "api_tokens_created_by_user_id_user_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "storage_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "assets_workspace_idx": {
+          "name": "assets_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_idx": {
+          "name": "assets_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_storage_provider_key_unique": {
+          "name": "assets_storage_provider_key_unique",
+          "columns": [
+            {
+              "expression": "storage_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_created_at_idx": {
+          "name": "assets_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_workspace_id_workspaces_id_fk": {
+          "name": "assets_workspace_id_workspaces_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assets_created_by_user_id_user_id_fk": {
+          "name": "assets_created_by_user_id_user_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_jobs": {
+      "name": "generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "generation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_asset_id": {
+          "name": "result_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "generation_jobs_workspace_idx": {
+          "name": "generation_jobs_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_project_idx": {
+          "name": "generation_jobs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_status_idx": {
+          "name": "generation_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generation_jobs_created_at_idx": {
+          "name": "generation_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_jobs_workspace_id_workspaces_id_fk": {
+          "name": "generation_jobs_workspace_id_workspaces_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_project_id_projects_id_fk": {
+          "name": "generation_jobs_project_id_projects_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_result_asset_id_assets_id_fk": {
+          "name": "generation_jobs_result_asset_id_assets_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "result_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_jobs_created_by_user_id_user_id_fk": {
+          "name": "generation_jobs_created_by_user_id_user_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_idx": {
+          "name": "invitation_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_user_unique": {
+          "name": "member_organization_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_idx": {
+          "name": "member_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_idx": {
+          "name": "member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_directory_path": {
+          "name": "source_directory_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_json": {
+          "name": "workflow_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_workspace_slug_unique": {
+          "name": "projects_workspace_slug_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_workspace_idx": {
+          "name": "projects_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_workspaces_id_fk": {
+          "name": "projects_workspace_id_workspaces_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_user_id_fk": {
+          "name": "projects_created_by_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_prompts": {
+      "name": "saved_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "saved_prompt_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_config": {
+          "name": "form_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "saved_prompts_workspace_deleted_idx": {
+          "name": "saved_prompts_workspace_deleted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_prompts_public_mode_deleted_idx": {
+          "name": "saved_prompts_public_mode_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_prompts_created_at_idx": {
+          "name": "saved_prompts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_prompts_workspace_id_workspaces_id_fk": {
+          "name": "saved_prompts_workspace_id_workspaces_id_fk",
+          "tableFrom": "saved_prompts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_accounts": {
+      "name": "social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_secret": {
+          "name": "access_token_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_settings": {
+          "name": "additional_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_reauth": {
+          "name": "requires_reauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_accounts_workspace_platform_user_unique": {
+          "name": "social_accounts_workspace_platform_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_workspace_idx": {
+          "name": "social_accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_created_at_idx": {
+          "name": "social_accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_accounts_workspace_id_workspaces_id_fk": {
+          "name": "social_accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_accounts_created_by_user_id_user_id_fk": {
+          "name": "social_accounts_created_by_user_id_user_id_fk",
+          "tableFrom": "social_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_automation_rules": {
+      "name": "social_automation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_filters": {
+          "name": "trigger_filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repeat_interval_seconds": {
+          "name": "repeat_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_runs": {
+          "name": "max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'create_social_post'"
+        },
+        "action_config": {
+          "name": "action_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_automation_rules_workspace_idx": {
+          "name": "social_automation_rules_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_enabled_idx": {
+          "name": "social_automation_rules_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_trigger_source_idx": {
+          "name": "social_automation_rules_trigger_source_idx",
+          "columns": [
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_rules_created_at_idx": {
+          "name": "social_automation_rules_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_automation_rules_workspace_id_workspaces_id_fk": {
+          "name": "social_automation_rules_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_automation_rules",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_rules_created_by_user_id_user_id_fk": {
+          "name": "social_automation_rules_created_by_user_id_user_id_fk",
+          "tableFrom": "social_automation_rules",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_automation_tasks": {
+      "name": "social_automation_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_index": {
+          "name": "run_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "state": {
+          "name": "state",
+          "type": "automation_task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_post_id": {
+          "name": "source_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_automation_tasks_workspace_idx": {
+          "name": "social_automation_tasks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_rule_idx": {
+          "name": "social_automation_tasks_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_task_key_unique": {
+          "name": "social_automation_tasks_task_key_unique",
+          "columns": [
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_rule_run_index_unique": {
+          "name": "social_automation_tasks_rule_run_index_unique",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_state_idx": {
+          "name": "social_automation_tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_due_at_idx": {
+          "name": "social_automation_tasks_due_at_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_run_index_idx": {
+          "name": "social_automation_tasks_run_index_idx",
+          "columns": [
+            {
+              "expression": "run_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_claimed_at_idx": {
+          "name": "social_automation_tasks_claimed_at_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_automation_tasks_created_at_idx": {
+          "name": "social_automation_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_automation_tasks_workspace_id_workspaces_id_fk": {
+          "name": "social_automation_tasks_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_rule_id_social_automation_rules_id_fk": {
+          "name": "social_automation_tasks_rule_id_social_automation_rules_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_automation_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_source_post_id_social_posts_id_fk": {
+          "name": "social_automation_tasks_source_post_id_social_posts_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "source_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_automation_tasks_source_event_id_social_events_id_fk": {
+          "name": "social_automation_tasks_source_event_id_social_events_id_fk",
+          "tableFrom": "social_automation_tasks",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_dispatch_runs": {
+      "name": "social_dispatch_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "social_dispatch_run_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_dispatch_runs_dispatch_key_unique": {
+          "name": "social_dispatch_runs_dispatch_key_unique",
+          "columns": [
+            {
+              "expression": "dispatch_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_workspace_idx": {
+          "name": "social_dispatch_runs_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_state_idx": {
+          "name": "social_dispatch_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_dispatch_runs_created_at_idx": {
+          "name": "social_dispatch_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_dispatch_runs_workspace_id_workspaces_id_fk": {
+          "name": "social_dispatch_runs_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_post_id_social_posts_id_fk": {
+          "name": "social_dispatch_runs_post_id_social_posts_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_event_id_social_events_id_fk": {
+          "name": "social_dispatch_runs_event_id_social_events_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_dispatch_runs_account_id_social_accounts_id_fk": {
+          "name": "social_dispatch_runs_account_id_social_accounts_id_fk",
+          "tableFrom": "social_dispatch_runs",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_event_reads": {
+      "name": "social_event_reads",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_event_reads_workspace_idx": {
+          "name": "social_event_reads_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_event_reads_user_idx": {
+          "name": "social_event_reads_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_event_reads_read_at_idx": {
+          "name": "social_event_reads_read_at_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_event_reads_event_id_social_events_id_fk": {
+          "name": "social_event_reads_event_id_social_events_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_event_reads_workspace_id_workspaces_id_fk": {
+          "name": "social_event_reads_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_event_reads_user_id_user_id_fk": {
+          "name": "social_event_reads_user_id_user_id_fk",
+          "tableFrom": "social_event_reads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "social_event_reads_pk": {
+          "name": "social_event_reads_pk",
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_events": {
+      "name": "social_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "social_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "social_event_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_facing": {
+          "name": "user_facing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_ref": {
+          "name": "workflow_run_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_events_workspace_idx": {
+          "name": "social_events_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_event_type_idx": {
+          "name": "social_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_user_facing_idx": {
+          "name": "social_events_user_facing_idx",
+          "columns": [
+            {
+              "expression": "user_facing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_read_at_idx": {
+          "name": "social_events_read_at_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_post_idx": {
+          "name": "social_events_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_account_idx": {
+          "name": "social_events_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_events_created_at_idx": {
+          "name": "social_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_events_workspace_id_workspaces_id_fk": {
+          "name": "social_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_events_post_id_social_posts_id_fk": {
+          "name": "social_events_post_id_social_posts_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "social_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_events_account_id_social_accounts_id_fk": {
+          "name": "social_events_account_id_social_accounts_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_events_created_by_user_id_user_id_fk": {
+          "name": "social_events_created_by_user_id_user_id_fk",
+          "tableFrom": "social_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_mastodon_instances": {
+      "name": "social_mastodon_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_characters": {
+          "name": "max_characters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_mastodon_instances_url_unique": {
+          "name": "social_mastodon_instances_url_unique",
+          "columns": [
+            {
+              "expression": "instance_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_notification_preferences": {
+      "name": "social_notification_preferences",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_app_enabled": {
+          "name": "in_app_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mute_all": {
+          "name": "mute_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_notification_preferences_user_idx": {
+          "name": "social_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_notification_preferences_workspace_id_workspaces_id_fk": {
+          "name": "social_notification_preferences_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_notification_preferences",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_notification_preferences_user_id_user_id_fk": {
+          "name": "social_notification_preferences_user_id_user_id_fk",
+          "tableFrom": "social_notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "social_notification_preferences_pk": {
+          "name": "social_notification_preferences_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_oauth_selection_sessions": {
+      "name": "social_oauth_selection_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_secret": {
+          "name": "access_token_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_oauth_selection_sessions_workspace_idx": {
+          "name": "social_oauth_selection_sessions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_oauth_selection_sessions_expires_at_idx": {
+          "name": "social_oauth_selection_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_oauth_selection_sessions_workspace_id_workspaces_id_fk": {
+          "name": "social_oauth_selection_sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_oauth_selection_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_oauth_selection_sessions_created_by_user_id_user_id_fk": {
+          "name": "social_oauth_selection_sessions_created_by_user_id_user_id_fk",
+          "tableFrom": "social_oauth_selection_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_oauth_states": {
+      "name": "social_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_oauth_states_state_unique": {
+          "name": "social_oauth_states_state_unique",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_oauth_states_expires_at_idx": {
+          "name": "social_oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_account_id": {
+          "name": "social_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "root_post_id": {
+          "name": "root_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_status": {
+          "name": "dispatch_status",
+          "type": "social_dispatch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workflow_run_ref": {
+          "name": "workflow_run_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "delay_seconds": {
+          "name": "delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_template_post_id": {
+          "name": "source_template_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_settings": {
+          "name": "platform_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_url": {
+          "name": "platform_post_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parent_post_id": {
+          "name": "parent_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "studio_asset_id": {
+          "name": "studio_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_posts_workspace_idx": {
+          "name": "social_posts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_account_idx": {
+          "name": "social_posts_account_idx",
+          "columns": [
+            {
+              "expression": "social_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_root_post_idx": {
+          "name": "social_posts_root_post_idx",
+          "columns": [
+            {
+              "expression": "root_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_source_template_post_idx": {
+          "name": "social_posts_source_template_post_idx",
+          "columns": [
+            {
+              "expression": "source_template_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_kind_idx": {
+          "name": "social_posts_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_trigger_source_idx": {
+          "name": "social_posts_trigger_source_idx",
+          "columns": [
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_dispatch_status_idx": {
+          "name": "social_posts_dispatch_status_idx",
+          "columns": [
+            {
+              "expression": "dispatch_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_next_dispatch_at_idx": {
+          "name": "social_posts_next_dispatch_at_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_scheduled_at_idx": {
+          "name": "social_posts_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_posts_workspace_id_workspaces_id_fk": {
+          "name": "social_posts_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_posts_social_account_id_social_accounts_id_fk": {
+          "name": "social_posts_social_account_id_social_accounts_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "social_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_posts_studio_asset_id_assets_id_fk": {
+          "name": "social_posts_studio_asset_id_assets_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "studio_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_posts_created_by_user_id_user_id_fk": {
+          "name": "social_posts_created_by_user_id_user_id_fk",
+          "tableFrom": "social_posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_token_refresh_leases": {
+      "name": "social_token_refresh_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_account_id": {
+          "name": "social_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "social_token_refresh_lease_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "leased_at": {
+          "name": "leased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_token_refresh_leases_social_account_unique": {
+          "name": "social_token_refresh_leases_social_account_unique",
+          "columns": [
+            {
+              "expression": "social_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_workspace_idx": {
+          "name": "social_token_refresh_leases_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_state_idx": {
+          "name": "social_token_refresh_leases_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_token_refresh_leases_expires_at_idx": {
+          "name": "social_token_refresh_leases_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_token_refresh_leases_workspace_id_workspaces_id_fk": {
+          "name": "social_token_refresh_leases_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_token_refresh_leases",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_token_refresh_leases_social_account_id_social_accounts_id_fk": {
+          "name": "social_token_refresh_leases_social_account_id_social_accounts_id_fk",
+          "tableFrom": "social_token_refresh_leases",
+          "tableTo": "social_accounts",
+          "columnsFrom": [
+            "social_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_deliveries": {
+      "name": "social_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_webhook_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_deliveries_workspace_idx": {
+          "name": "social_webhook_deliveries_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_webhook_idx": {
+          "name": "social_webhook_deliveries_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_event_idx": {
+          "name": "social_webhook_deliveries_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_status_idx": {
+          "name": "social_webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_next_attempt_at_idx": {
+          "name": "social_webhook_deliveries_next_attempt_at_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_locked_at_idx": {
+          "name": "social_webhook_deliveries_locked_at_idx",
+          "columns": [
+            {
+              "expression": "locked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_deliveries_created_at_idx": {
+          "name": "social_webhook_deliveries_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_deliveries_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_deliveries_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_deliveries_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_deliveries_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_deliveries_event_id_social_events_id_fk": {
+          "name": "social_webhook_deliveries_event_id_social_events_id_fk",
+          "tableFrom": "social_webhook_deliveries",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_delivery_dead_letters": {
+      "name": "social_webhook_delivery_dead_letters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dead_letter_reason": {
+          "name": "dead_letter_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_state": {
+          "name": "replay_state",
+          "type": "social_webhook_dead_letter_replay_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dead_lettered'"
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "replay_requested_at": {
+          "name": "replay_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_requested_by_user_id": {
+          "name": "replay_requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_metadata": {
+          "name": "replay_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_delivery_id": {
+          "name": "replay_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replayed_at": {
+          "name": "replayed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_error": {
+          "name": "replay_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_delivery_dead_letters_delivery_unique": {
+          "name": "social_webhook_delivery_dead_letters_delivery_unique",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_workspace_idx": {
+          "name": "social_webhook_delivery_dead_letters_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_replay_state_idx": {
+          "name": "social_webhook_delivery_dead_letters_replay_state_idx",
+          "columns": [
+            {
+              "expression": "replay_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_delivery_dead_letters_created_at_idx": {
+          "name": "social_webhook_delivery_dead_letters_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_delivery_dead_letters_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_delivery_id_social_webhook_deliveries_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_delivery_id_social_webhook_deliveries_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhook_deliveries",
+          "columnsFrom": [
+            "delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_event_id_social_events_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_event_id_social_events_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_replay_requested_by_user_id_user_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_replay_requested_by_user_id_user_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "user",
+          "columnsFrom": [
+            "replay_requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "social_webhook_delivery_dead_letters_replay_delivery_id_social_webhook_deliveries_id_fk": {
+          "name": "social_webhook_delivery_dead_letters_replay_delivery_id_social_webhook_deliveries_id_fk",
+          "tableFrom": "social_webhook_delivery_dead_letters",
+          "tableTo": "social_webhook_deliveries",
+          "columnsFrom": [
+            "replay_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhook_subscriptions": {
+      "name": "social_webhook_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhook_subscriptions_workspace_idx": {
+          "name": "social_webhook_subscriptions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_webhook_idx": {
+          "name": "social_webhook_subscriptions_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_enabled_idx": {
+          "name": "social_webhook_subscriptions_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhook_subscriptions_created_at_idx": {
+          "name": "social_webhook_subscriptions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhook_subscriptions_workspace_id_workspaces_id_fk": {
+          "name": "social_webhook_subscriptions_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_subscriptions_webhook_id_social_webhooks_id_fk": {
+          "name": "social_webhook_subscriptions_webhook_id_social_webhooks_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "social_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhook_subscriptions_created_by_user_id_user_id_fk": {
+          "name": "social_webhook_subscriptions_created_by_user_id_user_id_fk",
+          "tableFrom": "social_webhook_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_webhooks": {
+      "name": "social_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret_encrypted": {
+          "name": "signing_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_webhooks_workspace_idx": {
+          "name": "social_webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhooks_enabled_idx": {
+          "name": "social_webhooks_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_webhooks_created_at_idx": {
+          "name": "social_webhooks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "social_webhooks_workspace_id_workspaces_id_fk": {
+          "name": "social_webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "social_webhooks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "social_webhooks_created_by_user_id_user_id_fk": {
+          "name": "social_webhooks_created_by_user_id_user_id_fk",
+          "tableFrom": "social_webhooks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_value_unique": {
+          "name": "verification_identifier_value_unique",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_members_user_idx": {
+          "name": "workspace_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_user_id_fk": {
+          "name": "workspace_members_user_id_user_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_pk": {
+          "name": "workspace_members_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_provider_keys": {
+      "name": "workspace_provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "byok_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_encrypted": {
+          "name": "key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint": {
+          "name": "key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_provider_keys_workspace_provider_unique": {
+          "name": "workspace_provider_keys_workspace_provider_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_provider_keys_workspace_idx": {
+          "name": "workspace_provider_keys_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_provider_keys_workspace_id_workspaces_id_fk": {
+          "name": "workspace_provider_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_provider_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_provider_keys_created_by_user_id_user_id_fk": {
+          "name": "workspace_provider_keys_created_by_user_id_user_id_fk",
+          "tableFrom": "workspace_provider_keys",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_settings": {
+      "name": "workspace_settings",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "brand_kit": {
+          "name": "brand_kit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_customer_id": {
+          "name": "billing_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_subscription_id": {
+          "name": "billing_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_metadata": {
+          "name": "billing_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_settings_organization_unique": {
+          "name": "workspace_settings_organization_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_settings_plan_tier_idx": {
+          "name": "workspace_settings_plan_tier_idx",
+          "columns": [
+            {
+              "expression": "plan_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_settings_workspace_id_workspaces_id_fk": {
+          "name": "workspace_settings_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_settings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_settings_organization_id_organization_id_fk": {
+          "name": "workspace_settings_organization_id_organization_id_fk",
+          "tableFrom": "workspace_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_storage_limits": {
+      "name": "workspace_storage_limits",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quota_bytes": {
+          "name": "quota_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_storage_limits_workspace_id_workspaces_id_fk": {
+          "name": "workspace_storage_limits_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_storage_limits",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_kit": {
+          "name": "brand_kit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspaces_slug_unique": {
+          "name": "workspaces_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_owner_idx": {
+          "name": "workspaces_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_user_id_user_id_fk": {
+          "name": "workspaces_owner_user_id_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "video",
+        "audio",
+        "model3d",
+        "workflow"
+      ]
+    },
+    "public.automation_task_state": {
+      "name": "automation_task_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.byok_provider": {
+      "name": "byok_provider",
+      "schema": "public",
+      "values": [
+        "gemini",
+        "openai",
+        "anthropic",
+        "kie",
+        "fal",
+        "replicate",
+        "wavespeed"
+      ]
+    },
+    "public.generation_status": {
+      "name": "generation_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "enterprise"
+      ]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.saved_prompt_mode": {
+      "name": "saved_prompt_mode",
+      "schema": "public",
+      "values": [
+        "photo",
+        "video",
+        "copy"
+      ]
+    },
+    "public.social_dispatch_run_state": {
+      "name": "social_dispatch_run_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.social_dispatch_status": {
+      "name": "social_dispatch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "dispatched",
+        "retry_scheduled",
+        "failed"
+      ]
+    },
+    "public.social_event_severity": {
+      "name": "social_event_severity",
+      "schema": "public",
+      "values": [
+        "info",
+        "warn",
+        "error"
+      ]
+    },
+    "public.social_event_type": {
+      "name": "social_event_type",
+      "schema": "public",
+      "values": [
+        "post.queued",
+        "post.publishing",
+        "post.published",
+        "post.failed",
+        "account.reauth_required",
+        "token.refreshed",
+        "dispatch.failed"
+      ]
+    },
+    "public.social_platform": {
+      "name": "social_platform",
+      "schema": "public",
+      "values": [
+        "x",
+        "linkedin",
+        "instagram",
+        "tiktok",
+        "threads",
+        "pinterest",
+        "facebook",
+        "youtube",
+        "reddit",
+        "bluesky",
+        "mastodon"
+      ]
+    },
+    "public.social_post_status": {
+      "name": "social_post_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "queued",
+        "publishing",
+        "published",
+        "failed"
+      ]
+    },
+    "public.social_token_refresh_lease_state": {
+      "name": "social_token_refresh_lease_state",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired"
+      ]
+    },
+    "public.social_webhook_dead_letter_replay_state": {
+      "name": "social_webhook_dead_letter_replay_state",
+      "schema": "public",
+      "values": [
+        "dead_lettered",
+        "replay_requested",
+        "replayed",
+        "failed"
+      ]
+    },
+    "public.social_webhook_delivery_status": {
+      "name": "social_webhook_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed"
+      ]
+    },
+    "public.storage_provider": {
+      "name": "storage_provider",
+      "schema": "public",
+      "values": [
+        "local",
+        "s3",
+        "r2"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1783656055936,
       "tag": "0015_harsh_energizer",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1783656978846,
+      "tag": "0016_dusty_vanisher",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/keys/[provider]/__tests__/route.test.ts
+++ b/src/app/api/keys/[provider]/__tests__/route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { mockIsDatabaseConfigured, mockAuthorizeStudioRequest, mockDeleteProviderKey } =
+  vi.hoisted(() => ({
+    mockIsDatabaseConfigured: vi.fn(() => true),
+    mockAuthorizeStudioRequest: vi.fn(),
+    mockDeleteProviderKey: vi.fn(),
+  }));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) =>
+    mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json(
+      { success: false, error: result.error },
+      { status: result.status },
+    ),
+}));
+
+vi.mock("@/lib/byok/repository", () => ({
+  deleteProviderKey: (...args: unknown[]) => mockDeleteProviderKey(...args),
+}));
+
+import { DELETE } from "../route";
+
+function createRequest(): NextRequest {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL("http://localhost:3000/api/keys/openai"),
+  } as unknown as NextRequest;
+}
+
+function context(provider: string) {
+  return { params: Promise.resolve({ provider }) };
+}
+
+function authorizedAs(workspaceId: string, userId = "user_1") {
+  mockAuthorizeStudioRequest.mockResolvedValue({
+    authorized: true,
+    userId,
+    workspaceId,
+    role: "owner",
+    permissions: ["workspaces:read", "workspaces:write", "workspaces:delete"],
+    contentSession: {},
+  });
+}
+
+function unauthorized(status: 401 | 403, error: string) {
+  mockAuthorizeStudioRequest.mockResolvedValue({
+    authorized: false,
+    status,
+    error,
+    reason: status === 401 ? "unauthenticated" : "forbidden",
+  });
+}
+
+describe("/api/keys/[provider]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsDatabaseConfigured.mockReturnValue(true);
+  });
+
+  describe("DELETE", () => {
+    it("deletes the workspace's stored key for the provider", async () => {
+      authorizedAs("ws_1");
+      mockDeleteProviderKey.mockResolvedValue(true);
+
+      const response = await DELETE(createRequest(), context("openai"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(mockDeleteProviderKey).toHaveBeenCalledWith({
+        workspaceId: "ws_1",
+        provider: "openai",
+      });
+    });
+
+    it("returns 404 when there is no stored key for the provider", async () => {
+      authorizedAs("ws_1");
+      mockDeleteProviderKey.mockResolvedValue(false);
+
+      const response = await DELETE(createRequest(), context("anthropic"));
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+    });
+
+    it("rejects an unknown provider with 400", async () => {
+      authorizedAs("ws_1");
+
+      const response = await DELETE(createRequest(), context("not-a-provider"));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(mockDeleteProviderKey).not.toHaveBeenCalled();
+    });
+
+    it("propagates the authz failure for non-owners/admins", async () => {
+      unauthorized(403, "You do not have access to this workspace.");
+
+      const response = await DELETE(createRequest(), context("openai"));
+
+      expect(response.status).toBe(403);
+      expect(mockDeleteProviderKey).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/keys/[provider]/route.ts
+++ b/src/app/api/keys/[provider]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { deleteProviderKey } from "@/lib/byok/repository";
+import { isByokProvider } from "@/lib/byok/providers";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
+
+const ROUTE = "/api/keys/[provider]";
+
+interface DeleteResponse {
+  success: boolean;
+  error?: string;
+}
+
+type ProviderContext = { params: Promise<{ provider: string }> };
+
+/** Delete the workspace's stored key for a provider. Takes effect immediately. */
+export const DELETE = withStudioAuth<ProviderContext>(
+  { route: ROUTE, action: "delete" },
+  async (
+    _request: NextRequest,
+    authz,
+    context,
+  ): Promise<NextResponse<DeleteResponse>> => {
+    const { provider } = await context.params;
+
+    if (!isByokProvider(provider)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "Unknown provider. Must be one of: gemini, openai, anthropic, kie, fal, replicate, wavespeed.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const deleted = await deleteProviderKey({
+      workspaceId: authz.workspaceId,
+      provider,
+    });
+
+    if (!deleted) {
+      return NextResponse.json(
+        { success: false, error: "No stored key for this provider." },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/keys/__tests__/route.test.ts
+++ b/src/app/api/keys/__tests__/route.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const {
+  mockIsDatabaseConfigured,
+  mockAuthorizeStudioRequest,
+  mockListProviderKeys,
+  mockUpsertProviderKey,
+  mockValidateProviderKey,
+} = vi.hoisted(() => ({
+  mockIsDatabaseConfigured: vi.fn(() => true),
+  mockAuthorizeStudioRequest: vi.fn(),
+  mockListProviderKeys: vi.fn(),
+  mockUpsertProviderKey: vi.fn(),
+  mockValidateProviderKey: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+}));
+
+vi.mock("@/lib/studio/authz", () => ({
+  authorizeStudioRequest: (...args: unknown[]) =>
+    mockAuthorizeStudioRequest(...args),
+  authzErrorResponse: (result: { status: number; error: string }) =>
+    NextResponse.json(
+      { success: false, error: result.error },
+      { status: result.status },
+    ),
+}));
+
+vi.mock("@/lib/byok/repository", () => ({
+  listProviderKeys: (...args: unknown[]) => mockListProviderKeys(...args),
+  upsertProviderKey: (...args: unknown[]) => mockUpsertProviderKey(...args),
+}));
+
+vi.mock("@/lib/byok/validation", () => ({
+  validateProviderKey: (...args: unknown[]) => mockValidateProviderKey(...args),
+}));
+
+import { GET, POST } from "../route";
+
+function createRequest(body?: unknown): NextRequest {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL("http://localhost:3000/api/keys"),
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+function authorizedAs(workspaceId: string, userId = "user_1") {
+  mockAuthorizeStudioRequest.mockResolvedValue({
+    authorized: true,
+    userId,
+    workspaceId,
+    role: "owner",
+    permissions: ["workspaces:read", "workspaces:write"],
+    contentSession: {},
+  });
+}
+
+function unauthorized(status: 401 | 403, error: string) {
+  mockAuthorizeStudioRequest.mockResolvedValue({
+    authorized: false,
+    status,
+    error,
+    reason: status === 401 ? "unauthenticated" : "forbidden",
+  });
+}
+
+describe("/api/keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsDatabaseConfigured.mockReturnValue(true);
+  });
+
+  describe("GET (list)", () => {
+    it("lists the workspace's provider keys as masked summaries only", async () => {
+      authorizedAs("ws_1");
+      const now = new Date("2026-07-10T00:00:00.000Z");
+      mockListProviderKeys.mockResolvedValue([
+        { provider: "openai", hint: "sk-…test", lastValidatedAt: now, updatedAt: now },
+      ]);
+
+      const response = await GET(createRequest());
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.keys).toHaveLength(1);
+      expect(data.keys[0]).toEqual(
+        expect.objectContaining({ provider: "openai", hint: "sk-…test" }),
+      );
+      expect(JSON.stringify(data)).not.toContain("keyEncrypted");
+      expect(mockListProviderKeys).toHaveBeenCalledWith("ws_1");
+    });
+
+    it("propagates the authz failure when unauthenticated", async () => {
+      unauthorized(401, "Please sign in.");
+
+      const response = await GET(createRequest());
+
+      expect(response.status).toBe(401);
+      expect(mockListProviderKeys).not.toHaveBeenCalled();
+    });
+
+    it("returns 503 when the database is not configured", async () => {
+      mockIsDatabaseConfigured.mockReturnValue(false);
+
+      const response = await GET(createRequest());
+
+      expect(response.status).toBe(503);
+    });
+  });
+
+  describe("POST (save)", () => {
+    it("validates the key live before saving and returns the masked summary", async () => {
+      authorizedAs("ws_1");
+      mockValidateProviderKey.mockResolvedValue({ ok: true });
+      const now = new Date("2026-07-10T00:00:00.000Z");
+      mockUpsertProviderKey.mockResolvedValue({
+        provider: "openai",
+        hint: "sk-…test",
+        lastValidatedAt: now,
+        updatedAt: now,
+      });
+
+      const response = await POST(
+        createRequest({ provider: "openai", apiKey: "sk-realkeyvalue1234" }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.key).toEqual(
+        expect.objectContaining({ provider: "openai", hint: "sk-…test" }),
+      );
+      expect(mockValidateProviderKey).toHaveBeenCalledWith(
+        "openai",
+        "sk-realkeyvalue1234",
+      );
+      expect(mockUpsertProviderKey).toHaveBeenCalledWith({
+        workspaceId: "ws_1",
+        provider: "openai",
+        rawKey: "sk-realkeyvalue1234",
+        createdByUserId: "user_1",
+      });
+      // The raw key must never appear in the response body.
+      expect(JSON.stringify(data)).not.toContain("sk-realkeyvalue1234");
+    });
+
+    it("rejects an invalid key with the provider's error, and does not persist it", async () => {
+      authorizedAs("ws_1");
+      mockValidateProviderKey.mockResolvedValue({
+        ok: false,
+        error: "Incorrect API key provided.",
+      });
+
+      const response = await POST(
+        createRequest({ provider: "openai", apiKey: "sk-bad" }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("Incorrect API key provided.");
+      expect(mockUpsertProviderKey).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown provider with 400", async () => {
+      authorizedAs("ws_1");
+
+      const response = await POST(
+        createRequest({ provider: "not-a-real-provider", apiKey: "abc" }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(mockValidateProviderKey).not.toHaveBeenCalled();
+      expect(mockUpsertProviderKey).not.toHaveBeenCalled();
+    });
+
+    it("rejects a missing apiKey with 400", async () => {
+      authorizedAs("ws_1");
+
+      const response = await POST(createRequest({ provider: "openai" }));
+
+      expect(response.status).toBe(400);
+      expect(mockValidateProviderKey).not.toHaveBeenCalled();
+    });
+
+    it("propagates the authz failure for non-writers", async () => {
+      unauthorized(403, "You do not have access to this workspace.");
+
+      const response = await POST(
+        createRequest({ provider: "openai", apiKey: "sk-x" }),
+      );
+
+      expect(response.status).toBe(403);
+      expect(mockValidateProviderKey).not.toHaveBeenCalled();
+      expect(mockUpsertProviderKey).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { listProviderKeys, upsertProviderKey } from "@/lib/byok/repository";
+import { isByokProvider } from "@/lib/byok/providers";
+import { validateProviderKey } from "@/lib/byok/validation";
+import { withStudioAuth } from "@/lib/studio/withStudioAuth";
+import type { ProviderKeySummary } from "@/lib/byok/repository";
+
+const ROUTE = "/api/keys";
+
+interface KeysListResponse {
+  success: boolean;
+  keys?: ProviderKeySummary[];
+  error?: string;
+}
+
+interface KeySaveResponse {
+  success: boolean;
+  key?: ProviderKeySummary;
+  error?: string;
+}
+
+/** List the current workspace's BYOK provider keys — masked hints only. */
+export const GET = withStudioAuth<undefined>(
+  { route: ROUTE, action: "read" },
+  async (
+    _request: NextRequest,
+    authz,
+  ): Promise<NextResponse<KeysListResponse>> => {
+    const keys = await listProviderKeys(authz.workspaceId);
+    return NextResponse.json({ success: true, keys });
+  },
+);
+
+/**
+ * Save (create or rotate) a provider key. The key is validated with a live,
+ * cheap authenticated call to the provider before it is ever persisted — an
+ * invalid key is rejected with the provider's own error message and never
+ * reaches the vault.
+ */
+export const POST = withStudioAuth<undefined>(
+  { route: ROUTE, action: "write" },
+  async (
+    request: NextRequest,
+    authz,
+  ): Promise<NextResponse<KeySaveResponse>> => {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      body = null;
+    }
+
+    const rawProvider =
+      body && typeof body === "object" && "provider" in body
+        ? (body as { provider?: unknown }).provider
+        : undefined;
+    const rawApiKey =
+      body && typeof body === "object" && "apiKey" in body
+        ? (body as { apiKey?: unknown }).apiKey
+        : undefined;
+
+    const provider = typeof rawProvider === "string" ? rawProvider : "";
+    const apiKey = typeof rawApiKey === "string" ? rawApiKey.trim() : "";
+
+    if (!isByokProvider(provider)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "Unknown provider. Must be one of: gemini, openai, anthropic, kie, fal, replicate, wavespeed.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { success: false, error: "An API key is required." },
+        { status: 400 },
+      );
+    }
+
+    const validation = await validateProviderKey(provider, apiKey);
+    if (!validation.ok) {
+      return NextResponse.json(
+        { success: false, error: validation.error },
+        { status: 422 },
+      );
+    }
+
+    const key = await upsertProviderKey({
+      workspaceId: authz.workspaceId,
+      provider,
+      rawKey: apiKey,
+      createdByUserId: authz.userId,
+    });
+
+    return NextResponse.json({ success: true, key });
+  },
+);

--- a/src/app/social/settings/page.tsx
+++ b/src/app/social/settings/page.tsx
@@ -1,5 +1,11 @@
 import { ApiTokensSettings } from "@/components/social/ApiTokensSettings"
+import { ProviderKeysSettings } from "@/components/social/ProviderKeysSettings"
 
 export default function SettingsPage() {
-  return <ApiTokensSettings />
+  return (
+    <div className="flex flex-1 flex-col divide-y">
+      <ApiTokensSettings />
+      <ProviderKeysSettings />
+    </div>
+  )
 }

--- a/src/components/social/ProviderKeysSettings.tsx
+++ b/src/components/social/ProviderKeysSettings.tsx
@@ -1,0 +1,224 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { KeyRoundIcon, Loader2Icon, ShieldCheckIcon } from "lucide-react"
+import { useToast } from "@/components/Toast"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { StudioApiError } from "@/lib/studio/client"
+import {
+  deleteProviderKeyRequest,
+  listProviderKeysRequest,
+  saveProviderKeyRequest,
+  type ProviderKeySummaryView,
+} from "@/lib/byok/client"
+import {
+  BYOK_PROVIDERS,
+  BYOK_PROVIDER_LABELS,
+  type ByokProvider,
+} from "@/lib/byok/providers"
+
+function formatDate(value: string | null): string {
+  if (!value) return "Never"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "—"
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+export function ProviderKeysSettings() {
+  const { show: showToast } = useToast()
+  const [keys, setKeys] = useState<ProviderKeySummaryView[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [provider, setProvider] = useState<ByokProvider>(BYOK_PROVIDERS[0])
+  const [apiKey, setApiKey] = useState("")
+  const [isSaving, setIsSaving] = useState(false)
+  const [deletingProvider, setDeletingProvider] = useState<string | null>(null)
+  const initialized = useRef(false)
+
+  async function loadKeys() {
+    setIsLoading(true)
+    try {
+      setKeys(await listProviderKeysRequest())
+    } catch (error) {
+      showToast(
+        error instanceof StudioApiError
+          ? error.message
+          : "Failed to load provider keys",
+        "error",
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // Load once on first render — no useEffect (matches repo convention).
+  if (!initialized.current) {
+    initialized.current = true
+    loadKeys()
+  }
+
+  async function handleSave(event: React.FormEvent) {
+    event.preventDefault()
+    const trimmed = apiKey.trim()
+    if (!trimmed || isSaving) return
+
+    setIsSaving(true)
+    try {
+      await saveProviderKeyRequest(provider, trimmed)
+      setApiKey("")
+      showToast(`${BYOK_PROVIDER_LABELS[provider]} key saved`, "success")
+      await loadKeys()
+    } catch (error) {
+      showToast(
+        error instanceof StudioApiError || error instanceof Error
+          ? error.message
+          : "Failed to save provider key",
+        "error",
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleDelete(target: ByokProvider) {
+    if (
+      !confirm(
+        `Delete the stored ${BYOK_PROVIDER_LABELS[target]} key for this workspace?`,
+      )
+    ) {
+      return
+    }
+
+    setDeletingProvider(target)
+    try {
+      await deleteProviderKeyRequest(target)
+      setKeys((prev) => prev.filter((key) => key.provider !== target))
+      showToast("Provider key deleted", "success")
+    } catch (error) {
+      showToast(
+        error instanceof StudioApiError
+          ? error.message
+          : "Failed to delete provider key",
+        "error",
+      )
+    } finally {
+      setDeletingProvider(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-4 md:p-6">
+      <div>
+        <h2 className="flex items-center gap-2 text-lg font-semibold">
+          <KeyRoundIcon className="size-5" />
+          Provider Keys (BYOK)
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Store your own AI provider API keys per workspace. Keys are
+          validated with a live check before saving, encrypted at rest, and
+          never shown again after creation.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSave}
+        className="flex flex-col gap-2 sm:flex-row sm:items-end"
+      >
+        <div>
+          <Label htmlFor="provider-key-provider">Provider</Label>
+          <select
+            id="provider-key-provider"
+            aria-label="Provider"
+            className="flex h-9 w-full min-w-40 rounded-lg border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none"
+            value={provider}
+            onChange={(event) =>
+              setProvider(event.target.value as ByokProvider)
+            }
+          >
+            {BYOK_PROVIDERS.map((value) => (
+              <option key={value} value={value}>
+                {BYOK_PROVIDER_LABELS[value]}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex-1">
+          <Label htmlFor="provider-key-value">API key</Label>
+          <Input
+            id="provider-key-value"
+            type="password"
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+            placeholder="Paste the provider's API key"
+            autoComplete="off"
+          />
+        </div>
+        <Button type="submit" disabled={!apiKey.trim() || isSaving}>
+          {isSaving ? (
+            <Loader2Icon className="size-4 animate-spin" />
+          ) : (
+            <ShieldCheckIcon className="size-4" />
+          )}
+          Save key
+        </Button>
+      </form>
+
+      <div className="rounded-lg border">
+        <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 border-b px-4 py-2.5 text-xs font-medium text-muted-foreground">
+          <span>Provider</span>
+          <span className="hidden sm:block">Key</span>
+          <span className="hidden sm:block">Updated</span>
+          <span className="text-end">Actions</span>
+        </div>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center gap-2 px-4 py-8 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Loading provider keys…
+          </div>
+        ) : keys.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No provider keys yet. Add one above to run generation on your own
+            budget.
+          </div>
+        ) : (
+          keys.map((key) => (
+            <div
+              key={key.provider}
+              className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 border-b px-4 py-3 text-sm last:border-b-0"
+            >
+              <p className="truncate font-medium">
+                {BYOK_PROVIDER_LABELS[key.provider] ?? key.provider}
+              </p>
+              <span className="hidden truncate font-mono text-xs text-muted-foreground sm:block">
+                {key.hint}
+              </span>
+              <span className="hidden text-muted-foreground sm:block">
+                {formatDate(key.updatedAt)}
+              </span>
+              <div className="text-end">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={deletingProvider === key.provider}
+                  onClick={() => handleDelete(key.provider)}
+                >
+                  {deletingProvider === key.provider ? (
+                    <Loader2Icon className="size-3.5 animate-spin" />
+                  ) : (
+                    "Delete"
+                  )}
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/social/__tests__/ProviderKeysSettings.test.tsx
+++ b/src/components/social/__tests__/ProviderKeysSettings.test.tsx
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockShowToast = vi.fn();
+const mockListProviderKeysRequest = vi.fn();
+const mockSaveProviderKeyRequest = vi.fn();
+const mockDeleteProviderKeyRequest = vi.fn();
+
+vi.mock("@/components/Toast", () => ({
+  useToast: () => ({ show: mockShowToast }),
+}));
+
+vi.mock("@/lib/byok/client", () => ({
+  listProviderKeysRequest: (...args: unknown[]) =>
+    mockListProviderKeysRequest(...args),
+  saveProviderKeyRequest: (...args: unknown[]) =>
+    mockSaveProviderKeyRequest(...args),
+  deleteProviderKeyRequest: (...args: unknown[]) =>
+    mockDeleteProviderKeyRequest(...args),
+}));
+
+import { ProviderKeysSettings } from "@/components/social/ProviderKeysSettings";
+
+describe("ProviderKeysSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListProviderKeysRequest.mockResolvedValue([]);
+  });
+
+  it("loads and displays stored provider keys with masked hints", async () => {
+    mockListProviderKeysRequest.mockResolvedValue([
+      {
+        provider: "openai",
+        hint: "sk-…test",
+        lastValidatedAt: "2026-07-10T00:00:00.000Z",
+        updatedAt: "2026-07-10T00:00:00.000Z",
+      },
+    ]);
+
+    render(<ProviderKeysSettings />);
+
+    expect(await screen.findByText("sk-…test")).toBeInTheDocument();
+    // "OpenAI" also appears as a <select> option, so assert at least one match.
+    expect(screen.getAllByText(/openai/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows an empty state when no keys are stored", async () => {
+    render(<ProviderKeysSettings />);
+
+    expect(await screen.findByText(/no provider keys yet/i)).toBeInTheDocument();
+  });
+
+  it("saves a new key and shows a success toast", async () => {
+    mockSaveProviderKeyRequest.mockResolvedValue({
+      provider: "openai",
+      hint: "sk-…new4",
+      lastValidatedAt: "2026-07-10T00:00:00.000Z",
+      updatedAt: "2026-07-10T00:00:00.000Z",
+    });
+
+    render(<ProviderKeysSettings />);
+    await waitFor(() => expect(mockListProviderKeysRequest).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/provider/i), {
+      target: { value: "openai" },
+    });
+    fireEvent.change(screen.getByLabelText(/api key/i), {
+      target: { value: "sk-realsecretvalue1234" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save key/i }));
+
+    await waitFor(() =>
+      expect(mockSaveProviderKeyRequest).toHaveBeenCalledWith(
+        "openai",
+        "sk-realsecretvalue1234",
+      ),
+    );
+    await waitFor(() =>
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.stringMatching(/saved/i),
+        "success",
+      ),
+    );
+  });
+
+  it("shows the provider's error toast when validation fails", async () => {
+    mockSaveProviderKeyRequest.mockRejectedValue(
+      new Error("Incorrect API key provided."),
+    );
+
+    render(<ProviderKeysSettings />);
+    await waitFor(() => expect(mockListProviderKeysRequest).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/api key/i), {
+      target: { value: "sk-bad" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save key/i }));
+
+    await waitFor(() =>
+      expect(mockShowToast).toHaveBeenCalledWith(
+        "Incorrect API key provided.",
+        "error",
+      ),
+    );
+  });
+
+  it("deletes a key after confirmation", async () => {
+    mockListProviderKeysRequest.mockResolvedValue([
+      {
+        provider: "openai",
+        hint: "sk-…test",
+        lastValidatedAt: null,
+        updatedAt: "2026-07-10T00:00:00.000Z",
+      },
+    ]);
+    mockDeleteProviderKeyRequest.mockResolvedValue(undefined);
+    vi.stubGlobal("confirm", vi.fn(() => true));
+
+    render(<ProviderKeysSettings />);
+    const deleteButton = await screen.findByRole("button", { name: /delete/i });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() =>
+      expect(mockDeleteProviderKeyRequest).toHaveBeenCalledWith("openai"),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not delete when the confirmation is declined", async () => {
+    mockListProviderKeysRequest.mockResolvedValue([
+      {
+        provider: "openai",
+        hint: "sk-…test",
+        lastValidatedAt: null,
+        updatedAt: "2026-07-10T00:00:00.000Z",
+      },
+    ]);
+    vi.stubGlobal("confirm", vi.fn(() => false));
+
+    render(<ProviderKeysSettings />);
+    const deleteButton = await screen.findByRole("button", { name: /delete/i });
+    fireEvent.click(deleteButton);
+
+    expect(mockDeleteProviderKeyRequest).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/lib/byok/__tests__/client.test.ts
+++ b/src/lib/byok/__tests__/client.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  deleteProviderKeyRequest,
+  listProviderKeysRequest,
+  saveProviderKeyRequest,
+} from "../client";
+import { setActiveWorkspaceId } from "@/lib/studio/client";
+
+function mockFetchOnce(status: number, body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("byok client", () => {
+  beforeEach(() => {
+    setActiveWorkspaceId("ws_1");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setActiveWorkspaceId(null);
+  });
+
+  it("lists provider keys from GET /api/keys with the workspace header", async () => {
+    const fetchMock = mockFetchOnce(200, {
+      success: true,
+      keys: [
+        {
+          provider: "openai",
+          hint: "sk-…test",
+          lastValidatedAt: "2026-07-10T00:00:00.000Z",
+          updatedAt: "2026-07-10T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const keys = await listProviderKeysRequest();
+
+    expect(keys).toHaveLength(1);
+    expect(keys[0].provider).toBe("openai");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/keys");
+    expect(new Headers(init.headers).get("x-workspace-id")).toBe("ws_1");
+  });
+
+  it("saves a provider key via POST and returns the masked summary", async () => {
+    const fetchMock = mockFetchOnce(200, {
+      success: true,
+      key: {
+        provider: "openai",
+        hint: "sk-…test",
+        lastValidatedAt: "2026-07-10T00:00:00.000Z",
+        updatedAt: "2026-07-10T00:00:00.000Z",
+      },
+    });
+
+    const saved = await saveProviderKeyRequest("openai", "sk-realsecret");
+
+    expect(saved.hint).toBe("sk-…test");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/keys");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({
+      provider: "openai",
+      apiKey: "sk-realsecret",
+    });
+  });
+
+  it("surfaces the provider's validation error on save failure", async () => {
+    mockFetchOnce(422, {
+      success: false,
+      error: "Incorrect API key provided.",
+    });
+
+    await expect(saveProviderKeyRequest("openai", "sk-bad")).rejects.toThrow(
+      "Incorrect API key provided.",
+    );
+  });
+
+  it("deletes a provider key via DELETE to the provider-scoped path", async () => {
+    const fetchMock = mockFetchOnce(200, { success: true });
+
+    await deleteProviderKeyRequest("anthropic");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/keys/anthropic");
+    expect(init.method).toBe("DELETE");
+  });
+});

--- a/src/lib/byok/__tests__/crypto.test.ts
+++ b/src/lib/byok/__tests__/crypto.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomBytes } from "node:crypto";
+
+// Generate a valid 32-byte hex key for tests
+const TEST_KEY = randomBytes(32).toString("hex");
+
+describe("byok/crypto", () => {
+  beforeEach(() => {
+    vi.stubEnv("BYOK_KEY_ENCRYPTION_KEY", TEST_KEY);
+    vi.stubEnv("DEV_AUTH_BYPASS", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  async function loadCrypto() {
+    return import("../crypto");
+  }
+
+  describe("encryptProviderKey / decryptProviderKey", () => {
+    it("round-trips a provider key correctly", async () => {
+      const { encryptProviderKey, decryptProviderKey } = await loadCrypto();
+      const rawKey = "sk-test-1234567890abcdef";
+      const encrypted = encryptProviderKey(rawKey);
+      expect(encrypted).not.toBe(rawKey);
+      expect(encrypted).not.toContain(rawKey);
+      expect(decryptProviderKey(encrypted)).toBe(rawKey);
+    });
+
+    it("produces different ciphertexts for the same plaintext", async () => {
+      const { encryptProviderKey } = await loadCrypto();
+      const rawKey = "same-key";
+      const a = encryptProviderKey(rawKey);
+      const b = encryptProviderKey(rawKey);
+      expect(a).not.toBe(b);
+    });
+
+    it("handles unicode content", async () => {
+      const { encryptProviderKey, decryptProviderKey } = await loadCrypto();
+      const rawKey = "key-with-émoji-🔑-and-日本語";
+      expect(decryptProviderKey(encryptProviderKey(rawKey))).toBe(rawKey);
+    });
+  });
+
+  describe("tamper detection", () => {
+    it("throws on tampered ciphertext", async () => {
+      const { encryptProviderKey, decryptProviderKey } = await loadCrypto();
+      const encrypted = encryptProviderKey("real-key");
+      const parts = encrypted.split(":");
+      const tamperedCiphertext = Buffer.from("tampered-data").toString(
+        "base64",
+      );
+      const tampered = `${parts[0]}:${parts[1]}:${tamperedCiphertext}`;
+      expect(() => decryptProviderKey(tampered)).toThrow();
+    });
+
+    it("throws on invalid format", async () => {
+      const { decryptProviderKey } = await loadCrypto();
+      expect(() => decryptProviderKey("not-valid-format")).toThrow(
+        "Invalid encrypted provider key format",
+      );
+    });
+  });
+
+  describe("missing encryption key", () => {
+    it("throws when encrypting without key and not in dev bypass", async () => {
+      vi.stubEnv("BYOK_KEY_ENCRYPTION_KEY", "");
+      vi.stubEnv("DEV_AUTH_BYPASS", "");
+      const { encryptProviderKey } = await loadCrypto();
+      expect(() => encryptProviderKey("key")).toThrow(
+        "BYOK_KEY_ENCRYPTION_KEY is required",
+      );
+    });
+
+    it("stores plaintext in dev bypass mode without key", async () => {
+      vi.stubEnv("BYOK_KEY_ENCRYPTION_KEY", "");
+      vi.stubEnv("DEV_AUTH_BYPASS", "true");
+      const { encryptProviderKey, decryptProviderKey } = await loadCrypto();
+      const encrypted = encryptProviderKey("dev-key");
+      expect(encrypted).toBe("plain:dev-key");
+      expect(decryptProviderKey(encrypted)).toBe("dev-key");
+    });
+  });
+
+  describe("invalid key format", () => {
+    it("throws on short key", async () => {
+      vi.stubEnv("BYOK_KEY_ENCRYPTION_KEY", "aabbcc");
+      const { encryptProviderKey } = await loadCrypto();
+      expect(() => encryptProviderKey("key")).toThrow(
+        "64-character hex string",
+      );
+    });
+  });
+
+  describe("isProviderKeyEncryptionConfigured", () => {
+    it("returns true when key is set", async () => {
+      const { isProviderKeyEncryptionConfigured } = await loadCrypto();
+      expect(isProviderKeyEncryptionConfigured()).toBe(true);
+    });
+
+    it("returns false when key is not set", async () => {
+      vi.stubEnv("BYOK_KEY_ENCRYPTION_KEY", "");
+      const { isProviderKeyEncryptionConfigured } = await loadCrypto();
+      expect(isProviderKeyEncryptionConfigured()).toBe(false);
+    });
+  });
+});

--- a/src/lib/byok/__tests__/mask.test.ts
+++ b/src/lib/byok/__tests__/mask.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { maskProviderKey } from "../mask";
+
+describe("maskProviderKey", () => {
+  it("keeps a short recognizable prefix and last 4 chars for a typical key", () => {
+    expect(maskProviderKey("sk-abcdefghijklmnopqrstuvwxyzabc4")).toBe(
+      "sk-…abc4",
+    );
+  });
+
+  it("masks a Gemini-style key the same way", () => {
+    expect(maskProviderKey("AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe")).toBe(
+      "AIz…ewQe",
+    );
+  });
+
+  it("never reveals more than the mask for very short keys", () => {
+    const hint = maskProviderKey("short1");
+    expect(hint).not.toContain("short1");
+    expect(hint).toBe("••••••");
+  });
+
+  it("never contains the raw key as a substring for any input", () => {
+    const raw = "sk-test-1234567890abcdef";
+    expect(maskProviderKey(raw)).not.toContain(raw);
+  });
+});

--- a/src/lib/byok/__tests__/repository.test.ts
+++ b/src/lib/byok/__tests__/repository.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomBytes } from "node:crypto";
+
+const TEST_KEY = randomBytes(32).toString("hex");
+
+const mockInsert = vi.fn();
+const mockSelect = vi.fn();
+const mockDelete = vi.fn();
+const mockValues = vi.fn();
+const mockOnConflictDoUpdate = vi.fn();
+const mockReturning = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLimit = vi.fn();
+
+function setupChainableMock() {
+  mockValues.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate });
+  mockOnConflictDoUpdate.mockReturnValue({ returning: mockReturning });
+  mockInsert.mockReturnValue({ values: mockValues });
+
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockSelect.mockReturnValue({ from: mockFrom });
+
+  mockWhere.mockReturnValue({
+    orderBy: mockOrderBy,
+    limit: mockLimit,
+    returning: mockReturning,
+  });
+  mockOrderBy.mockReturnValue(Promise.resolve([]));
+  mockLimit.mockReturnValue(Promise.resolve([]));
+
+  mockDelete.mockReturnValue({ where: mockWhere });
+}
+
+// Partial mock: keep the real `schema`/`isDatabaseConfigured` exports (so the
+// unrelated Better Auth import chain pulled in transitively by ../crypto
+// keeps working) and only replace `getDb` with our chainable query mocks.
+vi.mock("@/lib/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/db")>();
+  return {
+    ...actual,
+    getDb: () => ({
+      insert: mockInsert,
+      select: mockSelect,
+      delete: mockDelete,
+    }),
+  };
+});
+
+describe("byok/repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupChainableMock();
+    vi.stubEnv("BYOK_KEY_ENCRYPTION_KEY", TEST_KEY);
+    vi.stubEnv("DEV_AUTH_BYPASS", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  async function loadRepository() {
+    return import("../repository");
+  }
+
+  describe("upsertProviderKey", () => {
+    it("encrypts the raw key and stores only a masked hint in the summary", async () => {
+      const { upsertProviderKey } = await loadRepository();
+      const now = new Date("2026-07-10T00:00:00.000Z");
+      mockReturning.mockResolvedValue([
+        {
+          provider: "openai",
+          keyHint: "sk-…test",
+          lastValidatedAt: now,
+          updatedAt: now,
+        },
+      ]);
+
+      const summary = await upsertProviderKey({
+        workspaceId: "ws_1",
+        provider: "openai",
+        rawKey: "sk-abcdefghijklmnoptest",
+        createdByUserId: "user_1",
+      });
+
+      expect(summary).toEqual({
+        provider: "openai",
+        hint: "sk-…test",
+        lastValidatedAt: now,
+        updatedAt: now,
+      });
+
+      // The raw key must never be handed to the DB layer verbatim.
+      const insertedValues = mockValues.mock.calls[0][0];
+      expect(insertedValues.keyEncrypted).not.toContain(
+        "sk-abcdefghijklmnoptest",
+      );
+      expect(insertedValues.workspaceId).toBe("ws_1");
+      expect(insertedValues.provider).toBe("openai");
+    });
+
+    it("upserts on the (workspaceId, provider) unique constraint", async () => {
+      const { upsertProviderKey } = await loadRepository();
+      mockReturning.mockResolvedValue([
+        {
+          provider: "openai",
+          keyHint: "sk-…test",
+          lastValidatedAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      await upsertProviderKey({
+        workspaceId: "ws_1",
+        provider: "openai",
+        rawKey: "sk-newkeyvalue1234",
+        createdByUserId: "user_1",
+      });
+
+      const { workspaceProviderKeys } = await import("@/lib/db/schema");
+      expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: [
+            workspaceProviderKeys.workspaceId,
+            workspaceProviderKeys.provider,
+          ],
+        }),
+      );
+    });
+  });
+
+  describe("listProviderKeys", () => {
+    it("never includes keyEncrypted in the returned rows", async () => {
+      const { listProviderKeys } = await loadRepository();
+      const now = new Date("2026-07-10T00:00:00.000Z");
+      mockOrderBy.mockResolvedValue([
+        { provider: "openai", keyHint: "sk-…test", lastValidatedAt: now, updatedAt: now },
+      ]);
+
+      const keys = await listProviderKeys("ws_1");
+
+      expect(keys).toEqual([
+        { provider: "openai", hint: "sk-…test", lastValidatedAt: now, updatedAt: now },
+      ]);
+      expect(JSON.stringify(keys)).not.toContain("keyEncrypted");
+    });
+  });
+
+  describe("deleteProviderKey", () => {
+    it("returns true when a row was deleted", async () => {
+      const { deleteProviderKey } = await loadRepository();
+      mockReturning.mockResolvedValue([{ id: "provkey_1" }]);
+
+      const deleted = await deleteProviderKey({
+        workspaceId: "ws_1",
+        provider: "openai",
+      });
+
+      expect(deleted).toBe(true);
+    });
+
+    it("returns false when no matching row exists", async () => {
+      const { deleteProviderKey } = await loadRepository();
+      mockReturning.mockResolvedValue([]);
+
+      const deleted = await deleteProviderKey({
+        workspaceId: "ws_1",
+        provider: "anthropic",
+      });
+
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe("resolveProviderKey", () => {
+    it("returns the decrypted raw key when a row exists", async () => {
+      const { resolveProviderKey } = await loadRepository();
+      const { encryptProviderKey } = await import("../crypto");
+      const encrypted = encryptProviderKey("sk-realsecretvalue");
+
+      mockLimit.mockResolvedValue([{ keyEncrypted: encrypted }]);
+
+      const resolved = await resolveProviderKey("ws_1", "openai");
+
+      expect(resolved).toBe("sk-realsecretvalue");
+    });
+
+    it("returns null (not an error) when the workspace has no stored key", async () => {
+      const { resolveProviderKey } = await loadRepository();
+      mockLimit.mockResolvedValue([]);
+
+      const resolved = await resolveProviderKey("ws_1", "kie");
+
+      expect(resolved).toBeNull();
+    });
+  });
+});

--- a/src/lib/byok/__tests__/validation.test.ts
+++ b/src/lib/byok/__tests__/validation.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { validateProviderKey } from "../validation";
+
+function mockFetchOnce(status: number, body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("validateProviderKey", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts a valid gemini key via the models list endpoint", async () => {
+    const fetchMock = mockFetchOnce(200, { models: [] });
+
+    const result = await validateProviderKey("gemini", "AIzaSyTestKey1234567890");
+
+    expect(result).toEqual({ ok: true });
+    const [url] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("generativelanguage.googleapis.com/v1beta/models");
+    expect(String(url)).toContain("key=AIzaSyTestKey1234567890");
+  });
+
+  it("surfaces the Google error message for an invalid gemini key", async () => {
+    mockFetchOnce(400, {
+      error: { message: "API key not valid. Please pass a valid API key." },
+    });
+
+    const result = await validateProviderKey("gemini", "bad-key");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "API key not valid. Please pass a valid API key.",
+    });
+  });
+
+  it("accepts a valid openai key via GET /v1/models with a bearer token", async () => {
+    const fetchMock = mockFetchOnce(200, { data: [] });
+
+    const result = await validateProviderKey("openai", "sk-openai-test");
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/models");
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer sk-openai-test",
+    );
+  });
+
+  it("surfaces the OpenAI error message for an invalid key", async () => {
+    mockFetchOnce(401, {
+      error: { message: "Incorrect API key provided.", type: "invalid_request_error" },
+    });
+
+    const result = await validateProviderKey("openai", "sk-bad");
+
+    expect(result).toEqual({ ok: false, error: "Incorrect API key provided." });
+  });
+
+  it("accepts a valid anthropic key via GET /v1/models with x-api-key", async () => {
+    const fetchMock = mockFetchOnce(200, { data: [] });
+
+    const result = await validateProviderKey("anthropic", "ak-anthropic-test");
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.anthropic.com/v1/models");
+    const headers = new Headers(init.headers);
+    expect(headers.get("x-api-key")).toBe("ak-anthropic-test");
+    expect(headers.get("anthropic-version")).toBe("2023-06-01");
+  });
+
+  it("surfaces the Anthropic error message for an invalid key", async () => {
+    mockFetchOnce(401, {
+      type: "error",
+      error: { type: "authentication_error", message: "invalid x-api-key" },
+    });
+
+    const result = await validateProviderKey("anthropic", "ak-bad");
+
+    expect(result).toEqual({ ok: false, error: "invalid x-api-key" });
+  });
+
+  it("accepts a valid kie key via the credits endpoint", async () => {
+    const fetchMock = mockFetchOnce(200, { code: 200, msg: "success", data: 100 });
+
+    const result = await validateProviderKey("kie", "kie-test-key");
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.kie.ai/api/v1/chat/credit");
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer kie-test-key",
+    );
+  });
+
+  it("surfaces the Kie error message for an invalid key", async () => {
+    mockFetchOnce(401, {
+      code: 401,
+      msg: "Unauthorized - Authentication credentials are missing or invalid",
+      data: null,
+    });
+
+    const result = await validateProviderKey("kie", "kie-bad");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Unauthorized - Authentication credentials are missing or invalid",
+    });
+  });
+
+  it("accepts a valid fal key via the models endpoint", async () => {
+    const fetchMock = mockFetchOnce(200, { items: [] });
+
+    const result = await validateProviderKey("fal", "fal-test-key");
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("https://api.fal.ai/v1/models");
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Key fal-test-key",
+    );
+  });
+
+  it("surfaces a fal error message for an invalid key", async () => {
+    mockFetchOnce(401, { detail: "Invalid API key" });
+
+    const result = await validateProviderKey("fal", "fal-bad");
+
+    expect(result).toEqual({ ok: false, error: "Invalid API key" });
+  });
+
+  it("accepts a valid replicate key via the account endpoint", async () => {
+    const fetchMock = mockFetchOnce(200, { type: "user", username: "acme" });
+
+    const result = await validateProviderKey("replicate", "r8_test");
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.replicate.com/v1/account");
+    expect(new Headers(init.headers).get("authorization")).toBe("Bearer r8_test");
+  });
+
+  it("surfaces a replicate error message for an invalid key", async () => {
+    mockFetchOnce(401, { detail: "Invalid token." });
+
+    const result = await validateProviderKey("replicate", "r8_bad");
+
+    expect(result).toEqual({ ok: false, error: "Invalid token." });
+  });
+
+  it("accepts a valid wavespeed key via the balance endpoint", async () => {
+    const fetchMock = mockFetchOnce(200, {
+      code: 200,
+      message: "success",
+      data: { balance: 50.25 },
+    });
+
+    const result = await validateProviderKey("wavespeed", "ws-test-key");
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.wavespeed.ai/api/v3/balance");
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer ws-test-key",
+    );
+  });
+
+  it("surfaces a wavespeed error message for an invalid key", async () => {
+    mockFetchOnce(401, { code: 401, message: "Unauthorized" });
+
+    const result = await validateProviderKey("wavespeed", "ws-bad");
+
+    expect(result).toEqual({ ok: false, error: "Unauthorized" });
+  });
+
+  it("rejects an empty key without making a network call", async () => {
+    const fetchMock = mockFetchOnce(200, {});
+
+    const result = await validateProviderKey("openai", "   ");
+
+    expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error when the network call itself fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("fetch failed: ECONNREFUSED")),
+    );
+
+    const result = await validateProviderKey("openai", "sk-test");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/could not reach openai/i);
+    }
+  });
+});

--- a/src/lib/byok/client.ts
+++ b/src/lib/byok/client.ts
@@ -1,0 +1,93 @@
+/**
+ * BYOK provider-key client — frontend helpers for the workspace-settings UI.
+ * Reuses the studio client's workspace scoping and error type, following the
+ * same shape as `@/lib/api-tokens/client`.
+ */
+
+import { getActiveWorkspaceId, StudioApiError } from "@/lib/studio/client";
+import type { ByokProvider } from "./providers";
+
+export interface ProviderKeySummaryView {
+  provider: ByokProvider;
+  /** Non-secret display hint, e.g. "sk-…abc4". Never the raw key. */
+  hint: string;
+  lastValidatedAt: string | null;
+  updatedAt: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function mergeHeaders(init?: RequestInit): Headers {
+  const headers = new Headers(init?.headers || {});
+  const workspaceId = getActiveWorkspaceId();
+  if (workspaceId) {
+    headers.set("x-workspace-id", workspaceId);
+  }
+  return headers;
+}
+
+async function keysFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<JsonRecord> {
+  const workspaceId = getActiveWorkspaceId();
+  if (!workspaceId) {
+    throw new StudioApiError(403, "Select a workspace to continue.");
+  }
+
+  const response = await fetch(path, {
+    ...init,
+    headers: mergeHeaders(init),
+  });
+
+  let data: unknown = null;
+  try {
+    data = await response.json();
+  } catch {
+    throw new StudioApiError(
+      response.status,
+      `Request failed with status ${response.status}`,
+    );
+  }
+
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new StudioApiError(response.status, "Invalid API response");
+  }
+
+  const record = data as JsonRecord;
+  if (!response.ok || record.success === false) {
+    const message =
+      typeof record.error === "string" ? record.error : "Request failed";
+    throw new StudioApiError(response.status, message);
+  }
+
+  return record;
+}
+
+export async function listProviderKeysRequest(): Promise<
+  ProviderKeySummaryView[]
+> {
+  const record = await keysFetch("/api/keys");
+  const keys = record.keys;
+  return Array.isArray(keys) ? (keys as ProviderKeySummaryView[]) : [];
+}
+
+export async function saveProviderKeyRequest(
+  provider: ByokProvider,
+  apiKey: string,
+): Promise<ProviderKeySummaryView> {
+  const record = await keysFetch("/api/keys", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ provider, apiKey }),
+  });
+  return record.key as ProviderKeySummaryView;
+}
+
+export async function deleteProviderKeyRequest(
+  provider: ByokProvider,
+): Promise<void> {
+  await keysFetch(`/api/keys/${encodeURIComponent(provider)}`, {
+    method: "DELETE",
+  });
+}

--- a/src/lib/byok/crypto.ts
+++ b/src/lib/byok/crypto.ts
@@ -1,0 +1,105 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { isDevAuthBypassEnabled } from "@/lib/auth/session";
+import { logger } from "@/utils/logger";
+
+/**
+ * AES-256-GCM at-rest encryption for workspace BYOK provider keys.
+ *
+ * Deliberately mirrors `src/lib/social/crypto.ts` (same algorithm, format,
+ * and dev-bypass plaintext fallback) but uses its own env var so rotating
+ * the social-token key never invalidates provider keys or vice versa.
+ */
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+const PLAINTEXT_PREFIX = "plain:";
+
+function getEncryptionKey(): Buffer | null {
+  const hex = process.env.BYOK_KEY_ENCRYPTION_KEY?.trim();
+  if (!hex) return null;
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length !== 32) {
+    throw new Error(
+      "BYOK_KEY_ENCRYPTION_KEY must be a 64-character hex string (32 bytes).",
+    );
+  }
+  return buf;
+}
+
+/**
+ * Encrypt a plaintext provider API key for storage at rest.
+ * Format: base64(iv):base64(authTag):base64(ciphertext)
+ *
+ * In dev bypass mode without an encryption key, stores plaintext with a prefix.
+ */
+export function encryptProviderKey(plaintext: string): string {
+  const key = getEncryptionKey();
+  if (!key) {
+    if (isDevAuthBypassEnabled()) {
+      logger.warn(
+        "system",
+        "BYOK_KEY_ENCRYPTION_KEY not set — storing provider key in plaintext (dev bypass)",
+      );
+      return `${PLAINTEXT_PREFIX}${plaintext}`;
+    }
+    throw new Error(
+      "BYOK_KEY_ENCRYPTION_KEY is required for provider key encryption.",
+    );
+  }
+
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return `${iv.toString("base64")}:${authTag.toString("base64")}:${encrypted.toString("base64")}`;
+}
+
+/**
+ * Decrypt a provider key stored at rest.
+ */
+export function decryptProviderKey(encrypted: string): string {
+  if (encrypted.startsWith(PLAINTEXT_PREFIX)) {
+    return encrypted.slice(PLAINTEXT_PREFIX.length);
+  }
+
+  const key = getEncryptionKey();
+  if (!key) {
+    throw new Error(
+      "BYOK_KEY_ENCRYPTION_KEY is required for provider key decryption.",
+    );
+  }
+
+  const parts = encrypted.split(":");
+  if (parts.length !== 3) {
+    throw new Error("Invalid encrypted provider key format.");
+  }
+
+  const iv = Buffer.from(parts[0], "base64");
+  const authTag = Buffer.from(parts[1], "base64");
+  const ciphertext = Buffer.from(parts[2], "base64");
+
+  if (iv.length !== IV_LENGTH || authTag.length !== AUTH_TAG_LENGTH) {
+    throw new Error("Invalid encrypted provider key format.");
+  }
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+
+  return decrypted.toString("utf8");
+}
+
+/**
+ * Check if provider key encryption is configured.
+ */
+export function isProviderKeyEncryptionConfigured(): boolean {
+  return getEncryptionKey() !== null;
+}

--- a/src/lib/byok/mask.ts
+++ b/src/lib/byok/mask.ts
@@ -1,0 +1,20 @@
+/**
+ * Non-secret display hint for a provider API key, e.g. `sk-…abc4`. This is
+ * the ONLY form of a stored key any read path may return — the raw key is
+ * write-only and decrypted solely for outbound provider calls
+ * (see `resolveProviderKey` in `./repository`).
+ */
+const PREFIX_LENGTH = 3;
+const SUFFIX_LENGTH = 4;
+/** Below this length, showing prefix + suffix would reveal the whole key. */
+const MIN_LENGTH_FOR_PARTIAL_MASK = PREFIX_LENGTH + SUFFIX_LENGTH + 2;
+
+export function maskProviderKey(rawKey: string): string {
+  if (rawKey.length < MIN_LENGTH_FOR_PARTIAL_MASK) {
+    return "•".repeat(rawKey.length);
+  }
+
+  const prefix = rawKey.slice(0, PREFIX_LENGTH);
+  const suffix = rawKey.slice(-SUFFIX_LENGTH);
+  return `${prefix}…${suffix}`;
+}

--- a/src/lib/byok/providers.ts
+++ b/src/lib/byok/providers.ts
@@ -1,0 +1,30 @@
+/**
+ * The AI providers a workspace can store a BYOK key for. Kept as the single
+ * source of truth so the DB enum, validation, repository, routes, and UI all
+ * derive from one list.
+ */
+export const BYOK_PROVIDERS = [
+  "gemini",
+  "openai",
+  "anthropic",
+  "kie",
+  "fal",
+  "replicate",
+  "wavespeed",
+] as const;
+
+export type ByokProvider = (typeof BYOK_PROVIDERS)[number];
+
+export const BYOK_PROVIDER_LABELS: Record<ByokProvider, string> = {
+  gemini: "Google Gemini",
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  kie: "Kie.ai",
+  fal: "fal.ai",
+  replicate: "Replicate",
+  wavespeed: "WaveSpeed",
+};
+
+export function isByokProvider(value: string): value is ByokProvider {
+  return (BYOK_PROVIDERS as readonly string[]).includes(value);
+}

--- a/src/lib/byok/repository.ts
+++ b/src/lib/byok/repository.ts
@@ -9,6 +9,20 @@ import { maskProviderKey } from "./mask";
 import type { ByokProvider } from "./providers";
 
 /**
+ * TODO(#102 tool registry, PRD #100): once the agent-tool registry lands
+ * (`src/lib/agent-tools/` — owned by #102, intentionally not created here),
+ * add a `manage-keys` tool definition that wraps this module's
+ * `listProviderKeys` / `upsertProviderKey` / `deleteProviderKey` so the MCP
+ * server and CLI (`nb keys set/list/delete`) can manage BYOK keys the same
+ * way the app's settings UI does. The tool's "set" handler must call
+ * `validateProviderKey` from `./validation` before `upsertProviderKey`,
+ * exactly like `POST /api/keys` — never persist an unvalidated key. Its
+ * "list" handler must return `ProviderKeySummary` (masked hint only) and
+ * MUST NOT expose `resolveProviderKey`'s plaintext output over any tool,
+ * CLI, or MCP surface.
+ */
+
+/**
  * Everything a read path may ever expose about a stored provider key. The
  * raw key itself is deliberately absent from this shape — see
  * `resolveProviderKey` for the one seam that returns plaintext, and note

--- a/src/lib/byok/repository.ts
+++ b/src/lib/byok/repository.ts
@@ -1,0 +1,178 @@
+import { randomUUID } from "node:crypto";
+import { and, desc, eq } from "drizzle-orm";
+
+import { getDb } from "@/lib/db";
+import { workspaceProviderKeys } from "@/lib/db/schema";
+
+import { decryptProviderKey, encryptProviderKey } from "./crypto";
+import { maskProviderKey } from "./mask";
+import type { ByokProvider } from "./providers";
+
+/**
+ * Everything a read path may ever expose about a stored provider key. The
+ * raw key itself is deliberately absent from this shape — see
+ * `resolveProviderKey` for the one seam that returns plaintext, and note
+ * that it is not part of this type.
+ */
+export interface ProviderKeySummary {
+  provider: ByokProvider;
+  /** Non-secret display hint, e.g. "sk-…abc4". Never the raw key. */
+  hint: string;
+  lastValidatedAt: Date | null;
+  updatedAt: Date;
+}
+
+interface ProviderKeyRow {
+  provider: string;
+  keyHint: string;
+  lastValidatedAt: Date | null;
+  updatedAt: Date;
+}
+
+function toSummary(row: ProviderKeyRow): ProviderKeySummary {
+  return {
+    provider: row.provider as ByokProvider,
+    hint: row.keyHint,
+    lastValidatedAt: row.lastValidatedAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * List a workspace's stored provider keys (masked hints only, newest first).
+ * Callers should validate the key with `validateProviderKey` (see
+ * `./validation`) *before* calling `upsertProviderKey` — this repository
+ * does not re-validate, it only persists.
+ */
+export async function listProviderKeys(
+  workspaceId: string,
+): Promise<ProviderKeySummary[]> {
+  const db = getDb();
+
+  const rows = await db
+    .select({
+      provider: workspaceProviderKeys.provider,
+      keyHint: workspaceProviderKeys.keyHint,
+      lastValidatedAt: workspaceProviderKeys.lastValidatedAt,
+      updatedAt: workspaceProviderKeys.updatedAt,
+    })
+    .from(workspaceProviderKeys)
+    .where(eq(workspaceProviderKeys.workspaceId, workspaceId))
+    .orderBy(desc(workspaceProviderKeys.updatedAt));
+
+  return rows.map(toSummary);
+}
+
+/**
+ * Create or rotate the stored key for a (workspace, provider) pair. Encrypts
+ * at rest and stores a masked hint; the raw key is never persisted or
+ * returned. Upserts on the `(workspace_id, provider)` unique constraint, so
+ * saving again for the same provider rotates the key in place.
+ */
+export async function upsertProviderKey(input: {
+  workspaceId: string;
+  provider: ByokProvider;
+  rawKey: string;
+  createdByUserId: string;
+}): Promise<ProviderKeySummary> {
+  const db = getDb();
+  const now = new Date();
+  const keyEncrypted = encryptProviderKey(input.rawKey);
+  const keyHint = maskProviderKey(input.rawKey);
+
+  const [row] = await db
+    .insert(workspaceProviderKeys)
+    .values({
+      id: `provkey_${randomUUID()}`,
+      workspaceId: input.workspaceId,
+      provider: input.provider,
+      keyEncrypted,
+      keyHint,
+      lastValidatedAt: now,
+      createdByUserId: input.createdByUserId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [workspaceProviderKeys.workspaceId, workspaceProviderKeys.provider],
+      set: {
+        keyEncrypted,
+        keyHint,
+        lastValidatedAt: now,
+        updatedAt: now,
+      },
+    })
+    .returning({
+      provider: workspaceProviderKeys.provider,
+      keyHint: workspaceProviderKeys.keyHint,
+      lastValidatedAt: workspaceProviderKeys.lastValidatedAt,
+      updatedAt: workspaceProviderKeys.updatedAt,
+    });
+
+  return toSummary(row);
+}
+
+/**
+ * Delete a workspace's stored key for a provider. Returns true when a row
+ * was actually removed, false when there was nothing to delete.
+ */
+export async function deleteProviderKey(input: {
+  workspaceId: string;
+  provider: ByokProvider;
+}): Promise<boolean> {
+  const db = getDb();
+
+  const rows = await db
+    .delete(workspaceProviderKeys)
+    .where(
+      and(
+        eq(workspaceProviderKeys.workspaceId, input.workspaceId),
+        eq(workspaceProviderKeys.provider, input.provider),
+      ),
+    )
+    .returning({ id: workspaceProviderKeys.id });
+
+  return rows.length > 0;
+}
+
+/**
+ * Resolve the raw (decrypted) provider key for a workspace.
+ *
+ * This is the seam later slices (#108 generate route, #109 LLM route) call
+ * as the vault tier of the key-resolution order:
+ *
+ *   1. Request header override (e.g. `X-OpenAI-API-Key`) — ad-hoc / agent use
+ *   2. `resolveProviderKey(workspaceId, provider)` — this workspace vault
+ *   3. A typed "no key configured for <provider>" error surfaced to the user
+ *
+ * Contract:
+ *  - Returns `null` — never throws — when the workspace has no stored key
+ *    for the provider. Treat `null` as "fall through to the next tier", not
+ *    as an error condition.
+ *  - Returns the plaintext key, ready to use directly in a request header or
+ *    SDK client. Callers must never log or persist it.
+ *  - Throws only for genuine misconfiguration (e.g.
+ *    `BYOK_KEY_ENCRYPTION_KEY` unset outside dev bypass, or corrupted
+ *    ciphertext) — these are ops problems, not per-request conditions, and
+ *    should surface as 500s rather than "no key configured".
+ */
+export async function resolveProviderKey(
+  workspaceId: string,
+  provider: ByokProvider,
+): Promise<string | null> {
+  const db = getDb();
+
+  const [row] = await db
+    .select({ keyEncrypted: workspaceProviderKeys.keyEncrypted })
+    .from(workspaceProviderKeys)
+    .where(
+      and(
+        eq(workspaceProviderKeys.workspaceId, workspaceId),
+        eq(workspaceProviderKeys.provider, provider),
+      ),
+    )
+    .limit(1);
+
+  if (!row) return null;
+  return decryptProviderKey(row.keyEncrypted);
+}

--- a/src/lib/byok/validation.ts
+++ b/src/lib/byok/validation.ts
@@ -1,0 +1,136 @@
+import type { ByokProvider } from "./providers";
+import { BYOK_PROVIDER_LABELS } from "./providers";
+
+export type ProviderKeyValidationResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/** Generous but bounded — this is a cheap liveness check, not a real request. */
+const VALIDATION_TIMEOUT_MS = 8000;
+
+interface ProbeConfig {
+  url: string;
+  headers: Record<string, string>;
+}
+
+function buildProbe(provider: ByokProvider, rawKey: string): ProbeConfig {
+  switch (provider) {
+    case "gemini":
+      // Cheapest authenticated GET for a Gemini key: list models. Google's
+      // GenAI SDK also authenticates image/LLM calls via this `key` query
+      // param, so a 200 here is a faithful proxy for "the key works".
+      return {
+        url: `https://generativelanguage.googleapis.com/v1beta/models?pageSize=1&key=${encodeURIComponent(rawKey)}`,
+        headers: {},
+      };
+    case "openai":
+      // GET /v1/models is free (no token cost) and requires a valid key.
+      return {
+        url: "https://api.openai.com/v1/models",
+        headers: { Authorization: `Bearer ${rawKey}` },
+      };
+    case "anthropic":
+      // GET /v1/models mirrors the auth headers generateWithAnthropic()
+      // already sends in src/app/api/llm/route.ts.
+      return {
+        url: "https://api.anthropic.com/v1/models",
+        headers: {
+          "x-api-key": rawKey,
+          "anthropic-version": "2023-06-01",
+        },
+      };
+    case "kie":
+      // https://docs.kie.ai/common-api/get-account-credits — the cheapest
+      // authenticated GET Kie exposes (no task is created).
+      return {
+        url: "https://api.kie.ai/api/v1/chat/credit",
+        headers: { Authorization: `Bearer ${rawKey}` },
+      };
+    case "fal":
+      // fal's own auth docs recommend GET /v1/models (API scope, not Admin)
+      // as the lightweight way to confirm a key is valid and active.
+      return {
+        url: "https://api.fal.ai/v1/models?limit=1",
+        headers: { Authorization: `Key ${rawKey}` },
+      };
+    case "replicate":
+      // GET /v1/account returns the authenticated account — no run created.
+      return {
+        url: "https://api.replicate.com/v1/account",
+        headers: { Authorization: `Bearer ${rawKey}` },
+      };
+    case "wavespeed":
+      // GET /api/v3/balance — reads account balance, no generation started.
+      return {
+        url: "https://api.wavespeed.ai/api/v3/balance",
+        headers: { Authorization: `Bearer ${rawKey}` },
+      };
+  }
+}
+
+/**
+ * Best-effort extraction of a human-readable error message from a provider's
+ * JSON error body. Providers disagree on shape (`error.message`, `msg`,
+ * `message`, `detail`, ...) so this tries the common ones in order and falls
+ * back to a generic HTTP-status message.
+ */
+function extractErrorMessage(body: unknown, status: number): string {
+  if (body && typeof body === "object") {
+    const record = body as Record<string, unknown>;
+
+    const nestedError = record.error;
+    if (nestedError && typeof nestedError === "object") {
+      const message = (nestedError as Record<string, unknown>).message;
+      if (typeof message === "string" && message) return message;
+    }
+    if (typeof nestedError === "string" && nestedError) return nestedError;
+
+    for (const field of ["msg", "message", "detail"]) {
+      const value = record[field];
+      if (typeof value === "string" && value) return value;
+    }
+  }
+
+  return `Request failed with status ${status}.`;
+}
+
+/**
+ * Validate a BYOK provider key with a single cheap, authenticated GET call —
+ * the same "list models" / "account" style endpoint the app's own generation
+ * code would use to authenticate, so a pass here means the key genuinely
+ * works for real generation calls.
+ */
+export async function validateProviderKey(
+  provider: ByokProvider,
+  rawKey: string,
+): Promise<ProviderKeyValidationResult> {
+  const trimmed = rawKey.trim();
+  if (!trimmed) {
+    return { ok: false, error: "An API key is required." };
+  }
+
+  const probe = buildProbe(provider, trimmed);
+  const label = BYOK_PROVIDER_LABELS[provider];
+
+  let response: Response;
+  try {
+    response = await fetch(probe.url, {
+      method: "GET",
+      headers: probe.headers,
+      signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      error: `Could not reach ${label} to validate the key: ${message}`,
+    };
+  }
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    return { ok: false, error: extractErrorMessage(body, response.status) };
+  }
+
+  return { ok: true };
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -352,6 +352,58 @@ export const apiTokens = pgTable(
   }),
 );
 
+/**
+ * The AI inference providers a workspace may store a BYOK key for. Kept in
+ * sync with `BYOK_PROVIDERS` in `src/lib/byok/providers.ts`.
+ */
+export const byokProviderEnum = pgEnum("byok_provider", [
+  "gemini",
+  "openai",
+  "anthropic",
+  "kie",
+  "fal",
+  "replicate",
+  "wavespeed",
+]);
+
+/**
+ * Per-workspace, per-provider BYOK vault entry. One row per
+ * (workspaceId, provider) pair. `keyEncrypted` is AES-256-GCM ciphertext
+ * (see `src/lib/byok/crypto.ts`) and is never selected by any read path
+ * outside `resolveProviderKey` — list/read APIs project `keyHint` only.
+ */
+export const workspaceProviderKeys = pgTable(
+  "workspace_provider_keys",
+  {
+    id: text("id").primaryKey(),
+    workspaceId: text("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    provider: byokProviderEnum("provider").notNull(),
+    keyEncrypted: text("key_encrypted").notNull(),
+    /** Non-secret display hint, e.g. "sk-…abc4". Never the raw key. */
+    keyHint: text("key_hint").notNull(),
+    lastValidatedAt: timestamp("last_validated_at", { withTimezone: true }),
+    createdByUserId: text("created_by_user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "restrict" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    workspaceProviderUnique: uniqueIndex(
+      "workspace_provider_keys_workspace_provider_unique",
+    ).on(table.workspaceId, table.provider),
+    workspaceIdx: index("workspace_provider_keys_workspace_idx").on(
+      table.workspaceId,
+    ),
+  }),
+);
+
 export const projects = pgTable(
   "projects",
   {
@@ -1248,6 +1300,9 @@ export const savedPrompts = pgTable(
 
 export type ApiToken = typeof apiTokens.$inferSelect;
 export type NewApiToken = typeof apiTokens.$inferInsert;
+export type WorkspaceProviderKey = typeof workspaceProviderKeys.$inferSelect;
+export type NewWorkspaceProviderKey = typeof workspaceProviderKeys.$inferInsert;
+export type ByokProviderColumn = typeof byokProviderEnum.enumValues[number];
 export type WorkspaceRole = typeof workspaceRoleEnum.enumValues[number];
 export type ProjectStatus = typeof projectStatusEnum.enumValues[number];
 export type AssetType = typeof assetTypeEnum.enumValues[number];


### PR DESCRIPTION
Closes #107. Part of PRD #100. **Stacked on #123** (base = `feature/api-token-auth`); merge #123 first.

Per-workspace encrypted storage for the 7 inference providers (gemini, openai, anthropic, kie, fal, replicate, wavespeed):

- `workspace_provider_keys` table (migration `0016`): unique per workspace+provider, AES-256-GCM ciphertext (own env key `BYOK_KEY_ENCRYPTION_KEY`, mirrors the social-token crypto pattern), masked hint for display, last-validated timestamp.
- `resolveProviderKey(workspaceId, provider)` — the contract slices #108/#109 consume: decrypted key or `null` (= fall to next tier), throws only on genuine crypto misconfig. Designed for `request header → vault → typed error` resolution.
- Save validates the key with a cheap authenticated GET per provider (endpoints verified against current provider docs, not memory); invalid keys rejected with the provider's error.
- Raw keys never readable after creation — list returns provider + masked hint + dates only.
- CRUD API via `withStudioAuth` (members read, owners/admins write/delete) + "Provider Keys (BYOK)" section on `/social/settings`.

59 new tests (crypto, masking, validation, repo, routes, client, component) — re-run by reviewer. Full suite green except the 2 tracked pre-existing failures. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)