### PR TITLE
feat: BYOK-only inference on generate/LLM — header → vault → typed error (#108)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,29 +1,35 @@
-# Google Gemini API Key (Required for image generation and Google LLM)
-# Get your API key from: https://aistudio.google.com/
+# ------------------------------------------------------------------------------
+# AI provider inference keys — DEV / TEST ONLY. The product is BYOK.
+# ------------------------------------------------------------------------------
+# The running product does NOT read these on any inference path. Generation and
+# LLM routes resolve keys per request as: request header (X-<Provider>-API-Key)
+# → the workspace's encrypted provider-key vault (Settings → Provider Keys) →
+# a typed "no key configured" error. The business never bills the operator's own
+# key for customer inference.
+#
+# These variables remain only for local scripts, tests, and smoke tooling that
+# call providers directly outside the request pipeline. Leave them unset for a
+# normal BYOK product run.
+
+# Google Gemini — https://aistudio.google.com/
 GEMINI_API_KEY=your_gemini_api_key_here
 
-# OpenAI API Key (Optional - only needed if using OpenAI LLM provider)
-# Get your API key from: https://platform.openai.com/api-keys
+# OpenAI — https://platform.openai.com/api-keys
 OPENAI_API_KEY=your_openai_api_key_here
 
-# Anthropic API Key (Optional - only needed if using Anthropic Claude LLM provider)
-# Get your API key from: https://console.anthropic.com/settings/keys
+# Anthropic Claude — https://console.anthropic.com/settings/keys
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
-# Replicate API Key (Optional - only needed if using Replicate models)
-# Get your API key from: https://replicate.com/account/api-tokens
+# Replicate — https://replicate.com/account/api-tokens
 REPLICATE_API_KEY=your_replicate_api_key_here
 
-# fal.ai API Key (Optional - only needed if using fal.ai models)
-# Get your API key from: https://fal.ai/dashboard/keys
+# fal.ai — https://fal.ai/dashboard/keys
 FAL_API_KEY=your_fal_api_key_here
 
-# Kie.ai API Key (Optional - only needed if using Kie.ai models like Sora, Veo, Kling)
-# Get your API key from: https://kie.ai/
+# Kie.ai — https://kie.ai/
 KIE_API_KEY=your_kie_api_key_here
 
-# WaveSpeed API Key (Optional - only needed if using WaveSpeed models)
-# Get your API key from: https://wavespeed.ai/
+# WaveSpeed — https://wavespeed.ai/
 WAVESPEED_API_KEY=your_wavespeed_api_key_here
 
 # ------------------------------------------------------------------------------

--- a/src/app/api/generate/__tests__/route.test.ts
+++ b/src/app/api/generate/__tests__/route.test.ts
@@ -41,19 +41,47 @@ vi.mock("@/lib/images", () => ({
   deleteImages: vi.fn(),
 }));
 
+// BYOK vault shim: the route now resolves keys via resolveInferenceKey, whose
+// vault tier delegates to resolveProviderKey. Mock the repository so tests
+// never touch the database; by default the vault mirrors process.env so the
+// large body of generation-behavior tests keep providing a key by setting env
+// (which the route no longer reads directly — it flows through the vault here).
+// Requests carry a default `x-workspace-id`, so the vault tier is active.
+const PROVIDER_ENV_MAP: Record<string, string> = {
+  gemini: "GEMINI_API_KEY",
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  replicate: "REPLICATE_API_KEY",
+  fal: "FAL_API_KEY",
+  kie: "KIE_API_KEY",
+  wavespeed: "WAVESPEED_API_KEY",
+};
+
+vi.mock("@/lib/byok/repository", () => ({
+  resolveProviderKey: vi.fn(
+    async (_workspaceId: string, provider: string) =>
+      process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+  ),
+}));
+
+import { resolveProviderKey } from "@/lib/byok/repository";
 import { POST, clearFalInputMappingCache } from "../route";
+
+const mockedResolveProviderKey = vi.mocked(resolveProviderKey);
 
 // Store original env
 const originalEnv = { ...process.env };
 
-// Helper to create mock NextRequest for POST
+// Helper to create mock NextRequest for POST. Injects a default workspace
+// header so the BYOK vault tier is active; pass `x-workspace-id` in `headers`
+// to override, or an explicit empty value to exercise the header-only tier.
 function createMockPostRequest(
   body: unknown,
   headers?: Record<string, string>
 ): NextRequest {
   return {
     json: vi.fn().mockResolvedValue(body),
-    headers: new Headers(headers),
+    headers: new Headers({ "x-workspace-id": "ws-test", ...headers }),
   } as unknown as NextRequest;
 }
 
@@ -100,6 +128,12 @@ describe("/api/generate route", () => {
     MockGoogleGenAI.reset();
     // Reset env to original
     process.env = { ...originalEnv };
+    // Re-establish the default env-mirroring vault shim (clearAllMocks keeps
+    // implementations, but per-test overrides must not leak between tests).
+    mockedResolveProviderKey.mockImplementation(
+      async (_workspaceId: string, provider: string) =>
+        process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+    );
   });
 
   afterEach(() => {
@@ -414,8 +448,9 @@ describe("/api/generate route", () => {
       );
     });
 
-    it("should use X-Gemini-API-Key header over env var", async () => {
-      process.env.GEMINI_API_KEY = "env-gemini-key";
+    it("should use X-Gemini-API-Key header over the vault", async () => {
+      // Vault also has a key, but the request header must win.
+      mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
 
       mockGenerateContent.mockResolvedValueOnce(createGeminiImageResponse());
 
@@ -438,8 +473,12 @@ describe("/api/generate route", () => {
       });
     });
 
-    it("should return 500 when API key missing", async () => {
+    it("resolves the Gemini key from the workspace vault when no header is set", async () => {
+      // No env, no header — only the vault has a key.
       delete process.env.GEMINI_API_KEY;
+      mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
+
+      mockGenerateContent.mockResolvedValueOnce(createGeminiImageResponse());
 
       const request = createMockPostRequest({
         prompt: "Test prompt",
@@ -449,9 +488,55 @@ describe("/api/generate route", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(MockGoogleGenAI.lastCalledWith).toEqual({
+        apiKey: "vault-gemini-key",
+      });
+    });
+
+    it("returns a typed byok_key_missing error (4xx) when no key is resolvable", async () => {
+      delete process.env.GEMINI_API_KEY;
+      mockedResolveProviderKey.mockResolvedValue(null);
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        model: "nano-banana-pro",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
       expect(data.success).toBe(false);
-      expect(data.error).toContain("API key not configured");
+      expect(data.code).toBe("byok_key_missing");
+      expect(data.provider).toBe("gemini");
+      // Names the provider and where to add the key, never the env var.
+      expect(data.error).toContain("Google Gemini");
+      expect(data.error).toContain("Provider Keys");
+      expect(data.error).not.toMatch(/GEMINI_API_KEY|process\.env/);
+    });
+
+    it("never falls back to the server env key for Gemini", async () => {
+      // Env is set, but the vault returns nothing and there is no header:
+      // the route must NOT read process.env, so this must still fail.
+      process.env.GEMINI_API_KEY = "env-gemini-key";
+      mockedResolveProviderKey.mockResolvedValue(null);
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        model: "nano-banana-pro",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
+      expect(data.success).toBe(false);
+      expect(data.code).toBe("byok_key_missing");
+      expect(MockGoogleGenAI.callCount).toBe(0);
     });
 
     it("should return 429 on rate limit errors", async () => {
@@ -887,8 +972,9 @@ describe("/api/generate route", () => {
       expect(mockGenerateContent).toHaveBeenCalled();
     });
 
-    it("should return 401 for Replicate provider without API key", async () => {
+    it("should return typed byok_key_missing for Replicate without any key", async () => {
       delete process.env.REPLICATE_API_KEY;
+      mockedResolveProviderKey.mockResolvedValue(null);
 
       const request = createMockPostRequest({
         prompt: "Test prompt",
@@ -904,7 +990,11 @@ describe("/api/generate route", () => {
 
       expect(response.status).toBe(401);
       expect(data.success).toBe(false);
-      expect(data.error).toContain("Replicate API key not configured");
+      expect(data.code).toBe("byok_key_missing");
+      expect(data.provider).toBe("replicate");
+      expect(data.error).toContain("Replicate");
+      expect(data.error).toContain("Provider Keys");
+      expect(data.error).not.toMatch(/REPLICATE_API_KEY|process\.env/);
     });
   });
 
@@ -1102,8 +1192,9 @@ describe("/api/generate route", () => {
       expect(data.contentType).toBe("video");
     });
 
-    it("should return 401 when Replicate API key missing", async () => {
+    it("should return 401 when Replicate key missing (typed byok error)", async () => {
       delete process.env.REPLICATE_API_KEY;
+      mockedResolveProviderKey.mockResolvedValue(null);
 
       const request = createMockPostRequest({
         prompt: "Test prompt",
@@ -1119,7 +1210,9 @@ describe("/api/generate route", () => {
 
       expect(response.status).toBe(401);
       expect(data.success).toBe(false);
-      expect(data.error).toContain("Replicate API key not configured");
+      expect(data.code).toBe("byok_key_missing");
+      expect(data.error).toContain("Replicate");
+      expect(data.error).toContain("Provider Keys");
     });
 
     it("should handle rate limit (429) from Replicate", async () => {

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -15,6 +15,12 @@ import { GenerateRequest, GenerateResponse, ModelType, SelectedModel, ProviderTy
 import { GenerationInput, ModelCapability } from "@/lib/providers/types";
 import { resolveAssetRefsInPayload } from "./assetResolver";
 import { isS3Configured } from "@/lib/storage/s3";
+import {
+  resolveInferenceKey,
+  resolveInferenceKeyOptional,
+  isInferenceKeyError,
+  type InferenceKeyError,
+} from "@/lib/byok/resolveInferenceKey";
 import { generateWithGemini, generateWithGeminiVideo } from "./providers/gemini";
 import { generateWithReplicate } from "./providers/replicate";
 import { clearFalInputMappingCache as _clearFalInputMappingCache, generateWithFalQueue } from "./providers/fal";
@@ -73,6 +79,19 @@ function buildMediaResponse(output: { type: string; data: string; url?: string }
     image: output.data,
     contentType: "image",
   });
+}
+
+/**
+ * Translate a typed BYOK key-missing error into a 4xx JSON body. Names the
+ * provider and points to Settings → Provider Keys; never a 500, never a leaked
+ * env var name. `error` mirrors `message` so the existing client error-display
+ * path (which reads the `error` field) surfaces it on the node.
+ */
+function byokErrorResponse(err: InferenceKeyError): NextResponse {
+  return NextResponse.json(
+    { success: false, error: err.message, ...err.toJSON() },
+    { status: 401 }
+  );
 }
 
 function capabilitiesForMediaType(mediaType?: string): ModelCapability[] {
@@ -155,16 +174,17 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // User-provided key takes precedence over env variable
-      const replicateApiKey = request.headers.get("X-Replicate-API-Key") || process.env.REPLICATE_API_KEY;
-      if (!replicateApiKey) {
-        return NextResponse.json<GenerateResponse>(
-          {
-            success: false,
-            error: "Replicate API key not configured. Add REPLICATE_API_KEY to .env.local or configure in Settings.",
-          },
-          { status: 401 }
-        );
+      // BYOK: request header override → workspace vault → typed error. No env.
+      let replicateApiKey: string;
+      try {
+        replicateApiKey = await resolveInferenceKey({
+          headerKey: request.headers.get("X-Replicate-API-Key"),
+          workspaceId,
+          provider: "replicate",
+        });
+      } catch (err) {
+        if (isInferenceKeyError(err)) return byokErrorResponse(err);
+        throw err;
       }
 
       // Keep Data URIs as-is since localhost URLs won't work (provider can't reach them)
@@ -235,8 +255,14 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // User-provided key takes precedence over env variable
-      const falApiKey = request.headers.get("X-Fal-API-Key") || process.env.FAL_API_KEY || null;
+      // BYOK: request header override → workspace vault → null. fal.ai supports
+      // anonymous (rate-limited) use, so a missing key is a valid state, not an
+      // error — but the server env is never consulted.
+      const falApiKey = await resolveInferenceKeyOptional({
+        headerKey: request.headers.get("X-Fal-API-Key"),
+        workspaceId,
+        provider: "fal",
+      });
 
       if (!falApiKey) {
         console.warn(`[API:${requestId}] No FAL API key configured. Proceeding without auth (rate-limited).`);
@@ -310,16 +336,17 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // User-provided key takes precedence over env variable
-      const kieApiKey = request.headers.get("X-Kie-Key") || process.env.KIE_API_KEY;
-      if (!kieApiKey) {
-        return NextResponse.json<GenerateResponse>(
-          {
-            success: false,
-            error: "Kie.ai API key not configured. Add KIE_API_KEY to .env.local or configure in Settings.",
-          },
-          { status: 401 }
-        );
+      // BYOK: request header override → workspace vault → typed error. No env.
+      let kieApiKey: string;
+      try {
+        kieApiKey = await resolveInferenceKey({
+          headerKey: request.headers.get("X-Kie-Key"),
+          workspaceId,
+          provider: "kie",
+        });
+      } catch (err) {
+        if (isInferenceKeyError(err)) return byokErrorResponse(err);
+        throw err;
       }
 
       // Process images - Kie requires URLs, we'll upload base64 images in generateWithKie
@@ -389,16 +416,17 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // User-provided key takes precedence over env variable
-      const wavespeedApiKey = request.headers.get("X-WaveSpeed-Key") || process.env.WAVESPEED_API_KEY;
-      if (!wavespeedApiKey) {
-        return NextResponse.json<GenerateResponse>(
-          {
-            success: false,
-            error: "WaveSpeed API key not configured. Add WAVESPEED_API_KEY to .env.local or configure in Settings.",
-          },
-          { status: 401 }
-        );
+      // BYOK: request header override → workspace vault → typed error. No env.
+      let wavespeedApiKey: string;
+      try {
+        wavespeedApiKey = await resolveInferenceKey({
+          headerKey: request.headers.get("X-WaveSpeed-Key"),
+          workspaceId,
+          provider: "wavespeed",
+        });
+      } catch (err) {
+        if (isInferenceKeyError(err)) return byokErrorResponse(err);
+        throw err;
       }
 
       // Keep Data URIs as-is since localhost URLs won't work
@@ -461,17 +489,17 @@ export async function POST(request: NextRequest) {
     }
 
     // Default: Use Gemini
-    // User-provided key (from settings) takes precedence over env variable
-    const geminiApiKey = request.headers.get("X-Gemini-API-Key") || process.env.GEMINI_API_KEY;
-
-    if (!geminiApiKey) {
-      return NextResponse.json<GenerateResponse>(
-        {
-          success: false,
-          error: "API key not configured. Add GEMINI_API_KEY to .env.local or configure in Settings.",
-        },
-        { status: 500 }
-      );
+    // BYOK: request header override → workspace vault → typed error. No env.
+    let geminiApiKey: string;
+    try {
+      geminiApiKey = await resolveInferenceKey({
+        headerKey: request.headers.get("X-Gemini-API-Key"),
+        workspaceId,
+        provider: "gemini",
+      });
+    } catch (err) {
+      if (isInferenceKeyError(err)) return byokErrorResponse(err);
+      throw err;
     }
 
     // Use selectedModel.modelId if available (new format), fallback to legacy model field

--- a/src/app/api/llm/__tests__/route.test.ts
+++ b/src/app/api/llm/__tests__/route.test.ts
@@ -44,7 +44,28 @@ vi.mock("@/utils/logger", () => ({
   },
 }));
 
+// BYOK vault shim: the route resolves keys via resolveInferenceKey, whose vault
+// tier delegates to resolveProviderKey. Mock the repository so tests never touch
+// the database; by default the vault mirrors process.env so the existing
+// generation-behavior tests keep providing a key by setting env (which the route
+// no longer reads directly). Requests carry a default `x-workspace-id`.
+const PROVIDER_ENV_MAP: Record<string, string> = {
+  gemini: "GEMINI_API_KEY",
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+};
+
+vi.mock("@/lib/byok/repository", () => ({
+  resolveProviderKey: vi.fn(
+    async (_workspaceId: string, provider: string) =>
+      process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+  ),
+}));
+
+import { resolveProviderKey } from "@/lib/byok/repository";
 import { POST } from "../route";
+
+const mockedResolveProviderKey = vi.mocked(resolveProviderKey);
 
 // Store original env and fetch
 const originalEnv = { ...process.env };
@@ -53,14 +74,15 @@ const originalFetch = global.fetch;
 // Mock fetch for OpenAI API
 const mockFetch = vi.fn();
 
-// Helper to create mock NextRequest for POST
+// Helper to create mock NextRequest for POST. Injects a default workspace
+// header so the BYOK vault tier is active; override via `headers`.
 function createMockPostRequest(
   body: unknown,
   headers?: Record<string, string>
 ): NextRequest {
   return {
     json: vi.fn().mockResolvedValue(body),
-    headers: new Headers(headers),
+    headers: new Headers({ "x-workspace-id": "ws-test", ...headers }),
   } as unknown as NextRequest;
 }
 
@@ -70,6 +92,11 @@ describe("/api/llm route", () => {
     MockGoogleGenAI.reset();
     // Reset env to original
     process.env = { ...originalEnv };
+    // Re-establish the default env-mirroring vault shim after clearAllMocks.
+    mockedResolveProviderKey.mockImplementation(
+      async (_workspaceId: string, provider: string) =>
+        process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+    );
   });
 
   afterEach(() => {
@@ -167,8 +194,9 @@ describe("/api/llm route", () => {
       expect(data.error).toBe("Prompt is required");
     });
 
-    it("should reject missing API key (no env var, no header)", async () => {
+    it("returns a typed byok_key_missing error when no key is resolvable", async () => {
       delete process.env.GEMINI_API_KEY;
+      mockedResolveProviderKey.mockResolvedValue(null);
 
       const request = createMockPostRequest({
         prompt: "Test prompt",
@@ -179,13 +207,57 @@ describe("/api/llm route", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
       expect(data.success).toBe(false);
-      expect(data.error).toContain("GEMINI_API_KEY not configured");
+      expect(data.code).toBe("byok_key_missing");
+      expect(data.provider).toBe("gemini");
+      expect(data.error).toContain("Google Gemini");
+      expect(data.error).toContain("Provider Keys");
+      expect(data.error).not.toMatch(/GEMINI_API_KEY|process\.env/);
     });
 
-    it("should use X-Gemini-API-Key header over env var", async () => {
+    it("resolves the Gemini key from the workspace vault when no header is set", async () => {
+      delete process.env.GEMINI_API_KEY;
+      mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
+
+      mockGenerateContent.mockResolvedValueOnce({ text: "vault response" });
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        provider: "google",
+        model: "gemini-2.5-flash",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(MockGoogleGenAI.lastCalledWith).toEqual({ apiKey: "vault-gemini-key" });
+    });
+
+    it("never falls back to the server env key for Gemini", async () => {
       process.env.GEMINI_API_KEY = "env-gemini-key";
+      mockedResolveProviderKey.mockResolvedValue(null);
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        provider: "google",
+        model: "gemini-2.5-flash",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
+      expect(data.code).toBe("byok_key_missing");
+      expect(MockGoogleGenAI.callCount).toBe(0);
+    });
+
+    it("should use X-Gemini-API-Key header over the vault", async () => {
+      mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
 
       mockGenerateContent.mockResolvedValueOnce({
         text: "Response with header key",
@@ -428,8 +500,9 @@ describe("/api/llm route", () => {
       expect(data.error).toBe("Unknown provider: unknown-provider");
     });
 
-    it("should reject missing OpenAI API key", async () => {
+    it("should reject missing OpenAI API key with typed byok error", async () => {
       delete process.env.OPENAI_API_KEY;
+      mockedResolveProviderKey.mockResolvedValue(null);
 
       const request = createMockPostRequest({
         prompt: "Test prompt",
@@ -440,12 +513,17 @@ describe("/api/llm route", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
       expect(data.success).toBe(false);
-      expect(data.error).toContain("OPENAI_API_KEY not configured");
+      expect(data.code).toBe("byok_key_missing");
+      expect(data.provider).toBe("openai");
+      expect(data.error).toContain("OpenAI");
+      expect(data.error).toContain("Provider Keys");
+      expect(data.error).not.toMatch(/OPENAI_API_KEY|process\.env/);
     });
 
-    it("should use X-OpenAI-API-Key header over env var", async () => {
+    it("should use X-OpenAI-API-Key header over the vault", async () => {
       process.env.OPENAI_API_KEY = "env-openai-key";
 
       mockFetch.mockResolvedValueOnce({
@@ -687,8 +765,9 @@ describe("/api/llm route", () => {
       );
     });
 
-    it("should reject missing Anthropic API key", async () => {
+    it("should reject missing Anthropic API key with typed byok error", async () => {
       delete process.env.ANTHROPIC_API_KEY;
+      mockedResolveProviderKey.mockResolvedValue(null);
 
       const request = createMockPostRequest({
         prompt: "Test prompt",
@@ -699,12 +778,17 @@ describe("/api/llm route", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
       expect(data.success).toBe(false);
-      expect(data.error).toContain("ANTHROPIC_API_KEY not configured");
+      expect(data.code).toBe("byok_key_missing");
+      expect(data.provider).toBe("anthropic");
+      expect(data.error).toContain("Anthropic");
+      expect(data.error).toContain("Provider Keys");
+      expect(data.error).not.toMatch(/ANTHROPIC_API_KEY|process\.env/);
     });
 
-    it("should use X-Anthropic-API-Key header over env var", async () => {
+    it("should use X-Anthropic-API-Key header over the vault", async () => {
       process.env.ANTHROPIC_API_KEY = "env-anthropic-key";
 
       mockFetch.mockResolvedValueOnce({

--- a/src/app/api/llm/route.ts
+++ b/src/app/api/llm/route.ts
@@ -4,6 +4,10 @@ import { LLMGenerateRequest, LLMGenerateResponse, LLMModelType } from "@/types";
 import { logger } from "@/utils/logger";
 import { resolveAssetRefsInPayload } from "../generate/assetResolver";
 import { isS3Configured } from "@/lib/storage/s3";
+import {
+  resolveInferenceKey,
+  isInferenceKeyError,
+} from "@/lib/byok/resolveInferenceKey";
 
 export const maxDuration = 60; // 1 minute timeout
 
@@ -38,16 +42,9 @@ async function generateWithGoogle(
   maxTokens: number,
   images?: string[],
   requestId?: string,
-  userApiKey?: string | null
+  apiKey?: string
 ): Promise<string> {
-  // User-provided key takes precedence over env variable
-  const apiKey = userApiKey || process.env.GEMINI_API_KEY;
-  if (!apiKey) {
-    logger.error('api.error', 'GEMINI_API_KEY not configured', { requestId });
-    throw new Error("GEMINI_API_KEY not configured. Add it to .env.local or configure in Settings.");
-  }
-
-  const ai = new GoogleGenAI({ apiKey });
+  const ai = new GoogleGenAI({ apiKey: apiKey ?? "" });
   const modelId = GOOGLE_MODEL_MAP[model];
 
   logger.info('api.llm', 'Calling Google AI API', {
@@ -122,15 +119,8 @@ async function generateWithOpenAI(
   maxTokens: number,
   images?: string[],
   requestId?: string,
-  userApiKey?: string | null
+  apiKey?: string
 ): Promise<string> {
-  // User-provided key takes precedence over env variable
-  const apiKey = userApiKey || process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    logger.error('api.error', 'OPENAI_API_KEY not configured', { requestId });
-    throw new Error("OPENAI_API_KEY not configured. Add it to .env.local or configure in Settings.");
-  }
-
   const modelId = OPENAI_MODEL_MAP[model];
 
   logger.info('api.llm', 'Calling OpenAI API', {
@@ -206,14 +196,8 @@ async function generateWithAnthropic(
   maxTokens: number,
   images?: string[],
   requestId?: string,
-  userApiKey?: string | null
+  apiKey?: string
 ): Promise<string> {
-  const apiKey = userApiKey || process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    logger.error('api.error', 'ANTHROPIC_API_KEY not configured', { requestId });
-    throw new Error("ANTHROPIC_API_KEY not configured. Add it to .env.local or configure in Settings.");
-  }
-
   const modelId = ANTHROPIC_MODEL_MAP[model];
 
   logger.info('api.llm', 'Calling Anthropic API', {
@@ -252,7 +236,7 @@ async function generateWithAnthropic(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "x-api-key": apiKey,
+      "x-api-key": apiKey ?? "",
       "anthropic-version": "2023-06-01",
     },
     body: JSON.stringify({
@@ -339,11 +323,27 @@ export async function POST(request: NextRequest) {
     let text: string;
 
     if (provider === "google") {
-      text = await generateWithGoogle(prompt, model, temperature, maxTokens, images, requestId, geminiApiKey);
+      // BYOK: request header override → workspace vault → typed error. No env.
+      const apiKey = await resolveInferenceKey({
+        headerKey: geminiApiKey,
+        workspaceId,
+        provider: "gemini",
+      });
+      text = await generateWithGoogle(prompt, model, temperature, maxTokens, images, requestId, apiKey);
     } else if (provider === "openai") {
-      text = await generateWithOpenAI(prompt, model, temperature, maxTokens, images, requestId, openaiApiKey);
+      const apiKey = await resolveInferenceKey({
+        headerKey: openaiApiKey,
+        workspaceId,
+        provider: "openai",
+      });
+      text = await generateWithOpenAI(prompt, model, temperature, maxTokens, images, requestId, apiKey);
     } else if (provider === "anthropic") {
-      text = await generateWithAnthropic(prompt, model, temperature, maxTokens, images, requestId, anthropicApiKey);
+      const apiKey = await resolveInferenceKey({
+        headerKey: anthropicApiKey,
+        workspaceId,
+        provider: "anthropic",
+      });
+      text = await generateWithAnthropic(prompt, model, temperature, maxTokens, images, requestId, apiKey);
     } else {
       logger.warn('api.llm', 'Unknown provider requested', { requestId, provider });
       return NextResponse.json<LLMGenerateResponse>(
@@ -362,6 +362,17 @@ export async function POST(request: NextRequest) {
       text,
     });
   } catch (error) {
+    // No resolvable BYOK key: return a typed 4xx naming the provider and
+    // pointing to Settings → Provider Keys — never a 500, never a leaked env
+    // name. `error` mirrors `message` so the node error-display path shows it.
+    if (isInferenceKeyError(error)) {
+      logger.warn('api.llm', 'BYOK key missing', { requestId, provider: error.provider });
+      return NextResponse.json(
+        { success: false, error: error.message, ...error.toJSON() },
+        { status: 401 }
+      );
+    }
+
     logger.error('api.error', 'LLM generation error', { requestId }, error instanceof Error ? error : undefined);
 
     // Handle rate limiting

--- a/src/lib/byok/__tests__/resolveInferenceKey.test.ts
+++ b/src/lib/byok/__tests__/resolveInferenceKey.test.ts
@@ -120,11 +120,12 @@ describe("resolveInferenceKey", () => {
     mockedResolve.mockResolvedValue(null);
 
     for (const provider of ["gemini", "openai", "anthropic", "wavespeed"] as const) {
-      const error = await resolveInferenceKey({
-        headerKey: null,
-        workspaceId: "ws-1",
-        provider,
-      }).catch((e) => e as InferenceKeyError);
+      let error!: InferenceKeyError;
+      try {
+        await resolveInferenceKey({ headerKey: null, workspaceId: "ws-1", provider });
+      } catch (e) {
+        error = e as InferenceKeyError;
+      }
 
       expect(error.message).not.toMatch(/API_KEY|process\.env|_KEY|env/i);
       expect(error.remedy).not.toMatch(/API_KEY|process\.env|_KEY/i);

--- a/src/lib/byok/__tests__/resolveInferenceKey.test.ts
+++ b/src/lib/byok/__tests__/resolveInferenceKey.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The vault tier delegates to the repository's resolveProviderKey. Mock it so
+// these tests never touch the database and can drive header/vault/miss cases.
+vi.mock("../repository", () => ({
+  resolveProviderKey: vi.fn(),
+}));
+
+import { resolveProviderKey } from "../repository";
+import {
+  resolveInferenceKey,
+  InferenceKeyError,
+  isInferenceKeyError,
+} from "../resolveInferenceKey";
+
+const mockedResolve = vi.mocked(resolveProviderKey);
+
+describe("resolveInferenceKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the request header key, taking precedence over the vault", async () => {
+    mockedResolve.mockResolvedValue("vault-key");
+
+    const key = await resolveInferenceKey({
+      headerKey: "header-key",
+      workspaceId: "ws-1",
+      provider: "gemini",
+    });
+
+    expect(key).toBe("header-key");
+    // Header wins outright — the vault must not even be consulted.
+    expect(mockedResolve).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the workspace vault when no header is provided", async () => {
+    mockedResolve.mockResolvedValue("vault-key");
+
+    const key = await resolveInferenceKey({
+      headerKey: null,
+      workspaceId: "ws-1",
+      provider: "openai",
+    });
+
+    expect(key).toBe("vault-key");
+    expect(mockedResolve).toHaveBeenCalledWith("ws-1", "openai");
+  });
+
+  it("treats a blank/whitespace header as absent and falls through to the vault", async () => {
+    mockedResolve.mockResolvedValue("vault-key");
+
+    const key = await resolveInferenceKey({
+      headerKey: "   ",
+      workspaceId: "ws-1",
+      provider: "anthropic",
+    });
+
+    expect(key).toBe("vault-key");
+    expect(mockedResolve).toHaveBeenCalledWith("ws-1", "anthropic");
+  });
+
+  it("throws a typed byok_key_missing error when neither header nor vault has a key", async () => {
+    mockedResolve.mockResolvedValue(null);
+
+    await expect(
+      resolveInferenceKey({
+        headerKey: null,
+        workspaceId: "ws-1",
+        provider: "gemini",
+      }),
+    ).rejects.toBeInstanceOf(InferenceKeyError);
+  });
+
+  it("throws without consulting the vault when there is no workspace context (header-only tier)", async () => {
+    await expect(
+      resolveInferenceKey({
+        headerKey: null,
+        workspaceId: null,
+        provider: "kie",
+      }),
+    ).rejects.toBeInstanceOf(InferenceKeyError);
+
+    expect(mockedResolve).not.toHaveBeenCalled();
+  });
+
+  it("produces a structured error naming the provider and pointing to Settings → Provider Keys", async () => {
+    mockedResolve.mockResolvedValue(null);
+
+    let caught: unknown;
+    try {
+      await resolveInferenceKey({
+        headerKey: null,
+        workspaceId: "ws-1",
+        provider: "replicate",
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isInferenceKeyError(caught)).toBe(true);
+    const error = caught as InferenceKeyError;
+    expect(error.code).toBe("byok_key_missing");
+    expect(error.provider).toBe("replicate");
+    // Names the provider by human label, not the internal id.
+    expect(error.message).toContain("Replicate");
+    expect(error.message).toContain("Provider Keys");
+    expect(error.remedy).toContain("Provider Keys");
+
+    const body = error.toJSON();
+    expect(body).toMatchObject({
+      code: "byok_key_missing",
+      provider: "replicate",
+    });
+    expect(typeof body.message).toBe("string");
+    expect(typeof body.remedy).toBe("string");
+  });
+
+  it("never leaks the server env var name in the error message", async () => {
+    mockedResolve.mockResolvedValue(null);
+
+    for (const provider of ["gemini", "openai", "anthropic", "wavespeed"] as const) {
+      const error = await resolveInferenceKey({
+        headerKey: null,
+        workspaceId: "ws-1",
+        provider,
+      }).catch((e) => e as InferenceKeyError);
+
+      expect(error.message).not.toMatch(/API_KEY|process\.env|_KEY|env/i);
+      expect(error.remedy).not.toMatch(/API_KEY|process\.env|_KEY/i);
+    }
+  });
+});

--- a/src/lib/byok/resolveInferenceKey.ts
+++ b/src/lib/byok/resolveInferenceKey.ts
@@ -1,0 +1,118 @@
+/**
+ * BYOK inference-key resolution — the single seam every product inference path
+ * (generate, LLM) uses to obtain a provider API key.
+ *
+ * Resolution order:
+ *   1. Request-header override (e.g. `X-Gemini-API-Key`) — ad-hoc / agent use.
+ *   2. Workspace vault (`resolveProviderKey`) — the workspace's stored key.
+ *   3. A typed {@link InferenceKeyError} — never a server-env fallback.
+ *
+ * There is deliberately NO `process.env.<PROVIDER>_KEY` tier: the business does
+ * not provide or resell inference, so a product request that resolves no BYOK
+ * key must fail with a clear, user-actionable error — never silently bill the
+ * operator's own key.
+ *
+ * The error is a structured shape (`code`/`provider`/`message`/`remedy`) that
+ * routes translate into a 4xx JSON body naming the provider and pointing to
+ * Settings → Provider Keys. It never surfaces as a 500 and never leaks the
+ * server env var name.
+ */
+
+import { BYOK_PROVIDER_LABELS, type ByokProvider } from "./providers";
+import { resolveProviderKey } from "./repository";
+
+/** Where a user adds a workspace provider key in the app. */
+const SETTINGS_LOCATION = "Settings → Provider Keys";
+
+/** Serialisable shape a route can spread straight into a JSON error body. */
+export interface ByokKeyMissingBody {
+  code: "byok_key_missing";
+  provider: ByokProvider;
+  message: string;
+  remedy: string;
+}
+
+/**
+ * Thrown when no BYOK key can be resolved for a provider. Carries a structured,
+ * user-facing shape; routes catch it and return a 4xx (never a 500). The
+ * message intentionally names the human-readable provider and the in-app
+ * location, and never references the server environment.
+ */
+export class InferenceKeyError extends Error {
+  readonly code = "byok_key_missing" as const;
+  readonly provider: ByokProvider;
+  readonly remedy: string;
+
+  constructor(provider: ByokProvider) {
+    const label = BYOK_PROVIDER_LABELS[provider] ?? provider;
+    super(
+      `No ${label} API key is configured for this workspace. ` +
+        `Add one in ${SETTINGS_LOCATION}.`,
+    );
+    this.name = "InferenceKeyError";
+    this.provider = provider;
+    this.remedy = `Add a ${label} key in ${SETTINGS_LOCATION}.`;
+    // Restore prototype chain for `instanceof` across transpile targets.
+    Object.setPrototypeOf(this, InferenceKeyError.prototype);
+  }
+
+  toJSON(): ByokKeyMissingBody {
+    return {
+      code: this.code,
+      provider: this.provider,
+      message: this.message,
+      remedy: this.remedy,
+    };
+  }
+}
+
+export function isInferenceKeyError(
+  value: unknown,
+): value is InferenceKeyError {
+  return value instanceof InferenceKeyError;
+}
+
+export interface ResolveInferenceKeyInput {
+  /** Raw request-header value (e.g. `request.headers.get("X-Gemini-API-Key")`). */
+  headerKey?: string | null;
+  /** Workspace context from the `x-workspace-id` header; null when absent. */
+  workspaceId?: string | null;
+  provider: ByokProvider;
+}
+
+/**
+ * Resolve a usable provider key or throw {@link InferenceKeyError}.
+ *
+ * When `workspaceId` is absent, only the header tier applies (no vault lookup):
+ * a headerless request without workspace context fails with the typed error —
+ * it never falls back to a server env key.
+ */
+export async function resolveInferenceKey(
+  input: ResolveInferenceKeyInput,
+): Promise<string> {
+  const key = await resolveInferenceKeyOptional(input);
+  if (key) return key;
+  throw new InferenceKeyError(input.provider);
+}
+
+/**
+ * Same resolution order as {@link resolveInferenceKey}, but returns `null`
+ * instead of throwing when no key is found. For providers that intentionally
+ * support anonymous (rate-limited) use — e.g. fal.ai — where a missing key is
+ * a valid state rather than an error. Still never consults the server env.
+ */
+export async function resolveInferenceKeyOptional(
+  input: ResolveInferenceKeyInput,
+): Promise<string | null> {
+  const { headerKey, workspaceId, provider } = input;
+
+  const trimmedHeader = headerKey?.trim();
+  if (trimmedHeader) return trimmedHeader;
+
+  if (workspaceId) {
+    const vaultKey = await resolveProviderKey(workspaceId, provider);
+    if (vaultKey) return vaultKey;
+  }
+
+  return null;
+}

--- a/src/store/execution/__tests__/httpResponseError.test.ts
+++ b/src/store/execution/__tests__/httpResponseError.test.ts
@@ -54,6 +54,35 @@ describe("throwIfResponseError", () => {
     });
   });
 
+  it("surfaces the typed BYOK key-missing message to the node on 401", async () => {
+    // Mirrors the generate/LLM routes' byok_key_missing 401 body. The existing
+    // node error-display path must show the provider-named message verbatim and
+    // never a leaked server env var name.
+    const updateNodeData = vi.fn();
+    const body = JSON.stringify({
+      success: false,
+      error:
+        "No Google Gemini API key is configured for this workspace. Add one in Settings → Provider Keys.",
+      code: "byok_key_missing",
+      provider: "gemini",
+      remedy: "Add a Google Gemini key in Settings → Provider Keys.",
+    });
+    const response = makeResponse(false, 401, body);
+
+    await expect(
+      throwIfResponseError(response, "node-byok", updateNodeData),
+    ).rejects.toThrow(/Provider Keys/);
+
+    expect(updateNodeData).toHaveBeenCalledWith("node-byok", {
+      status: "error",
+      error:
+        "No Google Gemini API key is configured for this workspace. Add one in Settings → Provider Keys.",
+    });
+    const surfaced = updateNodeData.mock.calls[0][1].error as string;
+    expect(surfaced).toContain("Google Gemini");
+    expect(surfaced).not.toMatch(/GEMINI_API_KEY|process\.env/);
+  });
+
   it("throws 'HTTP 404' with no suffix when body is empty on 404", async () => {
     const updateNodeData = vi.fn();
     const response = makeResponse(false, 404, "");


### PR DESCRIPTION
Closes #108. Part of PRD #100. **Stacked on #125** — merge order: #123 → #125 → this.

The business no longer pays for customer inference on the generate/LLM paths:

- `resolveInferenceKey({headerKey, workspaceId, provider})`: trimmed header override → workspace vault → throw `InferenceKeyError` `{code: "byok_key_missing", provider, message, remedy}`. No env tier exists. Routes return 401 JSON naming the provider and pointing at Settings → Provider Keys; the existing node error path surfaces it verbatim (locked by test). Env var names never leak.
- `/api/generate`: gemini, replicate, kie, wavespeed BYOK-required; fal uses `resolveInferenceKeyOptional` to keep its keyless anonymous rate-limited mode (no operator key involved — flip one line if we want it strict).
- `/api/llm`: google/openai/anthropic resolved in the handler; provider fns no longer read env.
- Grep-proven: zero `process.env` in generate/llm non-test source. `.env.example` inference keys moved to a "DEV / TEST ONLY — product is BYOK" section.
- Chat/quickstart routes are the separate #109 (next in stack).

Tests: +19 (resolution unit suite, vault-hit/header-override/typed-error/no-env-fallback per provider on both routes, node-surface lock). Full suite green except the 2 tracked pre-existing failures; typecheck 0 errors. Reviewer re-ran resolution suite + env grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)