### PR TITLE
fix: Meta error classification + YouTube upload/auth classification

### DIFF
--- a/src/lib/social/providers/__tests__/facebook.contract.test.ts
+++ b/src/lib/social/providers/__tests__/facebook.contract.test.ts
@@ -190,15 +190,14 @@ describe("facebookProvider contract — permanent-failure", () => {
   });
 
   /**
-   * CANARY — documents the confirmed defect described in the file header.
-   * Facebook's numeric photo-size error code (1366046) should, per the
-   * existing `facebook.test.ts` unit tests (which assert this via a
-   * synthetic error whose `.message` IS the raw JSON blob), classify as
-   * "bad-body". Fed the real MetaApiError shape produced by `facebook.ts`'s
-   * own `uploadUnpublishedPhoto()`/feed-post error handling, it does not.
-   * This asserts the CURRENT (buggy) behavior as a regression canary.
+   * REGRESSION (formerly a CONFIRMED DEFECT canary) — Facebook's numeric
+   * photo-size error code (1366046) must classify as "bad-body" and fail
+   * fast, NOT silently downgrade to a forever-retry. The numeric code lives
+   * on the real `MetaApiError`'s structured `.code`/`.rawBody` fields (never
+   * folded into `.message`), so `classifyError()` must inspect the structured
+   * error, not just `.message` text.
    */
-  it("[CONFIRMED DEFECT] silently downgrades a real numeric-code Graph error to retry instead of bad-body", async () => {
+  it("classifies a real numeric-code Graph error (1366046) as bad-body", async () => {
     server.use(
       http.post(FEED_URL, () =>
         HttpResponse.json(
@@ -221,8 +220,9 @@ describe("facebookProvider contract — permanent-failure", () => {
     );
 
     const classified = facebookProvider.classifyError(error);
-    // INTENDED (per meta-common.ts code 1366046 branch): "bad-body".
-    // ACTUAL (confirmed real behavior — the defect):
-    expect(classified.type).toBe("retry");
+    expect(classified.type).toBe("bad-body");
+    expect(classified.message).toBe(
+      "Photos must be smaller than 4 MB and saved as JPG or PNG.",
+    );
   });
 });

--- a/src/lib/social/providers/__tests__/facebook.test.ts
+++ b/src/lib/social/providers/__tests__/facebook.test.ts
@@ -7,6 +7,23 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SocialProviderAdapter } from "@/lib/social/provider-interface";
+import { MetaApiError } from "@/lib/social/providers/meta-common";
+
+/**
+ * Build a production-realistic `MetaApiError` exactly as the Facebook provider
+ * throws one: the human-readable Graph message on `.message`, the numeric code
+ * on `.code`, and the full platform error body on `.rawBody`. The numeric code
+ * is NEVER folded into `.message` — that is the whole point of the shape.
+ */
+function metaError(message: string, code: number): MetaApiError {
+  return new MetaApiError(
+    message,
+    code,
+    JSON.stringify({
+      error: { message, type: "OAuthException", code, fbtrace_id: "AbCdEfGhIjK" },
+    }),
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Environment stubs
@@ -472,7 +489,7 @@ describe("facebookProvider.classifyError", () => {
   it("classifies 490 error as refresh-token", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":490,"message":"Token expired"}}'),
+      metaError("Token expired", 490),
     );
     expect(result.type).toBe("refresh-token");
   });
@@ -486,7 +503,7 @@ describe("facebookProvider.classifyError", () => {
   it("classifies 1366046 (photo too large) as bad-body", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":1366046,"message":"Photo too large"}}'),
+      metaError("Photo too large", 1366046),
     );
     expect(result.type).toBe("bad-body");
     expect(result.message).toContain("4 MB");
@@ -495,7 +512,7 @@ describe("facebookProvider.classifyError", () => {
   it("classifies 1390008 (posting too fast) as bad-body", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":1390008,"message":"Posting too fast"}}'),
+      metaError("Posting too fast", 1390008),
     );
     expect(result.type).toBe("bad-body");
     expect(result.message).toContain("too fast");
@@ -504,7 +521,7 @@ describe("facebookProvider.classifyError", () => {
   it("classifies 1346003 (abusive content) as bad-body", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":1346003,"message":"Abusive content"}}'),
+      metaError("Abusive content", 1346003),
     );
     expect(result.type).toBe("bad-body");
     expect(result.message).toContain("abusive");
@@ -513,7 +530,7 @@ describe("facebookProvider.classifyError", () => {
   it("classifies 1609008 (cannot post FB links) as bad-body", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":1609008,"message":"Cannot post Facebook.com links"}}'),
+      metaError("Cannot post Facebook.com links", 1609008),
     );
     expect(result.type).toBe("bad-body");
   });
@@ -521,7 +538,7 @@ describe("facebookProvider.classifyError", () => {
   it("classifies temporary unavailability (1363047) as retry", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":1363047,"message":"Service temporarily unavailable"}}'),
+      metaError("Service temporarily unavailable", 1363047),
     );
     expect(result.type).toBe("retry");
   });
@@ -529,7 +546,7 @@ describe("facebookProvider.classifyError", () => {
   it("classifies 1404078 (page authorization) as refresh-token", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":1404078,"message":"Page publishing authorization required"}}'),
+      metaError("Page publishing authorization required", 1404078),
     );
     expect(result.type).toBe("refresh-token");
   });

--- a/src/lib/social/providers/__tests__/instagram.contract.test.ts
+++ b/src/lib/social/providers/__tests__/instagram.contract.test.ts
@@ -254,19 +254,15 @@ describe("instagramProvider contract — permanent-failure", () => {
   });
 
   /**
-   * CANARY — documents the confirmed defect described in the file header.
-   * A real container-creation failure carrying Instagram's numeric media
-   * error code (2207081, "Trial Reels not supported") should, per the
-   * existing `instagram.test.ts` unit tests (which assert this via a
-   * synthetic error), classify as "bad-body". Fed the *real* MetaApiError
-   * shape instead, it does not — classifyError() only inspects `.message`
-   * text, and the human message ("This account doesn't support Trial
-   * Reels.") never contains the digits "2207081", so the code-based branch
-   * in classifyMetaError() never matches. This asserts the CURRENT (buggy)
-   * behavior; if this test ever starts failing because the type flips to
-   * "bad-body", the defect has been fixed and this test should be deleted.
+   * REGRESSION (formerly a CONFIRMED DEFECT canary) — a real
+   * container-creation failure carrying Instagram's numeric media error code
+   * (2207081, "Trial Reels not supported") must classify as "bad-body" and
+   * fail fast, NOT silently downgrade to a forever-retry. The numeric code is
+   * carried on the real `MetaApiError`'s structured `.code`/`.rawBody` fields
+   * (never folded into `.message`), so `classifyError()` must inspect the
+   * structured error, not just `.message` text.
    */
-  it("[CONFIRMED DEFECT] silently downgrades a real numeric-code Graph error to retry instead of bad-body", async () => {
+  it("classifies a real numeric-code Graph error (2207081) as bad-body", async () => {
     server.use(
       http.post(MEDIA_URL, () =>
         HttpResponse.json(
@@ -289,8 +285,7 @@ describe("instagramProvider contract — permanent-failure", () => {
     );
 
     const classified = instagramProvider.classifyError(error);
-    // INTENDED (per meta-common.ts code 2207081 branch): "bad-body".
-    // ACTUAL (confirmed real behavior — the defect):
-    expect(classified.type).toBe("retry");
+    expect(classified.type).toBe("bad-body");
+    expect(classified.message).toBe("This account doesn't support Trial Reels.");
   });
 });

--- a/src/lib/social/providers/__tests__/instagram.test.ts
+++ b/src/lib/social/providers/__tests__/instagram.test.ts
@@ -7,6 +7,23 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SocialProviderAdapter } from "@/lib/social/provider-interface";
+import { MetaApiError } from "@/lib/social/providers/meta-common";
+
+/**
+ * Build a production-realistic `MetaApiError` exactly as the Instagram provider
+ * throws one: the human-readable Graph message on `.message`, the numeric code
+ * on `.code`, and the full platform error body on `.rawBody`. The numeric code
+ * is NEVER folded into `.message` — that is the whole point of the shape.
+ */
+function metaError(message: string, code: number): MetaApiError {
+  return new MetaApiError(
+    message,
+    code,
+    JSON.stringify({
+      error: { message, type: "OAuthException", code, fbtrace_id: "AbCdEfGhIjK" },
+    }),
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Environment stubs
@@ -508,7 +525,7 @@ describe("instagramProvider.classifyError", () => {
   it("classifies 2207081 as bad-body", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":2207081,"message":"Trial Reels not supported"}}'),
+      metaError("Trial Reels not supported", 2207081),
     );
     expect(result.type).toBe("bad-body");
     expect(result.message).toContain("Trial Reels");
@@ -517,7 +534,7 @@ describe("instagramProvider.classifyError", () => {
   it("classifies 2207009 (aspect ratio) as bad-body", async () => {
     const provider = await loadProvider();
     const result = provider.classifyError(
-      new Error('{"error":{"code":2207009,"message":"Aspect ratio error"}}'),
+      metaError("Aspect ratio error", 2207009),
     );
     expect(result.type).toBe("bad-body");
     expect(result.message).toContain("Aspect ratio");

--- a/src/lib/social/providers/__tests__/youtube.contract.test.ts
+++ b/src/lib/social/providers/__tests__/youtube.contract.test.ts
@@ -28,27 +28,26 @@
  * (node:stream, Node 17+); scenario 1 below now drives the real pipeline.
  *
  * ---------------------------------------------------------------------------
- * DEFECT 2 — classifyError() pattern-matches on fields that never reach `.message`
+ * DEFECT 2 (FIXED) — classifyError() matched fields that never reach `.message`
  * ---------------------------------------------------------------------------
- * `youTubeProvider.classifyError()` checks for literal reason-code strings
- * ("invalidTitle", "quotaExceeded", "forbidden", "UNAUTHENTICATED", ...).
- * Real `googleapis`/`gaxios` errors (`GaxiosError`) build `.message` purely
- * from the Google API JSON error's `.message` field (see
+ * `youTubeProvider.classifyError()` checked for literal reason-code strings
+ * ("invalidTitle", "quotaExceeded", "forbidden", "UNAUTHENTICATED", ...) in
+ * `.message` only. Real `googleapis`/`gaxios` errors (`GaxiosError`) build
+ * `.message` purely from the Google API JSON error's `.message` field (see
  * `GaxiosError.extractAPIErrorFromResponse` in `gaxios/build/.../common.js`)
- * — the per-error `reason` enum (where these strings actually live, e.g.
- * `errors[0].reason === "quotaExceeded"`) is never folded into `.message`.
- * Confirmed empirically below with real 401 and 403/quotaExceeded Google API
- * error bodies: BOTH classify as the generic "retry" fallback, including the
- * 401 — meaning an expired/invalid access token used against the real API
- * (as opposed to a refresh-token-endpoint failure, see scenario 2) is
- * silently retried instead of triggering re-authentication.
+ * — the per-error `reason` enum (where these strings live, e.g.
+ * `errors[0].reason === "quotaExceeded"`) and the AIP `status` enum
+ * ("UNAUTHENTICATED") live in `.response.data.error`, never folded into
+ * `.message`. So real 401/403s fell through to the generic "retry" fallback:
+ * an expired token was silently retried instead of triggering re-auth, and a
+ * permanent policy violation was retried instead of failing fast. Fixed by
+ * classifying from the GaxiosError structured response (HTTP status +
+ * `.response.data.error` reasons/status), preserving the intended mappings.
  *
- * Given DEFECT 1 blocks `post()`'s error paths entirely (the TypeError fires
- * before any network call), scenarios 2-4 below exercise `refreshToken()`
- * and `fetchPageInformation()` instead — both make real, unblocked
- * `googleapis` HTTP calls and are legitimate real-SDK error sources for
- * `classifyError()`, which is a general-purpose function not tied to a
- * single call site.
+ * Scenarios 2-4 exercise `refreshToken()` and `fetchPageInformation()` —
+ * both make real, unblocked `googleapis` HTTP calls and are legitimate
+ * real-SDK error sources for `classifyError()`, a general-purpose function
+ * not tied to a single call site.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -148,13 +147,14 @@ describe("youTubeProvider contract — token-refresh trigger", () => {
   });
 
   /**
-   * CANARY — documents DEFECT 2 for the auth case specifically. A stale
-   * access token used against the real Data API (NOT the OAuth token
-   * endpoint) throws a differently-shaped GaxiosError whose `.message` is
-   * "Request had invalid authentication credentials." — no match for any
-   * refresh-token branch — so it is misclassified as "retry".
+   * REGRESSION (formerly a DEFECT 2 canary) — a stale access token used
+   * against the real Data API (NOT the OAuth token endpoint) throws a
+   * GaxiosError whose `.message` is only "Request had invalid authentication
+   * credentials."; the auth signal (HTTP 401, reason "authError", AIP status
+   * "UNAUTHENTICATED") lives in `.status`/`.response.data.error`. classifyError
+   * must inspect that structured response and classify as refresh-token.
    */
-  it("[CONFIRMED DEFECT] a real 401 from the Data API itself does not classify as refresh-token", async () => {
+  it("classifies a real 401 from the Data API as refresh-token", async () => {
     server.use(
       http.get(CHANNELS_URL, () =>
         HttpResponse.json(
@@ -191,8 +191,7 @@ describe("youTubeProvider contract — token-refresh trigger", () => {
     );
 
     const classified = youTubeProvider.classifyError(caught);
-    // INTENDED: "refresh-token". ACTUAL (confirmed real behavior — the defect):
-    expect(classified.type).toBe("retry");
+    expect(classified.type).toBe("refresh-token");
   });
 });
 
@@ -236,10 +235,9 @@ describe("youTubeProvider contract — rate-limit retry", () => {
       "The request cannot be completed because you have exceeded your quota.",
     );
 
-    // classifyError()'s explicit "quotaExceeded" text check never matches
-    // (see DEFECT 2) — but the generic bottom-of-function fallback also
-    // returns "retry", so the *outcome* here happens to be correct even
-    // though the intended branch is dead code.
+    // classifyError() now reads the structured response, so the reason
+    // "quotaExceeded" (in .response.data.error.errors[].reason) matches the
+    // intended retry branch directly.
     const classified = youTubeProvider.classifyError(caught);
     expect(classified.type).toBe("retry");
   });
@@ -251,14 +249,13 @@ describe("youTubeProvider contract — rate-limit retry", () => {
 
 describe("youTubeProvider contract — permanent-failure", () => {
   /**
-   * CANARY — documents DEFECT 2 for the content-policy case. Unlike the
-   * rate-limit scenario above (where the generic fallback happens to
-   * produce the correct "retry" outcome), a permanent/forbidden failure
-   * being misclassified as "retry" IS a functional bug: the publish
-   * pipeline will retry (up to 3x) something that can never succeed,
-   * instead of failing fast via FatalError.
+   * REGRESSION (formerly a DEFECT 2 canary) — a permanent/forbidden failure
+   * must classify as bad-body and fail fast, NOT be retried (up to 3x)
+   * against something that can never succeed. The "forbidden" reason lives in
+   * `.response.data.error.errors[].reason`, so classifyError must inspect the
+   * structured response.
    */
-  it("[CONFIRMED DEFECT] a real forbidden/policy-violation rejection does not classify as bad-body", async () => {
+  it("classifies a real forbidden/policy-violation rejection as bad-body", async () => {
     server.use(
       http.get(CHANNELS_URL, () =>
         HttpResponse.json(
@@ -292,8 +289,6 @@ describe("youTubeProvider contract — permanent-failure", () => {
     );
 
     const classified = youTubeProvider.classifyError(caught);
-    // INTENDED (per the "forbidden" branch in classifyError): "bad-body".
-    // ACTUAL (confirmed real behavior — the defect):
-    expect(classified.type).toBe("retry");
+    expect(classified.type).toBe("bad-body");
   });
 });

--- a/src/lib/social/providers/__tests__/youtube.contract.test.ts
+++ b/src/lib/social/providers/__tests__/youtube.contract.test.ts
@@ -7,32 +7,25 @@
  * `vi.mock` — these tests exercise the *real* `googleapis`/`gaxios` SDK
  * against a mocked Google API boundary via MSW.
  *
- * Doing so surfaced two CONFIRMED, REAL defects in `youtube.ts`. Per the
- * task scope, provider code is left UNMODIFIED and both are reported here
- * instead of silently patched.
+ * Doing so surfaced two CONFIRMED, REAL defects in `youtube.ts`, both now
+ * FIXED. This file documents the fixes and guards against regression.
  *
  * ---------------------------------------------------------------------------
- * DEFECT 1 — video/thumbnail upload is structurally broken (blocks scenario 1)
+ * DEFECT 1 (FIXED) — video/thumbnail upload was structurally broken
  * ---------------------------------------------------------------------------
- * `urlToReadableStream()` does:
+ * `urlToReadableStream()` previously did:
  *   const response = await fetch(url);
  *   return response.body as unknown as NodeJS.ReadableStream;
  * Node's native `fetch()` (undici) returns `response.body` as a WHATWG
  * `ReadableStream` — it has NO `.pipe()` method. `googleapis-common`'s
  * multipart uploader (`apirequest.js`, `multipartUpload()`) unconditionally
- * calls `part.body.pipe(...)` on the media body. The result, reproduced
- * below with the real SDK and a real (msw-mocked) fetch response, is:
- *   TypeError: part.body.pipe is not a function
- * This is NOT an artifact of MSW or this test file — a bare
- * `await fetch(realUrl)` in plain Node confirms `response.body.pipe` is
- * `undefined` outside of any test harness. `urlToReadableStream()` needed
- * `Readable.fromWeb(response.body)` (Node 17+) to bridge Web Streams to a
- * Node Readable; it never does this. Every real `post()` call with video
- * media — which `post()` always requires — throws before any HTTP request
- * to the YouTube Data API is even made. **YouTube publishing does not work
- * in this codebase today.** `youtube.test.ts`'s `vi.mock("googleapis")`
- * replaces the whole SDK, so it never exercises the real multipart pipeline
- * and could not have caught this.
+ * calls `part.body.pipe(...)` on the media body, so every real `post()` with
+ * video media threw `TypeError: part.body.pipe is not a function` before any
+ * HTTP request to the YouTube Data API was even made — YouTube publishing did
+ * not work at all. `youtube.test.ts`'s `vi.mock("googleapis")` replaces the
+ * whole SDK, so it never exercised the real multipart pipeline and could not
+ * have caught this. Fixed by bridging with `Readable.fromWeb(response.body)`
+ * (node:stream, Node 17+); scenario 1 below now drives the real pipeline.
  *
  * ---------------------------------------------------------------------------
  * DEFECT 2 — classifyError() pattern-matches on fields that never reach `.message`
@@ -67,7 +60,8 @@ import type { PublishRequest } from "@/lib/social/provider-interface";
 
 const CHANNELS_URL = "https://youtube.googleapis.com/youtube/v3/channels";
 const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-const VIDEO_UPLOAD_URL = "https://www.googleapis.com/upload/youtube/v3/videos";
+const VIDEO_UPLOAD_URL =
+  "https://youtube.googleapis.com/upload/youtube/v3/videos";
 
 const videoPost: PublishRequest = {
   postId: "our-post-1",
@@ -100,16 +94,24 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("youTubeProvider contract — successful post publish", () => {
-  it("[CONFIRMED DEFECT] real video upload throws before any network call — see file header (DEFECT 1)", async () => {
+  it("uploads the real video body via the multipart pipeline and returns the published result", async () => {
     server.use(
       http.post(VIDEO_UPLOAD_URL, () =>
         HttpResponse.json({ id: "video-1", snippet: {}, status: {} }),
       ),
     );
 
-    await expect(
-      youTubeProvider.post("channel-1", "access-token", [videoPost]),
-    ).rejects.toThrow(/pipe is not a function/);
+    const results = await youTubeProvider.post("channel-1", "access-token", [
+      videoPost,
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      postId: "our-post-1",
+      platformPostId: "video-1",
+      platformPostUrl: "https://www.youtube.com/watch?v=video-1",
+      status: "published",
+    });
   });
 });
 

--- a/src/lib/social/providers/__tests__/youtube.test.ts
+++ b/src/lib/social/providers/__tests__/youtube.test.ts
@@ -448,7 +448,11 @@ describe("YouTube provider", () => {
     });
 
     it("uploads a thumbnail when thumbnailUrl is provided in platformSettings", async () => {
-      mockFetch.mockResolvedValue(videoFetchResponse());
+      // A fresh response (and therefore a fresh single-use body stream) per
+      // fetch, exactly as the real `fetch` behaves — the video upload and the
+      // thumbnail upload each consume their own stream now that
+      // urlToReadableStream bridges the body via Readable.fromWeb.
+      mockFetch.mockImplementation(async () => videoFetchResponse());
       mocks.videosInsert.mockResolvedValue({ data: { id: "vid-with-thumb" } });
       mocks.thumbnailsSet.mockResolvedValue({});
 

--- a/src/lib/social/providers/__tests__/youtube.test.ts
+++ b/src/lib/social/providers/__tests__/youtube.test.ts
@@ -73,6 +73,41 @@ function videoFetchResponse() {
   };
 }
 
+/**
+ * Build a production-realistic googleapis error. A real `GaxiosError`'s
+ * `.message` is ONLY the Google API error's `.message` field; the
+ * machine-readable `reason` enum and AIP `status` enum live in
+ * `.response.data.error` (with the HTTP status on `.status`), never folded
+ * into `.message`. This mirrors that shape so classifyError() is exercised
+ * against the real fields rather than a synthetic message blob.
+ */
+function gaxiosError(opts: {
+  message: string;
+  status: number;
+  reason?: string;
+  aipStatus?: string;
+}): Error {
+  const err = new Error(opts.message) as Error & {
+    status: number;
+    response: unknown;
+  };
+  err.status = opts.status;
+  err.response = {
+    status: opts.status,
+    data: {
+      error: {
+        code: opts.status,
+        message: opts.message,
+        ...(opts.aipStatus ? { status: opts.aipStatus } : {}),
+        ...(opts.reason
+          ? { errors: [{ message: opts.message, reason: opts.reason }] }
+          : {}),
+      },
+    },
+  };
+  return err;
+}
+
 const FAKE_ACCESS_TOKEN = "google-access-token";
 const FAKE_REFRESH_TOKEN = "google-refresh-token";
 
@@ -508,50 +543,86 @@ describe("YouTube provider", () => {
   // -------------------------------------------------------------------------
 
   describe("classifyError", () => {
-    it("classifies Unauthorized as refresh-token", () => {
-      const err = new Error("Unauthorized access");
+    it("classifies a real 401 auth error as refresh-token", () => {
+      const err = gaxiosError({
+        message: "Request had invalid authentication credentials.",
+        status: 401,
+        reason: "authError",
+        aipStatus: "UNAUTHENTICATED",
+      });
       expect(youTubeProvider.classifyError(err).type).toBe("refresh-token");
     });
 
-    it("classifies UNAUTHENTICATED as refresh-token", () => {
-      const err = new Error("UNAUTHENTICATED: token expired");
+    it("classifies a UNAUTHENTICATED AIP status as refresh-token", () => {
+      const err = gaxiosError({
+        message: "The request does not have valid authentication credentials.",
+        status: 401,
+        reason: "unauthorized",
+        aipStatus: "UNAUTHENTICATED",
+      });
       expect(youTubeProvider.classifyError(err).type).toBe("refresh-token");
     });
 
-    it("classifies invalid_grant as refresh-token", () => {
-      const err = new Error("invalid_grant: token has been expired");
+    it("classifies invalid_grant (OAuth token endpoint) as refresh-token", () => {
+      // The OAuth token endpoint sets the error message to the raw grant error.
+      const err = new Error("invalid_grant");
       expect(youTubeProvider.classifyError(err).type).toBe("refresh-token");
     });
 
     it("classifies invalidTitle as bad-body", () => {
-      const err = new Error("YouTube videos.insert failed: 400 invalidTitle");
+      const err = gaxiosError({
+        message: "The video title is invalid.",
+        status: 400,
+        reason: "invalidTitle",
+      });
       expect(youTubeProvider.classifyError(err).type).toBe("bad-body");
     });
 
-    it("classifies youtubeSignupRequired as bad-body", () => {
-      const err = new Error("youtubeSignupRequired: link your account");
+    it("classifies youtubeSignupRequired (a 401) as bad-body", () => {
+      // A 401 by HTTP status, but the reason means the account has no channel —
+      // retrying/refreshing can never help, so it must fail fast.
+      const err = gaxiosError({
+        message: "Unauthorized",
+        status: 401,
+        reason: "youtubeSignupRequired",
+      });
       expect(youTubeProvider.classifyError(err).type).toBe("bad-body");
     });
 
     it("classifies uploadLimitExceeded as bad-body", () => {
-      const err = new Error("uploadLimitExceeded daily quota");
+      const err = gaxiosError({
+        message: "The user has exceeded the number of videos they may upload.",
+        status: 400,
+        reason: "uploadLimitExceeded",
+      });
       expect(youTubeProvider.classifyError(err).type).toBe("bad-body");
     });
 
     it("classifies failedPrecondition (thumbnail) as bad-body", () => {
-      const err = new Error(
-        "youtube.thumbnail failedPrecondition: file too large",
-      );
+      const err = gaxiosError({
+        message: "The thumbnail file is too large.",
+        status: 400,
+        reason: "failedPrecondition",
+      });
       expect(youTubeProvider.classifyError(err).type).toBe("bad-body");
     });
 
     it("classifies quotaExceeded as retry", () => {
-      const err = new Error("quotaExceeded: API quota limit reached");
+      const err = gaxiosError({
+        message:
+          "The request cannot be completed because you have exceeded your quota.",
+        status: 403,
+        reason: "quotaExceeded",
+      });
       expect(youTubeProvider.classifyError(err).type).toBe("retry");
     });
 
     it("classifies rateLimitExceeded as retry", () => {
-      const err = new Error("rateLimitExceeded");
+      const err = gaxiosError({
+        message: "Rate limit exceeded.",
+        status: 429,
+        reason: "rateLimitExceeded",
+      });
       expect(youTubeProvider.classifyError(err).type).toBe("retry");
     });
 

--- a/src/lib/social/providers/facebook.ts
+++ b/src/lib/social/providers/facebook.ts
@@ -35,6 +35,7 @@ import {
   GRAPH_BASE,
   makeOAuthState,
   MetaApiError,
+  metaErrorToClassifierBody,
   verifyGrantedScopes,
 } from "@/lib/social/providers/meta-common";
 
@@ -382,12 +383,7 @@ export const facebookProvider: SocialProviderAdapter = {
   // -------------------------------------------------------------------------
 
   classifyError(error: unknown): SocialProviderError {
-    const body =
-      error instanceof Error
-        ? JSON.stringify({ message: error.message })
-        : typeof error === "string"
-          ? error
-          : JSON.stringify(error);
+    const body = metaErrorToClassifierBody(error);
 
     return (
       classifyMetaError(body) ?? {

--- a/src/lib/social/providers/instagram.ts
+++ b/src/lib/social/providers/instagram.ts
@@ -40,6 +40,7 @@ import {
   GRAPH_BASE,
   makeOAuthState,
   MetaApiError,
+  metaErrorToClassifierBody,
   verifyGrantedScopes,
 } from "@/lib/social/providers/meta-common";
 
@@ -562,12 +563,7 @@ export const instagramProvider: SocialProviderAdapter = {
   // -------------------------------------------------------------------------
 
   classifyError(error: unknown): SocialProviderError {
-    const body =
-      error instanceof Error
-        ? JSON.stringify({ message: error.message })
-        : typeof error === "string"
-          ? error
-          : JSON.stringify(error);
+    const body = metaErrorToClassifierBody(error);
 
     return (
       classifyMetaError(body) ?? {

--- a/src/lib/social/providers/meta-common.ts
+++ b/src/lib/social/providers/meta-common.ts
@@ -144,12 +144,62 @@ export async function verifyGrantedScopes(
 // ---------------------------------------------------------------------------
 
 /**
+ * Build the match string that {@link classifyMetaError} pattern-matches
+ * against, from a thrown error.
+ *
+ * A real {@link MetaApiError} carries the numeric Graph API error code on its
+ * structured `.code` field and the full platform error body (including
+ * `error_subcode`, `type` and `message`) on `.rawBody` — the numeric code is
+ * NEVER folded into the human-readable `.message`. The previous behaviour
+ * (`JSON.stringify({ message: error.message })`) therefore left every
+ * numeric-code branch below unreachable, so permanent content-policy failures
+ * mis-classified as transient "retry" and would retry forever. We fold every
+ * structured field into the match string instead.
+ *
+ * The numeric `code` is emitted with a trailing comma so the exact-match
+ * patterns `"190,"` / `"490,"` in {@link classifyMetaError} match regardless
+ * of how the platform ordered its JSON fields.
+ */
+export function metaErrorToClassifierBody(error: unknown): string {
+  if (isMetaApiError(error)) {
+    const parts: string[] = [];
+    if (error.code !== undefined && error.code !== null) {
+      parts.push(`${error.code},`);
+    }
+    if (error.message) parts.push(error.message);
+    if (error.rawBody) parts.push(error.rawBody);
+    return parts.join(" ");
+  }
+  if (error instanceof Error) {
+    return JSON.stringify({ message: error.message });
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return JSON.stringify(error);
+}
+
+/**
+ * Duck-typed MetaApiError check. Uses `.name` rather than `instanceof` so it
+ * stays correct when the class is loaded from a different module instance
+ * (e.g. after `vi.resetModules()` in tests, or across bundle boundaries).
+ */
+function isMetaApiError(error: unknown): error is MetaApiError {
+  return (
+    error instanceof Error &&
+    error.name === "MetaApiError" &&
+    ("code" in error || "rawBody" in error)
+  );
+}
+
+/**
  * Classify a Meta Graph API error body string into a SocialProviderError.
  *
  * This runs through the same error codes that Postiz's Instagram/Facebook
  * providers handle, adapted to our SocialProviderError type.
  *
- * @param body - The raw JSON-serialised error body (or any string containing it).
+ * @param body - The match string produced by {@link metaErrorToClassifierBody}
+ *   (or any string containing the platform error tokens).
  * @returns A classified SocialProviderError, or undefined if unknown.
  */
 export function classifyMetaError(body: string): SocialProviderError | undefined {

--- a/src/lib/social/providers/threads.ts
+++ b/src/lib/social/providers/threads.ts
@@ -17,6 +17,7 @@ import {
   GRAPH_BASE,
   makeOAuthState,
   MetaApiError,
+  metaErrorToClassifierBody,
   verifyGrantedScopes,
 } from "@/lib/social/providers/meta-common";
 import { registerProvider } from "@/lib/social/provider-registry";
@@ -248,12 +249,7 @@ export const threadsProvider: SocialProviderAdapter = {
   },
 
   classifyError(error: unknown): SocialProviderError {
-    const body =
-      error instanceof Error
-        ? JSON.stringify({ message: error.message })
-        : typeof error === "string"
-          ? error
-          : JSON.stringify(error);
+    const body = metaErrorToClassifierBody(error);
 
     return (
       classifyMetaError(body) ?? {

--- a/src/lib/social/providers/youtube.ts
+++ b/src/lib/social/providers/youtube.ts
@@ -1,4 +1,6 @@
 import { randomBytes } from "node:crypto";
+import { Readable } from "node:stream";
+import type { ReadableStream as WebReadableStream } from "node:stream/web";
 import { google } from "googleapis";
 import type {
   AuthenticateParams,
@@ -33,8 +35,16 @@ function buildOAuth2Client(redirectUri?: string) {
 }
 
 /**
- * Convert a public URL to a Node.js-compatible ReadableStream by fetching
- * it and returning the response body. Used for streaming video uploads.
+ * Convert a public URL to a Node.js Readable by fetching it and bridging the
+ * response body. Used for streaming video/thumbnail uploads.
+ *
+ * Node's native `fetch()` (undici) exposes `response.body` as a WHATWG
+ * `ReadableStream`, which has no `.pipe()` method. `googleapis-common`'s
+ * multipart uploader unconditionally calls `part.body.pipe(...)` on the media
+ * body, so handing it the raw Web stream throws
+ * `TypeError: part.body.pipe is not a function` before any upload request is
+ * made. `Readable.fromWeb()` (Node 17+) bridges the Web stream to a Node
+ * Readable with the `.pipe()` API the uploader requires.
  */
 async function urlToReadableStream(
   url: string,
@@ -45,11 +55,10 @@ async function urlToReadableStream(
       `YouTube: failed to fetch video from URL: ${response.status} ${url}`,
     );
   }
-  // response.body is a ReadableStream (Web Streams API). The googleapis
-  // upload accepts a Node.js Readable, but in practice passing the Web
-  // ReadableStream works fine in Node 18+ since they share the stream
-  // protocol for piping.
-  return response.body as unknown as NodeJS.ReadableStream;
+  if (!response.body) {
+    throw new Error(`YouTube: empty response body for URL: ${url}`);
+  }
+  return Readable.fromWeb(response.body as unknown as WebReadableStream<Uint8Array>);
 }
 
 export const youTubeProvider: SocialProviderAdapter = {

--- a/src/lib/social/providers/youtube.ts
+++ b/src/lib/social/providers/youtube.ts
@@ -61,6 +61,51 @@ async function urlToReadableStream(
   return Readable.fromWeb(response.body as unknown as WebReadableStream<Uint8Array>);
 }
 
+/**
+ * Extract a searchable signal string + HTTP status from a thrown error.
+ *
+ * A real googleapis call throws a `GaxiosError` whose `.message` is ONLY the
+ * Google API error's `.message` field — the machine-readable `reason` enum
+ * (e.g. "quotaExceeded", "forbidden", "authError") and the AIP `status` enum
+ * (e.g. "UNAUTHENTICATED") live in `.response.data.error`, never folded into
+ * `.message`. Matching on `.message` alone left every reason-based branch of
+ * classifyError() dead, so real 401/403s fell through to generic "retry".
+ * We therefore fold the structured response body into the signal string and
+ * expose the numeric HTTP status.
+ */
+function extractGoogleErrorSignals(error: unknown): {
+  message: string;
+  signals: string;
+  httpStatus?: number;
+} {
+  const message = error instanceof Error ? error.message : String(error);
+  const parts: string[] = [message];
+  let httpStatus: number | undefined;
+
+  if (error && typeof error === "object") {
+    const e = error as {
+      status?: unknown;
+      code?: unknown;
+      response?: { status?: unknown; data?: unknown };
+    };
+
+    const rawStatus = e.status ?? e.response?.status ?? e.code;
+    if (typeof rawStatus === "number") {
+      httpStatus = rawStatus;
+    }
+
+    const errorBody = (e.response?.data as { error?: unknown } | undefined)
+      ?.error;
+    if (errorBody !== undefined) {
+      parts.push(
+        typeof errorBody === "string" ? errorBody : JSON.stringify(errorBody),
+      );
+    }
+  }
+
+  return { message, signals: parts.join(" "), httpStatus };
+}
+
 export const youTubeProvider: SocialProviderAdapter = {
   identifier: "youtube",
   displayName: "YouTube",
@@ -202,14 +247,42 @@ export const youTubeProvider: SocialProviderAdapter = {
   },
 
   classifyError(error: unknown): SocialProviderError {
-    const message = error instanceof Error ? error.message : String(error);
+    const { message, signals, httpStatus } = extractGoogleErrorSignals(error);
 
+    // Content / permanent failures. Checked FIRST because some map to HTTP
+    // statuses that would otherwise be swept up by the broad status buckets
+    // below (e.g. "youtubeSignupRequired" is a 401 that must fail fast, not
+    // trigger a token refresh).
     if (
-      message.includes("Unauthorized") ||
-      message.includes("UNAUTHENTICATED") ||
-      message.includes("invalid_grant") ||
-      message.includes("Token has been expired") ||
-      message.includes("token expired")
+      signals.includes("invalidTitle") ||
+      signals.includes("invalidDescription") ||
+      signals.includes("invalidTags") ||
+      signals.includes("youtubeSignupRequired") ||
+      signals.includes("uploadLimitExceeded") ||
+      signals.includes("videoDurationTooLong") ||
+      signals.includes("videoFileSizeTooLarge") ||
+      signals.includes("failedPrecondition") ||
+      signals.includes("forbidden") ||
+      signals.includes("privacySettingNotSupportedForPartner")
+    ) {
+      return {
+        type: "bad-body",
+        message: `YouTube content validation failed: ${message}`,
+        original: error,
+      };
+    }
+
+    // Auth / re-auth. A real GaxiosError from an expired token against the
+    // Data API surfaces as HTTP 401 with reason "authError" / AIP status
+    // "UNAUTHENTICATED" — none of which reach `.message`.
+    if (
+      httpStatus === 401 ||
+      signals.includes("Unauthorized") ||
+      signals.includes("UNAUTHENTICATED") ||
+      signals.includes("authError") ||
+      signals.includes("invalid_grant") ||
+      signals.includes("Token has been expired") ||
+      signals.includes("token expired")
     ) {
       return {
         type: "refresh-token",
@@ -219,32 +292,17 @@ export const youTubeProvider: SocialProviderAdapter = {
       };
     }
 
+    // Transient / retry.
     if (
-      message.includes("invalidTitle") ||
-      message.includes("invalidDescription") ||
-      message.includes("invalidTags") ||
-      message.includes("youtubeSignupRequired") ||
-      message.includes("uploadLimitExceeded") ||
-      message.includes("videoDurationTooLong") ||
-      message.includes("videoFileSizeTooLarge") ||
-      message.includes("failedPrecondition") ||
-      message.includes("forbidden") ||
-      message.includes("privacySettingNotSupportedForPartner")
-    ) {
-      return {
-        type: "bad-body",
-        message: `YouTube content validation failed: ${message}`,
-        original: error,
-      };
-    }
-
-    if (
-      message.includes("quotaExceeded") ||
-      message.includes("rateLimitExceeded") ||
-      message.includes("backendError") ||
-      message.includes("internalError") ||
-      message.includes("serviceUnavailable") ||
-      message.includes("transientError")
+      signals.includes("quotaExceeded") ||
+      signals.includes("rateLimitExceeded") ||
+      signals.includes("backendError") ||
+      signals.includes("internalError") ||
+      signals.includes("serviceUnavailable") ||
+      signals.includes("transientError") ||
+      httpStatus === 429 ||
+      httpStatus === 500 ||
+      httpStatus === 503
     ) {
       return {
         type: "retry",


### PR DESCRIPTION
Part of PRD #100 (social-hub hardening; defects found by #111/#112 contract tests). **Stacked on #124** — merge order: #118 → #124 → this.

Three confirmed production defects fixed, one commit each, test-first (canary tests flipped red→green):

1. **Meta family** (`meta-common.ts`): real `MetaApiError` carries the Graph code in `.code` and subcode/type in `.rawBody` — never in `.message` — so every numeric permanent-failure branch was dead and content-policy failures retried forever. Classifier now folds code + message + rawBody. (Duck-typed detection because vi.resetModules breaks instanceof across dynamic re-imports.)
2. **YouTube upload**: undici fetch bodies are WHATWG streams; googleapis multipart needs Node `Readable` — every real upload threw `part.body.pipe is not a function` before any HTTP. Now bridged with `Readable.fromWeb`. **YouTube publishing worked for the first time under test.** (Also corrected the mock upload host to `youtube.googleapis.com`.)
3. **YouTube classifyError**: `reason` enums live in `.response.data.error.errors[].reason`, not `.message`. New `extractGoogleErrorSignals()`; content errors (e.g. `youtubeSignupRequired` on 401) deliberately classify before the generic 401→refresh rule.

Unit tests that encoded synthetic (non-production) error shapes were made realistic. Verified by reviewer: all 264 provider tests green; agent reports full suite green on the stack; zero new type errors vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)