### PR TITLE
feat: agent tool registry + MCP server (HTTP & stdio) + v1 parity routes (#102)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:gate-a": "vitest run src/app/api/studio/workspaces/__tests__/route.test.ts src/app/api/studio/projects/__tests__/route.test.ts src/app/api/studio/projects/[projectId]/__tests__/route.test.ts src/app/api/studio/assets/__tests__/route.test.ts src/app/api/studio/assets/[assetId]/__tests__/route.test.ts src/app/api/studio/assets/presign/__tests__/route.test.ts src/app/api/social/accounts/__tests__/route.test.ts src/app/api/social/posts/__tests__/route.test.ts src/components/__tests__/Header.test.tsx",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
+    "mcp:stdio": "tsx scripts/mcp-stdio.ts",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
     "db:generate": "drizzle-kit generate",
@@ -117,6 +118,7 @@
     "baseline-browser-mapping": "^2.10.12",
     "drizzle-kit": "^0.31.10",
     "jsdom": "^27.4.0",
+    "tsx": "^4.20.0",
     "typescript": "5.9.3",
     "vite-tsconfig-paths": "^6.0.4",
     "vitest": "^4.0.16"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@base-ui/react": "^1.3.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
+    "@modelcontextprotocol/sdk": "^1.28.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@google/genai": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@google/genai':
         specifier: ^1.30.0
         version: 1.30.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.28.0
+        version: 1.28.0(zod@4.3.6)
       '@react-three/drei':
         specifier: ^10.7.7
         version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.7)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.182.0))(@types/react@19.2.7)(@types/three@0.182.0)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.182.0)
@@ -3170,6 +3173,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -9131,7 +9135,6 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
@@ -15493,7 +15496,6 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
-    optional: true
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0
+      tsx:
+        specifier: ^4.20.0
+        version: 4.21.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -15015,7 +15018,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.4
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3

--- a/scripts/mcp-stdio.ts
+++ b/scripts/mcp-stdio.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Local stdio MCP entry point for agent harnesses (Claude Code, etc.).
+ *
+ * It does NOT touch the database or the tool registry directly — it bridges a
+ * local stdio MCP channel to the *hosted* streamable-HTTP endpoint, forwarding
+ * every request with the configured Bearer token. That way local harnesses
+ * exercise the exact same hosted auth + workspace-scoping path as remote ones.
+ *
+ * Usage:
+ *   NB_API_URL=https://your-app.example NB_API_TOKEN=nb_xxx pnpm mcp:stdio
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { createStdioProxyServer } from "../src/lib/agent-tools/mcp/stdio-bridge";
+
+async function main(): Promise<void> {
+  const token = process.env.NB_API_TOKEN;
+  const baseUrl = process.env.NB_API_URL;
+
+  if (!token) {
+    console.error("NB_API_TOKEN is required (a workspace API token, nb_...).");
+    process.exit(1);
+  }
+  if (!baseUrl) {
+    console.error(
+      "NB_API_URL is required (e.g. https://your-node-banana.example).",
+    );
+    process.exit(1);
+  }
+
+  const endpoint = new URL("/api/mcp", baseUrl);
+
+  const upstream = new Client({
+    name: "node-banana-stdio-proxy",
+    version: "1.0.0",
+  });
+  const httpTransport = new StreamableHTTPClientTransport(endpoint, {
+    requestInit: {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  });
+  await upstream.connect(httpTransport);
+
+  const proxy = createStdioProxyServer(upstream);
+  await proxy.connect(new StdioServerTransport());
+
+  // stdout is the MCP channel; all diagnostics must go to stderr.
+  console.error(`node-banana MCP stdio bridge connected -> ${endpoint.href}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/api/mcp/__tests__/route.test.ts
+++ b/src/app/api/mcp/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const { mockAuthorize, mockIsDatabaseConfigured, mockGetWorkspaceById } =
+  vi.hoisted(() => ({
+    mockAuthorize: vi.fn(),
+    mockIsDatabaseConfigured: vi.fn(() => true),
+    mockGetWorkspaceById: vi.fn(),
+  }));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+  getDb: vi.fn(),
+}));
+
+vi.mock("@/lib/api-tokens/auth", () => ({
+  authorizePublicApiRequest: (...args: unknown[]) => mockAuthorize(...args),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getWorkspaceById: (...args: unknown[]) => mockGetWorkspaceById(...args),
+  listWorkspaceAssets: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  listSocialAccounts: vi.fn(async () => []),
+}));
+
+import { POST } from "../route";
+
+function ownerSession(workspaceId = "ws_1") {
+  return {
+    user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+    workspace: { id: workspaceId, organizationId: null },
+    role: "owner" as const,
+    planTier: "free" as const,
+    permissions: getPermissionsForRole("owner"),
+  };
+}
+
+function mcpRequest(body: unknown, headers?: Record<string, string>): Request {
+  return new Request("http://localhost:3000/api/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const initializeBody = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "test", version: "1.0.0" },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDatabaseConfigured.mockReturnValue(true);
+});
+
+describe("/api/mcp POST", () => {
+  it("returns 401 for an unauthenticated request", async () => {
+    mockAuthorize.mockResolvedValue({
+      authorized: false,
+      response: NextResponse.json(
+        { success: false, error: "Invalid or revoked API token." },
+        { status: 401 },
+      ),
+    });
+
+    const response = await POST(
+      mcpRequest(initializeBody, { authorization: "Bearer nb_bogus" }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toMatch(/Bearer/i);
+  });
+
+  it("returns 503 when the database is not configured", async () => {
+    mockIsDatabaseConfigured.mockReturnValue(false);
+
+    const response = await POST(
+      mcpRequest(initializeBody, { authorization: "Bearer nb_valid" }),
+    );
+
+    expect(response.status).toBe(503);
+  });
+
+  it("initializes an MCP session for a valid token", async () => {
+    mockAuthorize.mockResolvedValue({
+      authorized: true,
+      session: ownerSession("ws_1"),
+    });
+
+    const response = await POST(
+      mcpRequest(initializeBody, { authorization: "Bearer nb_valid" }),
+    );
+
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    // Response may be JSON or an SSE frame; the initialize result carries the
+    // server identity either way.
+    expect(text).toContain("node-banana");
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ permission: "workspaces:read" }),
+    );
+  });
+});

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,78 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { NextResponse } from "next/server";
+
+import { authorizePublicApiRequest } from "@/lib/api-tokens/auth";
+import { buildMcpServer } from "@/lib/agent-tools/mcp/server";
+import { isDatabaseConfigured } from "@/lib/db";
+
+const ROUTE = "/api/mcp";
+
+// Streamable HTTP MCP requests can take a while (tool handlers hit the DB);
+// give them room beyond the platform default.
+export const maxDuration = 60;
+
+/**
+ * Hosted MCP endpoint over streamable HTTP.
+ *
+ * Auth is the same Bearer path as the rest of public API v1: an
+ * `Authorization: Bearer nb_...` token resolved (and workspace-scoped) by
+ * `authorizePublicApiRequest`. Unauthenticated requests get a 401 with a
+ * `WWW-Authenticate` challenge before any MCP handling.
+ *
+ * The server is built fresh per request from the tool registry and connected to
+ * a stateless transport, so nothing is shared across callers or tenants.
+ */
+async function handle(request: Request): Promise<Response> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message:
+            "DATABASE_URL is not configured. Configure Postgres to use the MCP API.",
+        },
+        id: null,
+      },
+      { status: 503 },
+    );
+  }
+
+  const auth = await authorizePublicApiRequest(request, {
+    route: ROUTE,
+    permission: "workspaces:read",
+  });
+
+  if (!auth.authorized) {
+    const response = auth.response;
+    response.headers.set(
+      "WWW-Authenticate",
+      'Bearer realm="node-banana", error="invalid_token"',
+    );
+    return response;
+  }
+
+  const server = buildMcpServer(auth.session);
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    // Stateless: no session id, and return a complete JSON body per request
+    // rather than an open SSE stream — the natural fit for a serverless
+    // request/response handler.
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+
+  await server.connect(transport);
+  return transport.handleRequest(request);
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return handle(request);
+}
+
+export async function GET(request: Request): Promise<Response> {
+  return handle(request);
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  return handle(request);
+}

--- a/src/app/api/v1/assets/__tests__/route.test.ts
+++ b/src/app/api/v1/assets/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const { mockAuthorize, mockIsDatabaseConfigured, mockListWorkspaceAssets } =
+  vi.hoisted(() => ({
+    mockAuthorize: vi.fn(),
+    mockIsDatabaseConfigured: vi.fn(() => true),
+    mockListWorkspaceAssets: vi.fn(),
+  }));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+  getDb: vi.fn(),
+}));
+
+vi.mock("@/lib/api-tokens/auth", () => ({
+  authorizePublicApiRequest: (...args: unknown[]) => mockAuthorize(...args),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getWorkspaceById: vi.fn(),
+  listWorkspaceAssets: (...args: unknown[]) => mockListWorkspaceAssets(...args),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  listSocialAccounts: vi.fn(),
+}));
+
+import { GET } from "../route";
+
+function createRequest(url: string, headers?: HeadersInit): NextRequest {
+  return {
+    headers: new Headers(headers),
+    nextUrl: new URL(url),
+  } as unknown as NextRequest;
+}
+
+function authorized(workspaceId = "ws_1") {
+  return {
+    authorized: true,
+    session: {
+      user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+      workspace: { id: workspaceId, organizationId: null },
+      role: "owner" as const,
+      planTier: "free" as const,
+      permissions: getPermissionsForRole("owner"),
+    },
+  };
+}
+
+const BASE = "http://localhost:3000/api/v1/assets";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDatabaseConfigured.mockReturnValue(true);
+});
+
+describe("/api/v1/assets GET", () => {
+  it("returns 503 when the database is not configured", async () => {
+    mockIsDatabaseConfigured.mockReturnValue(false);
+
+    const response = await GET(
+      createRequest(BASE, { authorization: "Bearer nb_valid" }),
+    );
+
+    expect(response.status).toBe(503);
+  });
+
+  it("lists assets and forwards type/limit filters from the query string", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+    mockListWorkspaceAssets.mockResolvedValue([
+      {
+        id: "asset_1",
+        workspaceId: "ws_1",
+        projectId: null,
+        type: "image",
+        mimeType: "image/png",
+        sizeBytes: 1024,
+        width: 256,
+        height: 256,
+        durationSeconds: null,
+        createdAt: new Date("2026-02-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const response = await GET(
+      createRequest(`${BASE}?type=image&limit=5`, {
+        authorization: "Bearer nb_valid",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.assets[0].id).toBe("asset_1");
+    expect(mockListWorkspaceAssets).toHaveBeenCalledWith("ws_1", {
+      type: "image",
+      limit: 5,
+    });
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ permission: "assets:read" }),
+    );
+  });
+
+  it("returns a structured 400 for an invalid limit", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+
+    const response = await GET(
+      createRequest(`${BASE}?limit=abc`, {
+        authorization: "Bearer nb_valid",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("invalid_input");
+    expect(mockListWorkspaceAssets).not.toHaveBeenCalled();
+  });
+
+  it("passes through the auth layer's 401 for an invalid token", async () => {
+    mockAuthorize.mockResolvedValue({
+      authorized: false,
+      response: NextResponse.json(
+        { success: false, error: "Invalid or revoked API token." },
+        { status: 401 },
+      ),
+    });
+
+    const response = await GET(
+      createRequest(BASE, { authorization: "Bearer nb_bogus" }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockListWorkspaceAssets).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/assets/route.ts
+++ b/src/app/api/v1/assets/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { listAssetsTool } from "@/lib/agent-tools/tools/list-assets";
+import { toolErrorResponse } from "@/lib/agent-tools/http";
+import { runTool } from "@/lib/agent-tools/runtime";
+import { authorizePublicApiRequest } from "@/lib/api-tokens/auth";
+import { isDatabaseConfigured } from "@/lib/db";
+
+const ROUTE = "/api/v1/assets";
+
+/**
+ * Public API v1: list the workspace's media assets.
+ *
+ * A thin wrapper over the `list_assets` registry tool. Query params `type` and
+ * `limit` are forwarded to the tool, whose Zod schema validates them (an
+ * invalid value yields a structured 400) — the route holds no business logic.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use the API.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const auth = await authorizePublicApiRequest(request, {
+    route: ROUTE,
+    permission: listAssetsTool.requiredPermission,
+  });
+
+  if (!auth.authorized) {
+    return auth.response;
+  }
+
+  const params = request.nextUrl.searchParams;
+  const rawType = params.get("type");
+  const rawLimit = params.get("limit");
+
+  const input = {
+    type: rawType ?? undefined,
+    limit: rawLimit === null ? undefined : Number(rawLimit),
+  };
+
+  try {
+    const output = await runTool(listAssetsTool, input, {
+      session: auth.session,
+    });
+    return NextResponse.json({ success: true, ...output });
+  } catch (error) {
+    return toolErrorResponse(error);
+  }
+}

--- a/src/app/api/v1/social-accounts/__tests__/route.test.ts
+++ b/src/app/api/v1/social-accounts/__tests__/route.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const { mockAuthorize, mockIsDatabaseConfigured, mockListSocialAccounts } =
+  vi.hoisted(() => ({
+    mockAuthorize: vi.fn(),
+    mockIsDatabaseConfigured: vi.fn(() => true),
+    mockListSocialAccounts: vi.fn(),
+  }));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+  getDb: vi.fn(),
+}));
+
+vi.mock("@/lib/api-tokens/auth", () => ({
+  authorizePublicApiRequest: (...args: unknown[]) => mockAuthorize(...args),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getWorkspaceById: vi.fn(),
+  listWorkspaceAssets: vi.fn(),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  listSocialAccounts: (...args: unknown[]) => mockListSocialAccounts(...args),
+}));
+
+import { GET } from "../route";
+
+function createRequest(headers?: HeadersInit): NextRequest {
+  return {
+    headers: new Headers(headers),
+    nextUrl: new URL("http://localhost:3000/api/v1/social-accounts"),
+  } as unknown as NextRequest;
+}
+
+function authorized(workspaceId = "ws_1") {
+  return {
+    authorized: true,
+    session: {
+      user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+      workspace: { id: workspaceId, organizationId: null },
+      role: "owner" as const,
+      planTier: "free" as const,
+      permissions: getPermissionsForRole("owner"),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDatabaseConfigured.mockReturnValue(true);
+});
+
+describe("/api/v1/social-accounts GET", () => {
+  it("returns 503 when the database is not configured", async () => {
+    mockIsDatabaseConfigured.mockReturnValue(false);
+
+    const response = await GET(
+      createRequest({ authorization: "Bearer nb_valid" }),
+    );
+
+    expect(response.status).toBe(503);
+  });
+
+  it("returns the workspace's accounts through the registry handler", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+    mockListSocialAccounts.mockResolvedValue([
+      {
+        id: "sacct_1",
+        workspaceId: "ws_1",
+        platform: "x",
+        platformUserId: "12345",
+        displayName: "Acme on X",
+        username: "acme",
+        avatarUrl: null,
+        accessTokenEncrypted: "SECRET",
+        refreshTokenEncrypted: null,
+        accessTokenSecret: null,
+        tokenExpiresAt: null,
+        requiresReauth: false,
+        disabled: false,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const response = await GET(
+      createRequest({ authorization: "Bearer nb_valid" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.accounts).toHaveLength(1);
+    expect(data.accounts[0].id).toBe("sacct_1");
+    expect(mockListSocialAccounts).toHaveBeenCalledWith("ws_1");
+    expect(JSON.stringify(data)).not.toContain("SECRET");
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ permission: "social:view" }),
+    );
+  });
+
+  it("passes through the auth layer's 401 for an invalid token", async () => {
+    mockAuthorize.mockResolvedValue({
+      authorized: false,
+      response: NextResponse.json(
+        { success: false, error: "Invalid or revoked API token." },
+        { status: 401 },
+      ),
+    });
+
+    const response = await GET(
+      createRequest({ authorization: "Bearer nb_bogus" }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockListSocialAccounts).not.toHaveBeenCalled();
+  });
+
+  it("returns a structured 500 when the repository throws", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+    mockListSocialAccounts.mockRejectedValue(new Error("db down"));
+
+    const response = await GET(
+      createRequest({ authorization: "Bearer nb_valid" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("internal");
+    expect(data.error.fix).toBeTruthy();
+  });
+});

--- a/src/app/api/v1/social-accounts/route.ts
+++ b/src/app/api/v1/social-accounts/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { listSocialAccountsTool } from "@/lib/agent-tools/tools/list-social-accounts";
+import { toolErrorResponse } from "@/lib/agent-tools/http";
+import { runTool } from "@/lib/agent-tools/runtime";
+import { authorizePublicApiRequest } from "@/lib/api-tokens/auth";
+import { isDatabaseConfigured } from "@/lib/db";
+
+const ROUTE = "/api/v1/social-accounts";
+
+/**
+ * Public API v1: list the workspace's connected social accounts.
+ *
+ * A thin wrapper over the `list_social_accounts` registry tool — the same
+ * handler the MCP server and CLI use — so REST parity is guaranteed by
+ * construction. No business logic lives here.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use the API.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const auth = await authorizePublicApiRequest(request, {
+    route: ROUTE,
+    permission: listSocialAccountsTool.requiredPermission,
+  });
+
+  if (!auth.authorized) {
+    return auth.response;
+  }
+
+  try {
+    const output = await runTool(
+      listSocialAccountsTool,
+      {},
+      { session: auth.session },
+    );
+    return NextResponse.json({ success: true, ...output });
+  } catch (error) {
+    return toolErrorResponse(error);
+  }
+}

--- a/src/lib/agent-tools/__tests__/runtime.test.ts
+++ b/src/lib/agent-tools/__tests__/runtime.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import type { ContentOSSession } from "@/lib/studio/authz";
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+import { ToolError } from "../errors";
+import { runTool } from "../runtime";
+import type { ToolDefinition } from "../types";
+
+function sessionWithRole(role: "owner" | "member"): ContentOSSession {
+  return {
+    user: { id: `apitoken:ws_1`, name: null, email: null },
+    workspace: { id: "ws_1", organizationId: null },
+    role,
+    planTier: "free",
+    permissions: getPermissionsForRole(role),
+  };
+}
+
+const echoTool: ToolDefinition<
+  z.ZodObject<{ value: z.ZodString }>,
+  z.ZodObject<{ echoed: z.ZodString; workspaceId: z.ZodString }>
+> = {
+  name: "echo",
+  description: "Echoes its input scoped to the caller's workspace.",
+  requiredPermission: "assets:read",
+  inputSchema: z.object({ value: z.string() }),
+  outputSchema: z.object({ echoed: z.string(), workspaceId: z.string() }),
+  handler: async (input, ctx) => ({
+    echoed: input.value,
+    workspaceId: ctx.session.workspace.id,
+  }),
+};
+
+describe("runTool", () => {
+  it("validates input, runs the handler, and returns schema-valid output", async () => {
+    const result = await runTool(
+      echoTool,
+      { value: "hello" },
+      { session: sessionWithRole("owner") },
+    );
+
+    expect(result).toEqual({ echoed: "hello", workspaceId: "ws_1" });
+  });
+
+  it("scopes the handler to the session's workspace", async () => {
+    const session = sessionWithRole("owner");
+    session.workspace.id = "ws_other";
+
+    const result = await runTool(echoTool, { value: "x" }, { session });
+
+    expect(result.workspaceId).toBe("ws_other");
+  });
+
+  it("throws a structured invalid_input error when input fails the schema", async () => {
+    await expect(
+      runTool(
+        echoTool,
+        { value: 123 } as unknown as { value: string },
+        { session: sessionWithRole("owner") },
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      fix: expect.any(String),
+    });
+  });
+
+  it("denies access with a forbidden error when the role lacks the permission", async () => {
+    const restrictedTool: ToolDefinition = {
+      ...echoTool,
+      // members do not have assets:delete
+      requiredPermission: "assets:delete",
+    };
+
+    const error = await runTool(
+      restrictedTool,
+      { value: "hi" },
+      { session: sessionWithRole("member") },
+    ).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ToolError);
+    expect((error as ToolError).code).toBe("forbidden");
+    expect((error as ToolError).toStructured()).toMatchObject({
+      code: "forbidden",
+      message: expect.any(String),
+      fix: expect.any(String),
+    });
+  });
+
+  it("wraps an unexpected handler throw in a structured internal error", async () => {
+    const boomTool: ToolDefinition = {
+      ...echoTool,
+      handler: async () => {
+        throw new Error("database exploded");
+      },
+    };
+
+    const error = await runTool(
+      boomTool,
+      { value: "hi" },
+      { session: sessionWithRole("owner") },
+    ).catch((e) => e);
+
+    expect((error as ToolError).code).toBe("internal");
+    expect((error as ToolError).message).toContain("database exploded");
+  });
+
+  it("passes a handler-thrown ToolError through unchanged", async () => {
+    const notFoundTool: ToolDefinition = {
+      ...echoTool,
+      handler: async () => {
+        throw new ToolError({
+          code: "not_found",
+          message: "No such thing.",
+          fix: "Check the id.",
+        });
+      },
+    };
+
+    const error = await runTool(
+      notFoundTool,
+      { value: "hi" },
+      { session: sessionWithRole("owner") },
+    ).catch((e) => e);
+
+    expect((error as ToolError).code).toBe("not_found");
+    expect((error as ToolError).message).toBe("No such thing.");
+  });
+
+  it("raises invalid_output when the handler returns schema-invalid data", async () => {
+    const badOutputTool: ToolDefinition = {
+      ...echoTool,
+      handler: async () => ({ echoed: "ok" }) as unknown as {
+        echoed: string;
+        workspaceId: string;
+      },
+    };
+
+    const error = await runTool(
+      badOutputTool,
+      { value: "hi" },
+      { session: sessionWithRole("owner") },
+    ).catch((e) => e);
+
+    expect((error as ToolError).code).toBe("invalid_output");
+  });
+});

--- a/src/lib/agent-tools/__tests__/runtime.test.ts
+++ b/src/lib/agent-tools/__tests__/runtime.test.ts
@@ -67,7 +67,7 @@ describe("runTool", () => {
   });
 
   it("denies access with a forbidden error when the role lacks the permission", async () => {
-    const restrictedTool: ToolDefinition = {
+    const restrictedTool: typeof echoTool = {
       ...echoTool,
       // members do not have assets:delete
       requiredPermission: "assets:delete",
@@ -89,7 +89,7 @@ describe("runTool", () => {
   });
 
   it("wraps an unexpected handler throw in a structured internal error", async () => {
-    const boomTool: ToolDefinition = {
+    const boomTool: typeof echoTool = {
       ...echoTool,
       handler: async () => {
         throw new Error("database exploded");
@@ -107,7 +107,7 @@ describe("runTool", () => {
   });
 
   it("passes a handler-thrown ToolError through unchanged", async () => {
-    const notFoundTool: ToolDefinition = {
+    const notFoundTool: typeof echoTool = {
       ...echoTool,
       handler: async () => {
         throw new ToolError({
@@ -129,7 +129,7 @@ describe("runTool", () => {
   });
 
   it("raises invalid_output when the handler returns schema-invalid data", async () => {
-    const badOutputTool: ToolDefinition = {
+    const badOutputTool: typeof echoTool = {
       ...echoTool,
       handler: async () => ({ echoed: "ok" }) as unknown as {
         echoed: string;

--- a/src/lib/agent-tools/errors.ts
+++ b/src/lib/agent-tools/errors.ts
@@ -1,0 +1,53 @@
+/**
+ * Structured, agent-friendly errors for the tool registry.
+ *
+ * Every failure an agent can hit is one of these codes and always carries a
+ * `fix` — a plain-language next step — so an LLM harness can self-correct
+ * instead of guessing. The same shape is surfaced across all three registry
+ * surfaces (MCP, CLI, public API), so agents learn one error contract.
+ */
+export type ToolErrorCode =
+  | "invalid_input"
+  | "unauthenticated"
+  | "forbidden"
+  | "not_found"
+  | "invalid_output"
+  | "internal";
+
+export interface StructuredToolError {
+  code: ToolErrorCode;
+  message: string;
+  /** What the caller should do next to succeed. */
+  fix: string;
+}
+
+export class ToolError extends Error {
+  readonly code: ToolErrorCode;
+  readonly fix: string;
+
+  constructor(args: { code: ToolErrorCode; message: string; fix: string }) {
+    super(args.message);
+    this.name = "ToolError";
+    this.code = args.code;
+    this.fix = args.fix;
+    // Restore prototype chain for `instanceof` across transpilation targets.
+    Object.setPrototypeOf(this, ToolError.prototype);
+  }
+
+  toStructured(): StructuredToolError {
+    return { code: this.code, message: this.message, fix: this.fix };
+  }
+}
+
+/** Narrow an unknown thrown value to its structured form for transport. */
+export function toStructuredError(error: unknown): StructuredToolError {
+  if (error instanceof ToolError) {
+    return error.toStructured();
+  }
+
+  return {
+    code: "internal",
+    message: error instanceof Error ? error.message : "Unexpected tool failure.",
+    fix: "Retry the request; if it persists, the server may be unavailable.",
+  };
+}

--- a/src/lib/agent-tools/http.ts
+++ b/src/lib/agent-tools/http.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+import { toStructuredError, type ToolErrorCode } from "./errors";
+
+const STATUS_BY_CODE: Record<ToolErrorCode, number> = {
+  invalid_input: 400,
+  unauthenticated: 401,
+  forbidden: 403,
+  not_found: 404,
+  invalid_output: 500,
+  internal: 500,
+};
+
+/**
+ * Map any error thrown by `runTool` to an HTTP response for the public API v1
+ * wrappers. The structured `{ code, message, fix }` body is preserved verbatim
+ * so REST, MCP, and CLI callers all see the same actionable error contract.
+ */
+export function toolErrorResponse(
+  error: unknown,
+): NextResponse<{ success: false; error: ReturnType<typeof toStructuredError> }> {
+  const structured = toStructuredError(error);
+  return NextResponse.json(
+    { success: false, error: structured },
+    { status: STATUS_BY_CODE[structured.code] },
+  );
+}

--- a/src/lib/agent-tools/index.ts
+++ b/src/lib/agent-tools/index.ts
@@ -1,0 +1,8 @@
+export { ToolError, toStructuredError } from "./errors";
+export type { StructuredToolError, ToolErrorCode } from "./errors";
+export { runTool } from "./runtime";
+export { getTool, listToolNames, toolRegistry } from "./registry";
+export type { AnyToolDefinition, ToolContext, ToolDefinition } from "./types";
+export { listAssetsTool } from "./tools/list-assets";
+export { listSocialAccountsTool } from "./tools/list-social-accounts";
+export { listWorkspacesTool } from "./tools/list-workspaces";

--- a/src/lib/agent-tools/mcp/__tests__/server.test.ts
+++ b/src/lib/agent-tools/mcp/__tests__/server.test.ts
@@ -1,0 +1,121 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ContentOSSession } from "@/lib/studio/authz";
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const { mockGetWorkspaceById, mockListSocialAccounts } = vi.hoisted(() => ({
+  mockGetWorkspaceById: vi.fn(),
+  mockListSocialAccounts: vi.fn(),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getWorkspaceById: (...args: unknown[]) => mockGetWorkspaceById(...args),
+  listWorkspaceAssets: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  listSocialAccounts: (...args: unknown[]) => mockListSocialAccounts(...args),
+}));
+
+import { buildMcpServer } from "../server";
+
+function session(
+  role: "owner" | "member" = "owner",
+  workspaceId = "ws_1",
+): ContentOSSession {
+  return {
+    user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+    workspace: { id: workspaceId, organizationId: null },
+    role,
+    planTier: "free",
+    permissions: getPermissionsForRole(role),
+  };
+}
+
+async function connectClient(sess: ContentOSSession): Promise<Client> {
+  const server = buildMcpServer(sess);
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+  return client;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildMcpServer (registry-derived MCP tools)", () => {
+  it("exposes exactly the registry's tools with input and output schemas", async () => {
+    const client = await connectClient(session());
+
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+
+    expect(names).toEqual([
+      "list_assets",
+      "list_social_accounts",
+      "list_workspaces",
+    ]);
+    for (const tool of tools) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeTruthy();
+      expect(tool.outputSchema).toBeTruthy();
+    }
+
+    await client.close();
+  });
+
+  it("calls a tool and returns structured content scoped to the session", async () => {
+    mockGetWorkspaceById.mockResolvedValue({
+      id: "ws_1",
+      name: "Acme Brand",
+      slug: "acme-brand",
+    });
+
+    const client = await connectClient(session("owner", "ws_1"));
+
+    const result = await client.callTool({
+      name: "list_workspaces",
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({
+      workspaces: [{ id: "ws_1", name: "Acme Brand", slug: "acme-brand" }],
+    });
+    expect(mockGetWorkspaceById).toHaveBeenCalledWith("ws_1");
+
+    await client.close();
+  });
+
+  it("surfaces a structured forbidden error when the role lacks permission", async () => {
+    const memberSession = session("member");
+    memberSession.permissions = memberSession.permissions.filter(
+      (p) => p !== "social:view",
+    );
+
+    const client = await connectClient(memberSession);
+
+    const result = await client.callTool({
+      name: "list_social_accounts",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    const structured = result.structuredContent as {
+      code: string;
+      fix: string;
+    };
+    expect(structured.code).toBe("forbidden");
+    expect(structured.fix).toBeTruthy();
+    expect(mockListSocialAccounts).not.toHaveBeenCalled();
+
+    await client.close();
+  });
+});

--- a/src/lib/agent-tools/mcp/__tests__/stdio-bridge.test.ts
+++ b/src/lib/agent-tools/mcp/__tests__/stdio-bridge.test.ts
@@ -1,0 +1,102 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ContentOSSession } from "@/lib/studio/authz";
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const { mockGetWorkspaceById } = vi.hoisted(() => ({
+  mockGetWorkspaceById: vi.fn(),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getWorkspaceById: (...args: unknown[]) => mockGetWorkspaceById(...args),
+  listWorkspaceAssets: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  listSocialAccounts: vi.fn(async () => []),
+}));
+
+import { buildMcpServer } from "../server";
+import { createStdioProxyServer } from "../stdio-bridge";
+
+function ownerSession(workspaceId = "ws_1"): ContentOSSession {
+  return {
+    user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+    workspace: { id: workspaceId, organizationId: null },
+    role: "owner",
+    planTier: "free",
+    permissions: getPermissionsForRole("owner"),
+  };
+}
+
+/**
+ * Stand up the full local-harness path in memory:
+ *   downstream client (stdin/stdout stand-in)
+ *     -> proxy server (what the bin runs)
+ *       -> upstream client
+ *         -> hosted MCP server (built from the registry)
+ * The proxy must forward tools/list and tools/call across that chain, exactly
+ * as the shipped bin does over real stdio + HTTP.
+ */
+async function connectDownstream(): Promise<Client> {
+  const hostedServer = buildMcpServer(ownerSession("ws_1"));
+  const [upstreamClientT, hostedServerT] = InMemoryTransport.createLinkedPair();
+  const upstream = new Client({ name: "upstream", version: "1.0.0" });
+  await Promise.all([
+    upstream.connect(upstreamClientT),
+    hostedServer.connect(hostedServerT),
+  ]);
+
+  const proxy = createStdioProxyServer(upstream);
+  const [downstreamClientT, proxyServerT] = InMemoryTransport.createLinkedPair();
+  const downstream = new Client({ name: "downstream", version: "1.0.0" });
+  await Promise.all([
+    downstream.connect(downstreamClientT),
+    proxy.connect(proxyServerT),
+  ]);
+
+  return downstream;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createStdioProxyServer", () => {
+  it("forwards tools/list from the upstream MCP server", async () => {
+    const downstream = await connectDownstream();
+
+    const { tools } = await downstream.listTools();
+
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      "list_assets",
+      "list_social_accounts",
+      "list_workspaces",
+    ]);
+
+    await downstream.close();
+  });
+
+  it("forwards tools/call and returns the upstream result", async () => {
+    mockGetWorkspaceById.mockResolvedValue({
+      id: "ws_1",
+      name: "Acme Brand",
+      slug: "acme-brand",
+    });
+
+    const downstream = await connectDownstream();
+
+    const result = await downstream.callTool({
+      name: "list_workspaces",
+      arguments: {},
+    });
+
+    expect(result.structuredContent).toEqual({
+      workspaces: [{ id: "ws_1", name: "Acme Brand", slug: "acme-brand" }],
+    });
+
+    await downstream.close();
+  });
+});

--- a/src/lib/agent-tools/mcp/server.ts
+++ b/src/lib/agent-tools/mcp/server.ts
@@ -1,0 +1,58 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import type { ContentOSSession } from "@/lib/studio/authz";
+
+import { toStructuredError } from "../errors";
+import { toolRegistry } from "../registry";
+import { runTool } from "../runtime";
+
+const SERVER_INFO = {
+  name: "node-banana",
+  version: "1.0.0",
+} as const;
+
+/**
+ * Build an MCP server whose tools are derived mechanically from the tool
+ * registry — the server never hand-declares a tool. For each registry entry we
+ * register the same Zod input/output schemas the registry owns and delegate
+ * execution to `runTool`, so MCP behaviour (validation, authz, structured
+ * errors) is identical to every other surface.
+ *
+ * The server is bound to one already-resolved, workspace-scoped session; build
+ * a fresh server per authenticated request (stateless transport) so no state or
+ * credentials leak across callers.
+ */
+export function buildMcpServer(session: ContentOSSession): McpServer {
+  const server = new McpServer(SERVER_INFO);
+
+  for (const tool of toolRegistry) {
+    server.registerTool(
+      tool.name,
+      {
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        outputSchema: tool.outputSchema,
+      },
+      async (input: unknown) => {
+        try {
+          const output = await runTool(tool, input, { session });
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(output) }],
+            structuredContent: output as Record<string, unknown>,
+          };
+        } catch (error) {
+          const structured = toStructuredError(error);
+          return {
+            isError: true,
+            content: [
+              { type: "text" as const, text: JSON.stringify(structured) },
+            ],
+            structuredContent: structured as unknown as Record<string, unknown>,
+          };
+        }
+      },
+    );
+  }
+
+  return server;
+}

--- a/src/lib/agent-tools/mcp/stdio-bridge.ts
+++ b/src/lib/agent-tools/mcp/stdio-bridge.ts
@@ -1,0 +1,37 @@
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const PROXY_INFO = {
+  name: "node-banana-stdio",
+  version: "1.0.0",
+} as const;
+
+/**
+ * Build a low-level MCP server that proxies `tools/list` and `tools/call` to an
+ * already-connected upstream client.
+ *
+ * This is the core of the local stdio harness: the bin connects `upstream` to
+ * the *hosted* HTTP endpoint (with the Bearer token), so every proxied call
+ * exercises the real hosted auth + registry path rather than touching the
+ * database directly. Injecting the client keeps the proxy logic testable
+ * without a network.
+ */
+export function createStdioProxyServer(upstream: Client): Server {
+  const server = new Server(PROXY_INFO, {
+    capabilities: { tools: {} },
+  });
+
+  server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+    return upstream.listTools(request.params);
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    return upstream.callTool(request.params);
+  });
+
+  return server;
+}

--- a/src/lib/agent-tools/registry.ts
+++ b/src/lib/agent-tools/registry.ts
@@ -1,0 +1,30 @@
+import { listAssetsTool } from "./tools/list-assets";
+import { listSocialAccountsTool } from "./tools/list-social-accounts";
+import { listWorkspacesTool } from "./tools/list-workspaces";
+import type { AnyToolDefinition } from "./types";
+
+/**
+ * The tool registry — the single source of truth for the agent surface.
+ *
+ * Every adapter (MCP server, CLI, public API v1) derives its behaviour from
+ * this array; none re-declares a tool. Adding a tool here makes it available on
+ * all surfaces at once. Keep it ordered by the sequence an agent typically
+ * follows: discover workspace → discover accounts → discover assets.
+ */
+export const toolRegistry: readonly AnyToolDefinition[] = [
+  listWorkspacesTool,
+  listSocialAccountsTool,
+  listAssetsTool,
+] as const;
+
+const toolsByName = new Map<string, AnyToolDefinition>(
+  toolRegistry.map((tool) => [tool.name, tool]),
+);
+
+export function getTool(name: string): AnyToolDefinition | undefined {
+  return toolsByName.get(name);
+}
+
+export function listToolNames(): string[] {
+  return toolRegistry.map((tool) => tool.name);
+}

--- a/src/lib/agent-tools/runtime.ts
+++ b/src/lib/agent-tools/runtime.ts
@@ -1,0 +1,81 @@
+import type { z } from "zod";
+
+import { ToolError } from "./errors";
+import type { ToolContext, ToolDefinition } from "./types";
+
+function describeIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+}
+
+/**
+ * Execute a tool definition end-to-end — the single seam every adapter calls.
+ *
+ * Order matters and is part of the contract:
+ *  1. Validate input against the tool's Zod schema (`invalid_input`).
+ *  2. Enforce the tool's required permission against the resolved, already
+ *     workspace-scoped session (`forbidden`). Authorization to *reach* the
+ *     workspace happens earlier in the adapter; this is the per-tool check.
+ *  3. Run the handler, wrapping any non-ToolError throw as `internal` while
+ *     letting handler-raised ToolErrors (e.g. `not_found`) pass through.
+ *  4. Validate the handler's output against its schema (`invalid_output`), so a
+ *     schema-valid response is guaranteed to every surface.
+ */
+export async function runTool<
+  InputSchema extends z.ZodTypeAny,
+  OutputSchema extends z.ZodTypeAny,
+>(
+  definition: ToolDefinition<InputSchema, OutputSchema>,
+  rawInput: unknown,
+  ctx: ToolContext,
+): Promise<z.infer<OutputSchema>> {
+  const parsedInput = definition.inputSchema.safeParse(rawInput ?? {});
+  if (!parsedInput.success) {
+    throw new ToolError({
+      code: "invalid_input",
+      message: `Invalid arguments for '${definition.name}': ${describeIssues(
+        parsedInput.error,
+      )}`,
+      fix: "Adjust the arguments to match the tool's input schema.",
+    });
+  }
+
+  if (!ctx.session.permissions.includes(definition.requiredPermission)) {
+    throw new ToolError({
+      code: "forbidden",
+      message: `The token's workspace role does not grant '${definition.requiredPermission}', required by '${definition.name}'.`,
+      fix: "Use a token for a workspace where your role grants this permission, or ask an owner/admin to grant it.",
+    });
+  }
+
+  let output: z.infer<OutputSchema>;
+  try {
+    output = await definition.handler(parsedInput.data, ctx);
+  } catch (error) {
+    if (error instanceof ToolError) {
+      throw error;
+    }
+    throw new ToolError({
+      code: "internal",
+      message: error instanceof Error ? error.message : "Tool handler failed.",
+      fix: "Retry the request; if it persists, the database or an upstream service may be unavailable.",
+    });
+  }
+
+  const parsedOutput = definition.outputSchema.safeParse(output);
+  if (!parsedOutput.success) {
+    throw new ToolError({
+      code: "invalid_output",
+      message: `Tool '${definition.name}' returned data that failed its output schema: ${describeIssues(
+        parsedOutput.error,
+      )}`,
+      fix: "This is a server-side bug; please report it with the tool name.",
+    });
+  }
+
+  return parsedOutput.data;
+}

--- a/src/lib/agent-tools/tools/__tests__/read-tools.test.ts
+++ b/src/lib/agent-tools/tools/__tests__/read-tools.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ContentOSSession } from "@/lib/studio/authz";
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const {
+  mockGetWorkspaceById,
+  mockListWorkspaceAssets,
+  mockListSocialAccounts,
+} = vi.hoisted(() => ({
+  mockGetWorkspaceById: vi.fn(),
+  mockListWorkspaceAssets: vi.fn(),
+  mockListSocialAccounts: vi.fn(),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getWorkspaceById: (...args: unknown[]) => mockGetWorkspaceById(...args),
+  listWorkspaceAssets: (...args: unknown[]) => mockListWorkspaceAssets(...args),
+}));
+
+vi.mock("@/lib/social/repository", () => ({
+  listSocialAccounts: (...args: unknown[]) => mockListSocialAccounts(...args),
+}));
+
+import { runTool } from "../../runtime";
+import { listAssetsTool } from "../list-assets";
+import { listSocialAccountsTool } from "../list-social-accounts";
+import { listWorkspacesTool } from "../list-workspaces";
+
+function session(
+  role: "owner" | "member" = "owner",
+  workspaceId = "ws_1",
+): ContentOSSession {
+  return {
+    user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+    workspace: { id: workspaceId, organizationId: null },
+    role,
+    planTier: "free",
+    permissions: getPermissionsForRole(role),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("list_workspaces tool", () => {
+  it("returns the single workspace the token is scoped to", async () => {
+    mockGetWorkspaceById.mockResolvedValue({
+      id: "ws_1",
+      name: "Acme Brand",
+      slug: "acme-brand",
+    });
+
+    const result = await runTool(
+      listWorkspacesTool,
+      {},
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(result).toEqual({
+      workspaces: [{ id: "ws_1", name: "Acme Brand", slug: "acme-brand" }],
+    });
+    expect(mockGetWorkspaceById).toHaveBeenCalledWith("ws_1");
+  });
+
+  it("returns an empty list when the scoped workspace is gone", async () => {
+    mockGetWorkspaceById.mockResolvedValue(null);
+
+    const result = await runTool(listWorkspacesTool, {}, { session: session() });
+
+    expect(result).toEqual({ workspaces: [] });
+  });
+});
+
+describe("list_social_accounts tool", () => {
+  it("maps accounts to safe fields and never leaks encrypted tokens", async () => {
+    mockListSocialAccounts.mockResolvedValue([
+      {
+        id: "sacct_1",
+        workspaceId: "ws_1",
+        platform: "x",
+        platformUserId: "12345",
+        displayName: "Acme on X",
+        username: "acme",
+        avatarUrl: "https://cdn/avatar.png",
+        accessTokenEncrypted: "SECRET-ENCRYPTED",
+        refreshTokenEncrypted: "SECRET-REFRESH",
+        accessTokenSecret: "SECRET-SECRET",
+        tokenExpiresAt: new Date("2026-01-01T00:00:00.000Z"),
+        requiresReauth: false,
+        disabled: false,
+        createdAt: new Date("2025-12-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await runTool(
+      listSocialAccountsTool,
+      {},
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(mockListSocialAccounts).toHaveBeenCalledWith("ws_1");
+    expect(result.accounts).toEqual([
+      {
+        id: "sacct_1",
+        platform: "x",
+        platformUserId: "12345",
+        displayName: "Acme on X",
+        username: "acme",
+        avatarUrl: "https://cdn/avatar.png",
+        tokenExpiresAt: "2026-01-01T00:00:00.000Z",
+        requiresReauth: false,
+        disabled: false,
+        createdAt: "2025-12-01T00:00:00.000Z",
+      },
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("SECRET-ENCRYPTED");
+    expect(serialized).not.toContain("SECRET-REFRESH");
+    expect(serialized).not.toContain("SECRET-SECRET");
+  });
+
+  it("denies callers whose role lacks social:view", async () => {
+    const memberSession = session("member");
+    memberSession.permissions = memberSession.permissions.filter(
+      (p) => p !== "social:view",
+    );
+
+    const error = await runTool(listSocialAccountsTool, {}, {
+      session: memberSession,
+    }).catch((e) => e);
+
+    expect(error.code).toBe("forbidden");
+  });
+});
+
+describe("list_assets tool", () => {
+  it("returns workspace assets with safe metadata", async () => {
+    mockListWorkspaceAssets.mockResolvedValue([
+      {
+        id: "asset_1",
+        workspaceId: "ws_1",
+        projectId: "proj_1",
+        type: "image",
+        mimeType: "image/png",
+        sizeBytes: 2048,
+        width: 512,
+        height: 512,
+        durationSeconds: null,
+        createdAt: new Date("2026-02-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await runTool(
+      listAssetsTool,
+      { type: "image", limit: 10 },
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(mockListWorkspaceAssets).toHaveBeenCalledWith("ws_1", {
+      type: "image",
+      limit: 10,
+    });
+    expect(result.assets).toEqual([
+      {
+        id: "asset_1",
+        projectId: "proj_1",
+        type: "image",
+        mimeType: "image/png",
+        sizeBytes: 2048,
+        width: 512,
+        height: 512,
+        durationSeconds: null,
+        createdAt: "2026-02-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("passes no filters through when none are supplied", async () => {
+    mockListWorkspaceAssets.mockResolvedValue([]);
+
+    const result = await runTool(
+      listAssetsTool,
+      {},
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(mockListWorkspaceAssets).toHaveBeenCalledWith("ws_1", {
+      type: undefined,
+      limit: undefined,
+    });
+    expect(result).toEqual({ assets: [] });
+  });
+
+  it("rejects an out-of-range limit with invalid_input", async () => {
+    const error = await runTool(
+      listAssetsTool,
+      { limit: 9999 },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("invalid_input");
+    expect(mockListWorkspaceAssets).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/agent-tools/tools/list-assets.ts
+++ b/src/lib/agent-tools/tools/list-assets.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+import { listWorkspaceAssets } from "@/lib/studio/repository";
+
+import type { ToolDefinition } from "../types";
+
+const assetTypeSchema = z.enum([
+  "image",
+  "video",
+  "audio",
+  "model3d",
+  "workflow",
+]);
+
+const inputSchema = z.object({
+  type: assetTypeSchema.optional(),
+  limit: z.number().int().min(1).max(200).optional(),
+});
+
+const assetSchema = z.object({
+  id: z.string(),
+  projectId: z.string().nullable(),
+  type: assetTypeSchema,
+  mimeType: z.string().nullable(),
+  sizeBytes: z.number().nullable(),
+  width: z.number().nullable(),
+  height: z.number().nullable(),
+  durationSeconds: z.number().nullable(),
+  createdAt: z.string(),
+});
+
+const outputSchema = z.object({
+  assets: z.array(assetSchema),
+});
+
+function toIso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+/**
+ * List the media assets in the token's workspace, optionally filtered by type
+ * and capped by limit. Assets are referenced by id when composing posts, so an
+ * agent can reuse generated media without re-uploading.
+ */
+export const listAssetsTool: ToolDefinition<
+  typeof inputSchema,
+  typeof outputSchema
+> = {
+  name: "list_assets",
+  description:
+    "List media assets (image, video, audio, model3d, workflow) in this workspace. Filter by `type` and cap with `limit`. Reference returned ids when composing posts.",
+  requiredPermission: "assets:read",
+  inputSchema,
+  outputSchema,
+  handler: async (input, ctx) => {
+    const rows = await listWorkspaceAssets(ctx.session.workspace.id, {
+      type: input.type,
+      limit: input.limit,
+    });
+
+    return {
+      assets: rows.map((asset) => ({
+        id: asset.id,
+        projectId: asset.projectId ?? null,
+        type: asset.type,
+        mimeType: asset.mimeType ?? null,
+        sizeBytes: asset.sizeBytes ?? null,
+        width: asset.width ?? null,
+        height: asset.height ?? null,
+        durationSeconds: asset.durationSeconds ?? null,
+        createdAt: toIso(asset.createdAt),
+      })),
+    };
+  },
+};

--- a/src/lib/agent-tools/tools/list-social-accounts.ts
+++ b/src/lib/agent-tools/tools/list-social-accounts.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+import { listSocialAccounts } from "@/lib/social/repository";
+
+import type { ToolDefinition } from "../types";
+
+const inputSchema = z.object({});
+
+const socialAccountSchema = z.object({
+  id: z.string(),
+  platform: z.string(),
+  platformUserId: z.string(),
+  displayName: z.string(),
+  username: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  tokenExpiresAt: z.string().nullable(),
+  requiresReauth: z.boolean(),
+  disabled: z.boolean(),
+  createdAt: z.string(),
+});
+
+const outputSchema = z.object({
+  accounts: z.array(socialAccountSchema),
+});
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+/**
+ * List the connected social accounts for the token's workspace. Encrypted
+ * tokens/secrets are stripped here — only non-sensitive display and status
+ * fields cross the tool boundary, so no surface can ever leak credentials.
+ */
+export const listSocialAccountsTool: ToolDefinition<
+  typeof inputSchema,
+  typeof outputSchema
+> = {
+  name: "list_social_accounts",
+  description:
+    "List the social accounts connected to this workspace, with platform, handle, and connection status. Use the returned ids to target posts.",
+  requiredPermission: "social:view",
+  inputSchema,
+  outputSchema,
+  handler: async (_input, ctx) => {
+    const accounts = await listSocialAccounts(ctx.session.workspace.id);
+    return {
+      accounts: accounts.map((account) => ({
+        id: account.id,
+        platform: account.platform,
+        platformUserId: account.platformUserId,
+        displayName: account.displayName,
+        username: account.username ?? null,
+        avatarUrl: account.avatarUrl ?? null,
+        tokenExpiresAt: toIso(account.tokenExpiresAt),
+        requiresReauth: account.requiresReauth,
+        disabled: account.disabled,
+        createdAt: toIso(account.createdAt) as string,
+      })),
+    };
+  },
+};

--- a/src/lib/agent-tools/tools/list-workspaces.ts
+++ b/src/lib/agent-tools/tools/list-workspaces.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+import { getWorkspaceById } from "@/lib/studio/repository";
+
+import type { ToolDefinition } from "../types";
+
+const inputSchema = z.object({});
+
+const workspaceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+});
+
+const outputSchema = z.object({
+  workspaces: z.array(workspaceSchema),
+});
+
+/**
+ * List the workspace(s) the calling token can reach. An API token is scoped to
+ * exactly one workspace, so this returns that single workspace (or an empty
+ * list if it has since been deleted) — the agent's first call to discover which
+ * brand it is acting on.
+ */
+export const listWorkspacesTool: ToolDefinition<
+  typeof inputSchema,
+  typeof outputSchema
+> = {
+  name: "list_workspaces",
+  description:
+    "List the workspaces (brands) this token can act on. Call this first to confirm which workspace you are scoped to.",
+  requiredPermission: "workspaces:read",
+  inputSchema,
+  outputSchema,
+  handler: async (_input, ctx) => {
+    const workspace = await getWorkspaceById(ctx.session.workspace.id);
+    return { workspaces: workspace ? [workspace] : [] };
+  },
+};

--- a/src/lib/agent-tools/types.ts
+++ b/src/lib/agent-tools/types.ts
@@ -1,0 +1,39 @@
+import type { z } from "zod";
+
+import type { ContentOSPermission, ContentOSSession } from "@/lib/studio/authz";
+
+/**
+ * Everything a tool handler is allowed to know about the caller. The session is
+ * already resolved and workspace-scoped by the calling adapter (MCP route, v1
+ * route, CLI) via `authorizePublicApiRequest`, so handlers never touch raw
+ * tokens or headers — tenant isolation is guaranteed before the handler runs.
+ */
+export interface ToolContext {
+  session: ContentOSSession;
+}
+
+/**
+ * A single tool definition — the one source of truth. The MCP server, the CLI,
+ * and the public API v1 routes all derive their behaviour from this shape; none
+ * of them re-declares a tool. Each surface is a thin adapter over the registry.
+ */
+export interface ToolDefinition<
+  InputSchema extends z.ZodTypeAny = z.ZodTypeAny,
+  OutputSchema extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  /** Stable machine name (snake_case), e.g. `list_social_accounts`. */
+  name: string;
+  /** Human/agent-facing description surfaced in MCP tool discovery. */
+  description: string;
+  /** Permission the caller's workspace role must hold to run this tool. */
+  requiredPermission: ContentOSPermission;
+  inputSchema: InputSchema;
+  outputSchema: OutputSchema;
+  handler: (
+    input: z.infer<InputSchema>,
+    ctx: ToolContext,
+  ) => Promise<z.infer<OutputSchema>>;
+}
+
+/** A tool definition with its schemas erased, for storing heterogeneously. */
+export type AnyToolDefinition = ToolDefinition<z.ZodTypeAny, z.ZodTypeAny>;

--- a/src/lib/studio/repository.ts
+++ b/src/lib/studio/repository.ts
@@ -887,6 +887,21 @@ export async function listWorkspaceAssets(
   return opts?.limit ? base.limit(opts.limit) : base;
 }
 
+export async function getWorkspaceById(workspaceId: string) {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      id: workspaces.id,
+      name: workspaces.name,
+      slug: workspaces.slug,
+    })
+    .from(workspaces)
+    .where(and(eq(workspaces.id, workspaceId), isNull(workspaces.deletedAt)))
+    .limit(1);
+
+  return row ?? null;
+}
+
 export async function getAsset(workspaceId: string, assetId: string) {
   const db = getDb();
   const [asset] = await db


### PR DESCRIPTION
Closes #102. Part of PRD #100 — this is the priority-1 agent surface. **Stacked on #123** (base = `feature/api-token-auth`); merge #123 first.

- **Tool registry** (`src/lib/agent-tools/`) — the single new seam: each tool = name + description + required permission + Zod input/output schemas + workspace-scoped handler. `runTool()` is the one executor (validate → authz → run → validate output; structured errors `{code, message, fix}` so agents self-correct). First tools: `list_workspaces`, `list_social_accounts` (encrypted tokens stripped), `list_assets`.
- **MCP server at `/api/mcp`**: streamable HTTP (SDK v1.28 `WebStandardStreamableHTTPServerTransport`, stateless per-request — the right fit for serverless + token-per-request tenancy). Tools derive mechanically from the registry; nothing hand-declared. Bearer `nb_…` auth via #101's path; 401 + `WWW-Authenticate` otherwise.
- **stdio bridge** (`pnpm mcp:stdio`, NB_API_URL/NB_API_TOKEN) proxying local harnesses to the hosted endpoint — exercises the real auth path, never the DB.
- **v1 parity routes**: `GET /api/v1/social-accounts`, `GET /api/v1/assets` over the same registry handlers.

Connect from Claude Code:
`claude mcp add --transport http node-banana https://APP/api/mcp --header "Authorization: Bearer nb_XXXX"`

30 new tests incl. a real in-memory MCP client listing/calling tools and a live initialize handshake through the actual route — re-run by reviewer. Full suite green except the 2 tracked pre-existing failures; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)