### PR TITLE
feat: nb CLI package + pnpm workspaces (#103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 # dependencies
 /node_modules
+# nested workspace-package dependencies (e.g. packages/*/node_modules)
+node_modules/
 /.pnp
 .pnp.js
 .yarn/install-state.gz
+
+# workspace-package build output
+packages/*/dist/
 
 # testing
 /coverage

--- a/README.md
+++ b/README.md
@@ -213,6 +213,22 @@ The `/examples` directory contains some example workflow files from my personal 
 4. **Run workflow** - Click the Run button to execute the pipeline
 5. **Save/Load** - Use the header menu to save or load workflows
 
+## CLI
+
+`@node-banana/cli` (binary `nb`) is a workspace package that drives the public
+API from a terminal or CI job — authenticate once with a workspace-scoped token,
+then list workspaces, social accounts, and assets, with a global `--json` flag
+for machine-readable output. It talks only to the hosted API, never the database.
+
+```bash
+pnpm --filter @node-banana/cli build
+node packages/cli/dist/index.js auth login --token nb_xxx --url https://app.example.com
+node packages/cli/dist/index.js workspaces list
+```
+
+See [`packages/cli/README.md`](packages/cli/README.md) for install, auth,
+examples, and CI usage.
+
 ## Connection Rules
 
 - **Image** handles connect to **Image** handles only

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,113 @@
+# @node-banana/cli (`nb`)
+
+A small, dependency-light command-line client for the **Node Banana public API**.
+It talks only to the hosted REST API (`/api/v1/*`) with a workspace-scoped API
+token — it never touches the database or imports server code — so it exercises
+exactly the same surface your agents and scripts use.
+
+## Install
+
+From a checkout of this monorepo:
+
+```bash
+pnpm install
+pnpm --filter @node-banana/cli build
+# run the built binary
+node packages/cli/dist/index.js --help
+# or link it as `nb`
+cd packages/cli && npm link   # then: nb --help
+```
+
+## Authenticate
+
+Create a workspace-scoped API token in the app (Workspace Settings → API
+tokens), then:
+
+```bash
+# pass the token inline...
+nb auth login --token nb_xxx --url https://app.example.com
+
+# ...or omit --token to be prompted (input is hidden, never echoed)
+nb auth login --url https://app.example.com
+
+nb auth status        # show the stored URL + a masked token (offline)
+```
+
+The token and URL are stored **outside any repo**, at
+`~/.config/node-banana/config.json` (honouring `XDG_CONFIG_HOME`, overridable
+with `NB_CONFIG_DIR`) with `0600` permissions. `nb auth login` verifies the
+token against the API before saving, so a stored credential always works.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `nb auth login [--token <t>] [--url <u>]` | Store and verify an API token. |
+| `nb auth status` | Show the current login state (offline, token masked). |
+| `nb workspaces list` | List the workspace (brand) the token can reach. |
+| `nb accounts list` | List connected social accounts (channels). |
+| `nb assets list [--type <t>] [--limit <n>]` | List media assets; `--type` = image \| video \| audio \| model3d \| workflow. |
+
+### Examples
+
+```
+$ nb workspaces list
+ID    NAME         SLUG
+ws_9  Acme Studio  acme-studio
+
+$ nb accounts list
+ID     PLATFORM  USERNAME  DISPLAY NAME  STATUS
+acc_1  x         acmehq    Acme          connected
+
+$ nb assets list --type image --limit 5
+ID       TYPE   MIME       SIZE   CREATED
+asset_7  image  image/png  20480  2026-06-01T00:00:00.000Z
+```
+
+## `--json` and CI usage
+
+Every command accepts a global `--json` flag (before or after the subcommand)
+that prints the exact API data as JSON — ideal for pipelines:
+
+```bash
+# machine-readable output
+nb workspaces list --json
+nb --json assets list --type video
+
+# pipe into jq
+nb accounts list --json | jq -r '.[].id'
+```
+
+Exit codes are stable for scripting:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | The API rejected the request (auth, permission, not found, server) |
+| `2` | The invocation was wrong (bad flag, missing arg, not logged in) |
+
+Structured API errors are surfaced with an actionable `fix`, e.g.:
+
+```
+$ nb accounts list
+Error: This token cannot access this resource.
+  code: forbidden
+  fix:  Use a token whose role grants social:view.
+```
+
+A typical CI step:
+
+```bash
+nb auth login --token "$NB_TOKEN" --url "$NB_URL" --json > /dev/null
+nb assets list --type image --json > assets.json || exit 1
+```
+
+## Development
+
+```bash
+pnpm --filter @node-banana/cli test:run   # unit + smoke tests
+pnpm --filter @node-banana/cli typecheck
+pnpm --filter @node-banana/cli build
+```
+
+CLI tests also run as part of the repo-root `pnpm test:run`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@node-banana/cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Command-line interface for the Node Banana public API (nb).",
+  "license": "MIT",
+  "bin": {
+    "nb": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "dependencies": {
+    "commander": "^14.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "typescript": "5.9.3",
+    "vitest": "^4.0.16"
+  }
+}

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ApiClient } from "../api/client";
+import type { AppDeps } from "../commands/context";
+import { buildProgram } from "../program";
+
+function makeDeps(): { deps: AppDeps; out: string[] } {
+  const out: string[] = [];
+  const client: ApiClient = {
+    listWorkspaces: vi.fn(async () => [{ id: "ws_1", name: "Acme", slug: "acme" }]),
+    listSocialAccounts: vi.fn(async () => []),
+    listAssets: vi.fn(async () => []),
+    verifyToken: vi.fn(async () => undefined),
+  };
+  const deps: AppDeps = {
+    loadConfig: () => ({ token: "nb_secret", url: "https://api.example.com" }),
+    saveConfig: vi.fn(),
+    clearConfig: vi.fn(),
+    createClient: vi.fn(() => client),
+    promptSecret: vi.fn(async () => "nb_prompted"),
+    io: { out: (line) => out.push(line), err: () => {} },
+  };
+  return { deps, out };
+}
+
+async function run(deps: AppDeps, argv: string[]): Promise<void> {
+  const program = buildProgram(deps);
+  program.exitOverride();
+  await program.parseAsync(argv, { from: "user" });
+}
+
+describe("buildProgram", () => {
+  it("names the binary nb and registers the top-level commands", () => {
+    const { deps } = makeDeps();
+    const program = buildProgram(deps);
+    expect(program.name()).toBe("nb");
+    const names = program.commands.map((c) => c.name()).sort();
+    expect(names).toEqual(["accounts", "assets", "auth", "workspaces"]);
+  });
+
+  it("runs `workspaces list` and prints a table", async () => {
+    const { deps, out } = makeDeps();
+    await run(deps, ["workspaces", "list"]);
+    expect(out.join("\n")).toContain("ws_1");
+  });
+
+  it("honours a global --json flag placed before the subcommand", async () => {
+    const { deps, out } = makeDeps();
+    await run(deps, ["--json", "workspaces", "list"]);
+    expect(JSON.parse(out.join("\n"))).toEqual([
+      { id: "ws_1", name: "Acme", slug: "acme" },
+    ]);
+  });
+
+  it("honours a --json flag placed after the subcommand", async () => {
+    const { deps, out } = makeDeps();
+    await run(deps, ["workspaces", "list", "--json"]);
+    expect(JSON.parse(out.join("\n"))).toEqual([
+      { id: "ws_1", name: "Acme", slug: "acme" },
+    ]);
+  });
+
+  it("wires auth status through the program", async () => {
+    const { deps, out } = makeDeps();
+    await run(deps, ["auth", "status"]);
+    expect(out.join("\n").toLowerCase()).toContain("https://api.example.com");
+  });
+});

--- a/packages/cli/src/api/__tests__/api.test.ts
+++ b/packages/cli/src/api/__tests__/api.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "../../errors/errors";
+import { createApiClient } from "../client";
+
+interface Captured {
+  url: string;
+  headers: Record<string, string>;
+}
+
+function fakeFetch(
+  body: unknown,
+  init: { status?: number } = {},
+): { fetch: typeof fetch; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const impl = (async (input: string | URL | Request, options?: RequestInit) => {
+    const headers = new Headers(options?.headers);
+    const record: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      record[key] = value;
+    });
+    calls.push({ url: String(input), headers: record });
+    return new Response(JSON.stringify(body), {
+      status: init.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetch: impl, calls };
+}
+
+const WORKSPACE = { id: "ws_1", name: "Acme", slug: "acme" };
+
+describe("createApiClient", () => {
+  it("sends a bearer token to the workspaces endpoint and returns the list", async () => {
+    const { fetch, calls } = fakeFetch({ success: true, workspaces: [WORKSPACE] });
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    const workspaces = await client.listWorkspaces();
+
+    expect(workspaces).toEqual([WORKSPACE]);
+    expect(calls[0]?.url).toBe("https://api.example.com/api/v1/workspaces");
+    expect(calls[0]?.headers.authorization).toBe("Bearer nb_secret");
+  });
+
+  it("strips a trailing slash from the base url", async () => {
+    const { fetch, calls } = fakeFetch({ success: true, workspaces: [] });
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com/",
+      fetchImpl: fetch,
+    });
+
+    await client.listWorkspaces();
+
+    expect(calls[0]?.url).toBe("https://api.example.com/api/v1/workspaces");
+  });
+
+  it("forwards type and limit query params for assets", async () => {
+    const { fetch, calls } = fakeFetch({ success: true, assets: [] });
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    await client.listAssets({ type: "image", limit: 10 });
+
+    expect(calls[0]?.url).toBe(
+      "https://api.example.com/api/v1/assets?type=image&limit=10",
+    );
+  });
+
+  it("returns social accounts from the registry-backed route", async () => {
+    const account = {
+      id: "acc_1",
+      platform: "x",
+      platformUserId: "123",
+      displayName: "Acme",
+      username: "acme",
+      avatarUrl: null,
+      tokenExpiresAt: null,
+      requiresReauth: false,
+      disabled: false,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+    const { fetch } = fakeFetch({ success: true, accounts: [account] });
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    expect(await client.listSocialAccounts()).toEqual([account]);
+  });
+
+  it("throws a structured ApiError for a registry-style error body", async () => {
+    const { fetch } = fakeFetch(
+      {
+        success: false,
+        error: {
+          code: "forbidden",
+          message: "This token cannot access this resource.",
+          fix: "Use a token whose role grants social:view.",
+        },
+      },
+      { status: 403 },
+    );
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    const error = await client.listSocialAccounts().catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.code).toBe("forbidden");
+    expect(error.fix).toBe("Use a token whose role grants social:view.");
+  });
+
+  it("throws an ApiError carrying the plain string error from /workspaces", async () => {
+    const { fetch } = fakeFetch(
+      { success: false, error: "Invalid or revoked API token." },
+      { status: 401 },
+    );
+    const client = createApiClient({
+      token: "nb_bad",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    const error = await client.listWorkspaces().catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.message).toBe("Invalid or revoked API token.");
+    expect(error.code).toBeUndefined();
+  });
+
+  it("wraps a network failure as an ApiError with a fix", async () => {
+    const impl = (async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof fetch;
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: impl,
+    });
+
+    const error = await client.listWorkspaces().catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.message).toContain("https://api.example.com");
+    expect(error.fix).toBeTruthy();
+  });
+
+  it("rejects a response whose payload violates the schema", async () => {
+    const { fetch } = fakeFetch({
+      success: true,
+      workspaces: [{ id: "ws_1" }],
+    });
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    const error = await client.listWorkspaces().catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.code).toBe("invalid_response");
+  });
+
+  it("verifyToken resolves when the token can list workspaces", async () => {
+    const { fetch } = fakeFetch({ success: true, workspaces: [WORKSPACE] });
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    await expect(client.verifyToken()).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -1,0 +1,176 @@
+import type { z } from "zod";
+
+import { ApiError } from "../errors/errors";
+import {
+  assetsResponseSchema,
+  socialAccountsResponseSchema,
+  workspacesResponseSchema,
+  type Asset,
+  type SocialAccount,
+  type Workspace,
+} from "./schemas";
+
+export interface ApiClientOptions {
+  /** Workspace-scoped API token (the `nb_...` value). */
+  token: string;
+  /** Base URL of the hosted app, e.g. `https://app.example.com`. */
+  url: string;
+  /**
+   * Injectable fetch — defaults to the global. Tests pass a fake; production
+   * uses Node's built-in fetch. The CLI never imports server code, so this is
+   * its only channel to the platform.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+export interface ApiClient {
+  listWorkspaces(): Promise<Workspace[]>;
+  listSocialAccounts(): Promise<SocialAccount[]>;
+  listAssets(options?: {
+    type?: string;
+    limit?: number;
+  }): Promise<Asset[]>;
+  /** Confirm the token is accepted; used by `nb auth login`. */
+  verifyToken(): Promise<void>;
+}
+
+interface ErrorEnvelope {
+  success: false;
+  error?: unknown;
+}
+
+function isStructuredError(
+  value: unknown,
+): value is { code?: string; message: string; fix?: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { message?: unknown }).message === "string"
+  );
+}
+
+/**
+ * Turn a non-success response body into an {@link ApiError}. Handles both API
+ * error shapes: the structured `{ code, message, fix }` (registry routes) and
+ * the bare `{ error: "..." }` string (the workspaces route).
+ */
+function toApiError(body: ErrorEnvelope, status: number): ApiError {
+  const raw = body.error;
+  if (isStructuredError(raw)) {
+    return new ApiError({
+      code: raw.code,
+      message: raw.message,
+      fix: raw.fix,
+    });
+  }
+  if (typeof raw === "string") {
+    return new ApiError({ message: raw });
+  }
+  return new ApiError({
+    message: `Request failed with status ${status}.`,
+    fix: "Check your token and API URL, then retry.",
+  });
+}
+
+/**
+ * Create a thin client over the public API. Every method issues one GET,
+ * unwraps the `{ success, ... }` envelope, validates the payload against a
+ * local schema, and surfaces failures as {@link ApiError} (exit code 1).
+ */
+export function createApiClient(options: ApiClientOptions): ApiClient {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const baseUrl = options.url.replace(/\/+$/, "");
+
+  async function requestJson(path: string): Promise<Record<string, unknown>> {
+    const url = `${baseUrl}${path}`;
+
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${options.token}`,
+          accept: "application/json",
+        },
+      });
+    } catch (cause) {
+      throw new ApiError({
+        message: `Could not reach ${baseUrl}: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+        fix: "Check the API URL (nb auth login --url ...) and your network.",
+      });
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new ApiError({
+        message: `Received a non-JSON response (status ${response.status}) from ${url}.`,
+        fix: "Confirm the API URL points at a Node Banana deployment.",
+      });
+    }
+
+    if (
+      !response.ok ||
+      (typeof body === "object" &&
+        body !== null &&
+        (body as { success?: unknown }).success === false)
+    ) {
+      throw toApiError(body as ErrorEnvelope, response.status);
+    }
+
+    return body as Record<string, unknown>;
+  }
+
+  async function requestParsed<Schema extends z.ZodTypeAny>(
+    path: string,
+    schema: Schema,
+  ): Promise<z.infer<Schema>> {
+    const body = await requestJson(path);
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      throw new ApiError({
+        code: "invalid_response",
+        message: `The API returned data in an unexpected shape for ${path}.`,
+        fix: "Update the CLI (npm i -g @node-banana/cli) so it matches the API.",
+      });
+    }
+    return parsed.data;
+  }
+
+  return {
+    async listWorkspaces() {
+      const { workspaces } = await requestParsed(
+        "/api/v1/workspaces",
+        workspacesResponseSchema,
+      );
+      return workspaces;
+    },
+
+    async listSocialAccounts() {
+      const { accounts } = await requestParsed(
+        "/api/v1/social-accounts",
+        socialAccountsResponseSchema,
+      );
+      return accounts;
+    },
+
+    async listAssets(listOptions) {
+      const params = new URLSearchParams();
+      if (listOptions?.type) params.set("type", listOptions.type);
+      if (listOptions?.limit !== undefined) {
+        params.set("limit", String(listOptions.limit));
+      }
+      const query = params.toString();
+      const path = query ? `/api/v1/assets?${query}` : "/api/v1/assets";
+      const { assets } = await requestParsed(path, assetsResponseSchema);
+      return assets;
+    },
+
+    async verifyToken() {
+      await this.listWorkspaces();
+    },
+  };
+}

--- a/packages/cli/src/api/schemas.ts
+++ b/packages/cli/src/api/schemas.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+/**
+ * Minimal Zod schemas mirroring the public API v1 response shapes.
+ *
+ * These are intentionally *duplicated* from the server's tool registry rather
+ * than imported: the registry tools pull in server-only modules (`@/lib/db`,
+ * repositories) that must never enter the CLI bundle. Keeping a tiny local copy
+ * keeps the CLI a pure API client while still validating every payload it
+ * consumes — a shape drift surfaces as a clear `invalid_response` error.
+ */
+
+export const workspaceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+});
+export type Workspace = z.infer<typeof workspaceSchema>;
+
+export const socialAccountSchema = z.object({
+  id: z.string(),
+  platform: z.string(),
+  platformUserId: z.string(),
+  displayName: z.string(),
+  username: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  tokenExpiresAt: z.string().nullable(),
+  requiresReauth: z.boolean(),
+  disabled: z.boolean(),
+  createdAt: z.string(),
+});
+export type SocialAccount = z.infer<typeof socialAccountSchema>;
+
+export const assetTypeSchema = z.enum([
+  "image",
+  "video",
+  "audio",
+  "model3d",
+  "workflow",
+]);
+export type AssetType = z.infer<typeof assetTypeSchema>;
+
+export const assetSchema = z.object({
+  id: z.string(),
+  projectId: z.string().nullable(),
+  type: assetTypeSchema,
+  mimeType: z.string().nullable(),
+  sizeBytes: z.number().nullable(),
+  width: z.number().nullable(),
+  height: z.number().nullable(),
+  durationSeconds: z.number().nullable(),
+  createdAt: z.string(),
+});
+export type Asset = z.infer<typeof assetSchema>;
+
+export const workspacesResponseSchema = z.object({
+  workspaces: z.array(workspaceSchema),
+});
+
+export const socialAccountsResponseSchema = z.object({
+  accounts: z.array(socialAccountSchema),
+});
+
+export const assetsResponseSchema = z.object({
+  assets: z.array(assetSchema),
+});

--- a/packages/cli/src/commands/__tests__/commands.test.ts
+++ b/packages/cli/src/commands/__tests__/commands.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiClient } from "../../api/client";
+import type { Asset, SocialAccount, Workspace } from "../../api/schemas";
+import { UsageError } from "../../errors/errors";
+import { authLogin, authStatus } from "../auth";
+import { accountsList } from "../accounts";
+import { assetsList } from "../assets";
+import { resolveClient, type AppDeps } from "../context";
+import { workspacesList } from "../workspaces";
+
+const WORKSPACE: Workspace = { id: "ws_1", name: "Acme", slug: "acme" };
+const ACCOUNT: SocialAccount = {
+  id: "acc_1",
+  platform: "x",
+  platformUserId: "123",
+  displayName: "Acme Co",
+  username: "acme",
+  avatarUrl: null,
+  tokenExpiresAt: null,
+  requiresReauth: false,
+  disabled: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+const ASSET: Asset = {
+  id: "asset_1",
+  projectId: null,
+  type: "image",
+  mimeType: "image/png",
+  sizeBytes: 2048,
+  width: 100,
+  height: 100,
+  durationSeconds: null,
+  createdAt: "2026-01-02T00:00:00.000Z",
+};
+
+function makeDeps(overrides: Partial<AppDeps> = {}): {
+  deps: AppDeps;
+  out: string[];
+  err: string[];
+  client: ApiClient;
+  created: Array<{ token: string; url: string }>;
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  const created: Array<{ token: string; url: string }> = [];
+
+  const client: ApiClient = {
+    listWorkspaces: vi.fn(async () => [WORKSPACE]),
+    listSocialAccounts: vi.fn(async () => [ACCOUNT]),
+    listAssets: vi.fn(async () => [ASSET]),
+    verifyToken: vi.fn(async () => undefined),
+  };
+
+  const deps: AppDeps = {
+    loadConfig: vi.fn(() => ({ token: "nb_secret", url: "https://api.example.com" })),
+    saveConfig: vi.fn(),
+    clearConfig: vi.fn(),
+    createClient: vi.fn((options) => {
+      created.push({ token: options.token, url: options.url });
+      return client;
+    }),
+    promptSecret: vi.fn(async () => "nb_prompted"),
+    io: { out: (line) => out.push(line), err: (line) => err.push(line) },
+    ...overrides,
+  };
+
+  return { deps, out, err, client, created };
+}
+
+describe("resolveClient", () => {
+  it("throws a UsageError when there is no stored config", () => {
+    const { deps } = makeDeps({ loadConfig: () => null });
+    expect(() => resolveClient(deps)).toThrow(UsageError);
+  });
+
+  it("builds a client from the stored token and url", () => {
+    const { deps, created } = makeDeps();
+    resolveClient(deps);
+    expect(created[0]).toEqual({ token: "nb_secret", url: "https://api.example.com" });
+  });
+});
+
+describe("workspaces list", () => {
+  it("prints a human table by default", async () => {
+    const { deps, out } = makeDeps();
+    await workspacesList(deps, { json: false });
+    const text = out.join("\n");
+    expect(text).toContain("ID");
+    expect(text).toContain("ws_1");
+    expect(text).toContain("Acme");
+    expect(text).toContain("acme");
+  });
+
+  it("prints exact JSON data with --json", async () => {
+    const { deps, out } = makeDeps();
+    await workspacesList(deps, { json: true });
+    expect(JSON.parse(out.join("\n"))).toEqual([WORKSPACE]);
+  });
+
+  it("shows an empty-state message when there are no workspaces", async () => {
+    const { deps, out, client } = makeDeps();
+    (client.listWorkspaces as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    await workspacesList(deps, { json: false });
+    expect(out.join("\n").toLowerCase()).toContain("no workspaces");
+  });
+});
+
+describe("accounts list", () => {
+  it("prints a human table including platform and username", async () => {
+    const { deps, out } = makeDeps();
+    await accountsList(deps, { json: false });
+    const text = out.join("\n");
+    expect(text).toContain("acc_1");
+    expect(text).toContain("x");
+    expect(text).toContain("acme");
+  });
+
+  it("prints exact JSON data with --json", async () => {
+    const { deps, out } = makeDeps();
+    await accountsList(deps, { json: true });
+    expect(JSON.parse(out.join("\n"))).toEqual([ACCOUNT]);
+  });
+});
+
+describe("assets list", () => {
+  it("forwards type and limit filters to the client", async () => {
+    const { deps, client } = makeDeps();
+    await assetsList(deps, { json: false, type: "image", limit: 5 });
+    expect(client.listAssets).toHaveBeenCalledWith({ type: "image", limit: 5 });
+  });
+
+  it("prints exact JSON data with --json", async () => {
+    const { deps, out } = makeDeps();
+    await assetsList(deps, { json: true });
+    expect(JSON.parse(out.join("\n"))).toEqual([ASSET]);
+  });
+});
+
+describe("auth login", () => {
+  it("verifies and stores a token passed via --token", async () => {
+    const { deps, out } = makeDeps({ loadConfig: () => null });
+    await authLogin(deps, {
+      token: "nb_new",
+      url: "https://app.example.com",
+      json: false,
+    });
+
+    expect(deps.createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "nb_new", url: "https://app.example.com" }),
+    );
+    expect(deps.saveConfig).toHaveBeenCalledWith({
+      token: "nb_new",
+      url: "https://app.example.com",
+    });
+    expect(out.join("\n").toLowerCase()).toContain("logged in");
+  });
+
+  it("prompts for the token when --token is omitted", async () => {
+    const { deps } = makeDeps({ loadConfig: () => null });
+    await authLogin(deps, { url: "https://app.example.com", json: false });
+
+    expect(deps.promptSecret).toHaveBeenCalled();
+    expect(deps.saveConfig).toHaveBeenCalledWith({
+      token: "nb_prompted",
+      url: "https://app.example.com",
+    });
+  });
+
+  it("does not persist a token the API rejects", async () => {
+    const { deps, client } = makeDeps({ loadConfig: () => null });
+    (client.verifyToken as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Invalid or revoked API token."),
+    );
+
+    await expect(
+      authLogin(deps, { token: "nb_bad", url: "https://app.example.com", json: false }),
+    ).rejects.toThrow();
+    expect(deps.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it("emits machine-readable json on success", async () => {
+    const { deps, out } = makeDeps({ loadConfig: () => null });
+    await authLogin(deps, {
+      token: "nb_new",
+      url: "https://app.example.com",
+      json: true,
+    });
+    expect(JSON.parse(out.join("\n"))).toEqual({
+      authenticated: true,
+      url: "https://app.example.com",
+    });
+  });
+});
+
+describe("auth status", () => {
+  it("reports the authenticated url and a masked token", async () => {
+    const { deps, out } = makeDeps();
+    await authStatus(deps, { json: false });
+    const text = out.join("\n");
+    expect(text.toLowerCase()).toContain("https://api.example.com");
+    // The raw token must never be printed in full.
+    expect(text).not.toContain("nb_secret");
+  });
+
+  it("reports not-authenticated as json when no config exists", async () => {
+    const { deps, out } = makeDeps({ loadConfig: () => null });
+    await authStatus(deps, { json: true });
+    expect(JSON.parse(out.join("\n"))).toEqual({
+      authenticated: false,
+      url: null,
+    });
+  });
+});

--- a/packages/cli/src/commands/accounts.ts
+++ b/packages/cli/src/commands/accounts.ts
@@ -1,0 +1,43 @@
+import type { SocialAccount } from "../api/schemas";
+import { formatJson, renderTable } from "../output/output";
+import { resolveClient, type AppDeps } from "./context";
+
+/** Connection status for the human table, collapsing the boolean flags. */
+function statusOf(account: SocialAccount): string {
+  if (account.disabled) return "disabled";
+  if (account.requiresReauth) return "needs-reauth";
+  return "connected";
+}
+
+/**
+ * `nb accounts list` — the connected social accounts (channels) for the
+ * token's workspace. Ids are used to target posts.
+ */
+export async function accountsList(
+  deps: AppDeps,
+  opts: { json: boolean },
+): Promise<void> {
+  const client = resolveClient(deps);
+  const accounts = await client.listSocialAccounts();
+
+  if (opts.json) {
+    deps.io.out(formatJson(accounts));
+    return;
+  }
+
+  if (accounts.length === 0) {
+    deps.io.out("No social accounts connected to this workspace.");
+    return;
+  }
+
+  const rows = accounts.map((a) => [
+    a.id,
+    a.platform,
+    a.username ?? "-",
+    a.displayName,
+    statusOf(a),
+  ]);
+  deps.io.out(
+    renderTable(["ID", "PLATFORM", "USERNAME", "DISPLAY NAME", "STATUS"], rows),
+  );
+}

--- a/packages/cli/src/commands/assets.ts
+++ b/packages/cli/src/commands/assets.ts
@@ -1,0 +1,39 @@
+import { formatJson, renderTable } from "../output/output";
+import { resolveClient, type AppDeps } from "./context";
+
+/**
+ * `nb assets list` — media assets in the token's workspace, optionally filtered
+ * by `--type` and capped by `--limit` (both forwarded to and validated by the
+ * API). Ids are referenced when composing posts.
+ */
+export async function assetsList(
+  deps: AppDeps,
+  opts: { json: boolean; type?: string; limit?: number },
+): Promise<void> {
+  const client = resolveClient(deps);
+
+  const listOptions: { type?: string; limit?: number } = {};
+  if (opts.type !== undefined) listOptions.type = opts.type;
+  if (opts.limit !== undefined) listOptions.limit = opts.limit;
+
+  const assets = await client.listAssets(listOptions);
+
+  if (opts.json) {
+    deps.io.out(formatJson(assets));
+    return;
+  }
+
+  if (assets.length === 0) {
+    deps.io.out("No assets found for this workspace.");
+    return;
+  }
+
+  const rows = assets.map((a) => [
+    a.id,
+    a.type,
+    a.mimeType ?? "-",
+    a.sizeBytes === null ? "-" : String(a.sizeBytes),
+    a.createdAt,
+  ]);
+  deps.io.out(renderTable(["ID", "TYPE", "MIME", "SIZE", "CREATED"], rows));
+}

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,71 @@
+import { DEFAULT_API_URL } from "../constants";
+import { UsageError } from "../errors/errors";
+import { formatJson } from "../output/output";
+import type { AppDeps } from "./context";
+
+/** Mask a token for display so `nb auth status` never prints it in full. */
+function maskToken(token: string): string {
+  if (token.length <= 6) return "***";
+  return `${token.slice(0, 3)}…${token.slice(-2)}`;
+}
+
+/**
+ * `nb auth login` — resolve a token (from `--token` or a hidden prompt) and a
+ * URL (from `--url`, the existing config, or the default), verify it against
+ * the API, and only then persist it. A rejected token is never written, so a
+ * stored credential always works.
+ */
+export async function authLogin(
+  deps: AppDeps,
+  opts: { token?: string; url?: string; json: boolean },
+): Promise<void> {
+  const url = opts.url ?? deps.loadConfig()?.url ?? DEFAULT_API_URL;
+  const rawToken = opts.token ?? (await deps.promptSecret("API token: "));
+  const token = rawToken.trim();
+
+  if (token.length === 0) {
+    throw new UsageError("No token provided. Pass --token or enter one when prompted.");
+  }
+
+  // Verify before persisting; verifyToken throws ApiError on rejection.
+  const client = deps.createClient({ token, url });
+  await client.verifyToken();
+
+  deps.saveConfig({ token, url });
+
+  if (opts.json) {
+    deps.io.out(formatJson({ authenticated: true, url }));
+  } else {
+    deps.io.out(`Logged in to ${url}.`);
+  }
+}
+
+/**
+ * `nb auth status` — report whether a token is stored and for which URL, with
+ * the token masked. Offline by design (no network), so it is fast and usable
+ * even when the API is unreachable.
+ */
+export async function authStatus(
+  deps: AppDeps,
+  opts: { json: boolean },
+): Promise<void> {
+  const config = deps.loadConfig();
+
+  if (!config) {
+    if (opts.json) {
+      deps.io.out(formatJson({ authenticated: false, url: null }));
+    } else {
+      deps.io.out("Not logged in. Run `nb auth login` to authenticate.");
+    }
+    return;
+  }
+
+  const masked = maskToken(config.token);
+  if (opts.json) {
+    deps.io.out(
+      formatJson({ authenticated: true, url: config.url, token: masked }),
+    );
+  } else {
+    deps.io.out(`Logged in to ${config.url} (token ${masked}).`);
+  }
+}

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -1,0 +1,37 @@
+import type { ApiClient, ApiClientOptions } from "../api/client";
+import type { StoredConfig } from "../config/config";
+import { UsageError } from "../errors/errors";
+
+/** Sink for user-facing output — stdout for data, stderr for diagnostics. */
+export interface Io {
+  out: (line: string) => void;
+  err: (line: string) => void;
+}
+
+/**
+ * Everything a command needs, injected rather than imported, so commands are
+ * pure and unit-testable: no real filesystem, network, or TTY in tests.
+ */
+export interface AppDeps {
+  loadConfig: () => StoredConfig | null;
+  saveConfig: (config: StoredConfig) => void;
+  clearConfig: () => void;
+  createClient: (options: ApiClientOptions) => ApiClient;
+  /** Read a secret (the API token) from the terminal without echoing it. */
+  promptSecret: (question: string) => Promise<string>;
+  io: Io;
+}
+
+/**
+ * Build an API client from the stored credentials, or fail with a usage error
+ * (exit 2) telling the user to log in. Every read command begins here.
+ */
+export function resolveClient(deps: AppDeps): ApiClient {
+  const config = deps.loadConfig();
+  if (!config) {
+    throw new UsageError(
+      "Not logged in. Run `nb auth login --token <token> --url <url>` first.",
+    );
+  }
+  return deps.createClient({ token: config.token, url: config.url });
+}

--- a/packages/cli/src/commands/workspaces.ts
+++ b/packages/cli/src/commands/workspaces.ts
@@ -1,0 +1,27 @@
+import { formatJson, renderTable } from "../output/output";
+import { resolveClient, type AppDeps } from "./context";
+
+/**
+ * `nb workspaces list` — the agent's first call, confirming which brand the
+ * token is scoped to. `--json` emits the exact API array; otherwise a table.
+ */
+export async function workspacesList(
+  deps: AppDeps,
+  opts: { json: boolean },
+): Promise<void> {
+  const client = resolveClient(deps);
+  const workspaces = await client.listWorkspaces();
+
+  if (opts.json) {
+    deps.io.out(formatJson(workspaces));
+    return;
+  }
+
+  if (workspaces.length === 0) {
+    deps.io.out("No workspaces found for this token.");
+    return;
+  }
+
+  const rows = workspaces.map((w) => [w.id, w.name, w.slug]);
+  deps.io.out(renderTable(["ID", "NAME", "SLUG"], rows));
+}

--- a/packages/cli/src/config/__tests__/config.test.ts
+++ b/packages/cli/src/config/__tests__/config.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  clearConfig,
+  getConfigPath,
+  loadConfig,
+  saveConfig,
+} from "../config";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "nb-cli-config-"));
+  process.env.NB_CONFIG_DIR = dir;
+});
+
+afterEach(() => {
+  delete process.env.NB_CONFIG_DIR;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("config storage", () => {
+  it("resolves the config path inside the NB_CONFIG_DIR override", () => {
+    expect(getConfigPath()).toBe(join(dir, "config.json"));
+  });
+
+  it("returns null when no config file exists yet", () => {
+    expect(loadConfig()).toBeNull();
+  });
+
+  it("round-trips a saved token and url", () => {
+    saveConfig({ token: "nb_secret", url: "https://api.example.com" });
+
+    expect(loadConfig()).toEqual({
+      token: "nb_secret",
+      url: "https://api.example.com",
+    });
+  });
+
+  it("writes the config file with 0600 permissions", () => {
+    saveConfig({ token: "nb_secret", url: "https://api.example.com" });
+
+    const mode = statSync(getConfigPath()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("creates missing parent directories when saving", () => {
+    // The temp dir exists but the nested node-banana dir is created lazily.
+    delete process.env.NB_CONFIG_DIR;
+    const nested = join(dir, "deep", "nested");
+    process.env.NB_CONFIG_DIR = nested;
+
+    saveConfig({ token: "nb_secret", url: "https://api.example.com" });
+
+    expect(existsSync(join(nested, "config.json"))).toBe(true);
+  });
+
+  it("overwrites an existing config on save", () => {
+    saveConfig({ token: "nb_first", url: "https://a.example.com" });
+    saveConfig({ token: "nb_second", url: "https://b.example.com" });
+
+    expect(loadConfig()).toEqual({
+      token: "nb_second",
+      url: "https://b.example.com",
+    });
+  });
+
+  it("clears a stored config", () => {
+    saveConfig({ token: "nb_secret", url: "https://api.example.com" });
+    clearConfig();
+
+    expect(loadConfig()).toBeNull();
+    expect(existsSync(getConfigPath())).toBe(false);
+  });
+
+  it("treats a corrupt config file as absent rather than throwing", () => {
+    saveConfig({ token: "nb_secret", url: "https://api.example.com" });
+    // Simulate corruption by writing garbage over the file.
+    const { writeFileSync } = require("node:fs") as typeof import("node:fs");
+    writeFileSync(getConfigPath(), "{ not json");
+
+    expect(loadConfig()).toBeNull();
+  });
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1,0 +1,90 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/**
+ * Persisted CLI credentials. Deliberately tiny: a workspace-scoped API token
+ * and the API base URL it belongs to. Stored OUTSIDE any repo (see
+ * {@link getConfigDir}) so a token never rides along in version control.
+ */
+export interface StoredConfig {
+  token: string;
+  url: string;
+}
+
+const CONFIG_FILE = "config.json";
+
+/**
+ * Resolve the directory holding the CLI config, honouring (in order):
+ *  1. `NB_CONFIG_DIR` — explicit override, used by tests and power users.
+ *  2. `XDG_CONFIG_HOME/node-banana` — the freedesktop convention.
+ *  3. `~/.config/node-banana` — the portable default.
+ *
+ * Never a location inside the working repo, so credentials cannot be committed.
+ */
+export function getConfigDir(): string {
+  const override = process.env.NB_CONFIG_DIR;
+  if (override && override.length > 0) return override;
+
+  const xdg = process.env.XDG_CONFIG_HOME;
+  if (xdg && xdg.length > 0) return join(xdg, "node-banana");
+
+  return join(homedir(), ".config", "node-banana");
+}
+
+/** Absolute path to the config JSON file. */
+export function getConfigPath(): string {
+  return join(getConfigDir(), CONFIG_FILE);
+}
+
+/**
+ * Load the stored config, or `null` when it is absent or unreadable. A corrupt
+ * file is treated as "not logged in" rather than crashing every command — the
+ * user recovers by running `nb auth login` again.
+ */
+export function loadConfig(): StoredConfig | null {
+  const path = getConfigPath();
+  if (!existsSync(path)) return null;
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof (parsed as StoredConfig).token === "string" &&
+      typeof (parsed as StoredConfig).url === "string"
+    ) {
+      const { token, url } = parsed as StoredConfig;
+      return { token, url };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the config with owner-only permissions. The parent directory is
+ * created 0700 and the file 0600 (and re-chmod'd, since an existing file keeps
+ * its old mode through `writeFileSync`) so no other local user can read the
+ * token.
+ */
+export function saveConfig(config: StoredConfig): void {
+  const path = getConfigPath();
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+/** Remove the stored config if present. A no-op when already absent. */
+export function clearConfig(): void {
+  const path = getConfigPath();
+  rmSync(path, { force: true });
+}

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Default API base URL when the user has not stored or passed one. Local dev
+ * points here; hosted users override with `nb auth login --url https://...`.
+ */
+export const DEFAULT_API_URL = "http://localhost:3000";

--- a/packages/cli/src/deps.ts
+++ b/packages/cli/src/deps.ts
@@ -1,0 +1,23 @@
+import { createApiClient } from "./api/client";
+import type { AppDeps } from "./commands/context";
+import { clearConfig, loadConfig, saveConfig } from "./config/config";
+import { promptSecret } from "./prompt";
+
+/**
+ * Wire the real dependencies: filesystem-backed config, a live API client,
+ * a TTY secret prompt, and stdout/stderr writers. This is the only place the
+ * CLI touches the outside world; commands stay pure and testable behind it.
+ */
+export function buildDefaultDeps(): AppDeps {
+  return {
+    loadConfig,
+    saveConfig,
+    clearConfig,
+    createClient: (options) => createApiClient(options),
+    promptSecret,
+    io: {
+      out: (line) => process.stdout.write(`${line}\n`),
+      err: (line) => process.stderr.write(`${line}\n`),
+    },
+  };
+}

--- a/packages/cli/src/errors/__tests__/errors.test.ts
+++ b/packages/cli/src/errors/__tests__/errors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ApiError,
+  CliError,
+  EXIT_API_ERROR,
+  EXIT_OK,
+  EXIT_USAGE,
+  UsageError,
+  renderError,
+} from "../errors";
+
+describe("exit codes", () => {
+  it("uses the documented codes", () => {
+    expect(EXIT_OK).toBe(0);
+    expect(EXIT_API_ERROR).toBe(1);
+    expect(EXIT_USAGE).toBe(2);
+  });
+});
+
+describe("error classes", () => {
+  it("maps a usage error to exit code 2", () => {
+    expect(new UsageError("bad flag").exitCode).toBe(EXIT_USAGE);
+  });
+
+  it("maps an API error to exit code 1", () => {
+    expect(new ApiError({ message: "boom" }).exitCode).toBe(EXIT_API_ERROR);
+  });
+
+  it("carries the structured code and fix from the API", () => {
+    const error = new ApiError({
+      code: "forbidden",
+      message: "This token cannot access this resource.",
+      fix: "Use a token whose role grants social:view.",
+    });
+
+    expect(error.code).toBe("forbidden");
+    expect(error.fix).toBe("Use a token whose role grants social:view.");
+    expect(error).toBeInstanceOf(CliError);
+  });
+});
+
+describe("renderError", () => {
+  it("renders a plain error as a single line", () => {
+    expect(renderError(new UsageError("unknown command 'frob'"))).toBe(
+      "Error: unknown command 'frob'",
+    );
+  });
+
+  it("renders a structured API error with its code and fix", () => {
+    const error = new ApiError({
+      code: "forbidden",
+      message: "This token cannot access this resource.",
+      fix: "Use a token whose role grants social:view.",
+    });
+
+    expect(renderError(error)).toBe(
+      [
+        "Error: This token cannot access this resource.",
+        "  code: forbidden",
+        "  fix:  Use a token whose role grants social:view.",
+      ].join("\n"),
+    );
+  });
+
+  it("omits code/fix lines when the API error only carries a message", () => {
+    // The /workspaces route returns `error: <string>` with no structured shape.
+    expect(renderError(new ApiError({ message: "Invalid or revoked API token." }))).toBe(
+      "Error: Invalid or revoked API token.",
+    );
+  });
+
+  it("renders an unknown thrown value defensively", () => {
+    expect(renderError("kaboom")).toBe("Error: kaboom");
+    expect(renderError(new Error("native failure"))).toBe(
+      "Error: native failure",
+    );
+  });
+});

--- a/packages/cli/src/errors/errors.ts
+++ b/packages/cli/src/errors/errors.ts
@@ -1,0 +1,68 @@
+/**
+ * Process exit codes, part of the CLI's contract with scripts and CI:
+ *  - 0  success
+ *  - 1  the API rejected the request (auth, permission, not found, server)
+ *  - 2  the invocation itself was wrong (bad flag, missing arg, not logged in)
+ */
+export const EXIT_OK = 0;
+export const EXIT_API_ERROR = 1;
+export const EXIT_USAGE = 2;
+
+/** Base for every error the CLI raises deliberately; carries its exit code. */
+export abstract class CliError extends Error {
+  abstract readonly exitCode: number;
+}
+
+/**
+ * A misuse of the CLI itself — unknown command, bad flag, or "not logged in".
+ * Distinct from an API failure so CI can tell a broken invocation (exit 2) from
+ * a rejected request (exit 1).
+ */
+export class UsageError extends CliError {
+  readonly exitCode = EXIT_USAGE;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+    Object.setPrototypeOf(this, UsageError.prototype);
+  }
+}
+
+/**
+ * A failure returned by the public API. Wraps both error shapes the API emits:
+ * the structured `{ code, message, fix }` from registry-backed routes and the
+ * bare `{ error: string }` from the workspaces route (code/fix then absent).
+ */
+export class ApiError extends CliError {
+  readonly exitCode = EXIT_API_ERROR;
+  readonly code: string | undefined;
+  readonly fix: string | undefined;
+
+  constructor(fields: { code?: string; message: string; fix?: string }) {
+    super(fields.message);
+    this.name = "ApiError";
+    this.code = fields.code;
+    this.fix = fields.fix;
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+}
+
+/**
+ * Render any thrown value as a human-readable message for stderr. A structured
+ * {@link ApiError} gains `code:` and `fix:` lines so an operator (or agent)
+ * sees the actionable next step; everything else collapses to one line.
+ */
+export function renderError(error: unknown): string {
+  if (error instanceof ApiError) {
+    const lines = [`Error: ${error.message}`];
+    if (error.code) lines.push(`  code: ${error.code}`);
+    if (error.fix) lines.push(`  fix:  ${error.fix}`);
+    return lines.join("\n");
+  }
+
+  if (error instanceof Error) {
+    return `Error: ${error.message}`;
+  }
+
+  return `Error: ${String(error)}`;
+}

--- a/packages/cli/src/errors/errors.ts
+++ b/packages/cli/src/errors/errors.ts
@@ -38,7 +38,11 @@ export class ApiError extends CliError {
   readonly code: string | undefined;
   readonly fix: string | undefined;
 
-  constructor(fields: { code?: string; message: string; fix?: string }) {
+  constructor(fields: {
+    code?: string | undefined;
+    message: string;
+    fix?: string | undefined;
+  }) {
     super(fields.message);
     this.name = "ApiError";
     this.code = fields.code;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import { CommanderError } from "commander";
+
+import { buildDefaultDeps } from "./deps";
+import { CliError, EXIT_OK, EXIT_USAGE, renderError } from "./errors/errors";
+import { buildProgram } from "./program";
+
+/**
+ * CLI entry point. Runs the command tree and maps any failure to an exit code:
+ *  - commander help/version   → 0
+ *  - commander usage errors   → 2 (message already printed by commander)
+ *  - CliError (usage/API)     → its own exit code, with a rendered message
+ *  - anything else            → 1
+ */
+async function main(): Promise<number> {
+  const deps = buildDefaultDeps();
+  const program = buildProgram(deps);
+  program.exitOverride();
+
+  try {
+    await program.parseAsync(process.argv);
+    return EXIT_OK;
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      if (
+        error.code === "commander.helpDisplayed" ||
+        error.code === "commander.help" ||
+        error.code === "commander.version"
+      ) {
+        return EXIT_OK;
+      }
+      // Usage errors: commander has already written its own message to stderr.
+      return EXIT_USAGE;
+    }
+
+    if (error instanceof CliError) {
+      deps.io.err(renderError(error));
+      return error.exitCode;
+    }
+
+    deps.io.err(renderError(error));
+    return 1;
+  }
+}
+
+void main().then((code) => {
+  process.exitCode = code;
+});

--- a/packages/cli/src/output/__tests__/output.test.ts
+++ b/packages/cli/src/output/__tests__/output.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { formatJson, renderTable } from "../output";
+
+describe("formatJson", () => {
+  it("pretty-prints with two-space indentation", () => {
+    expect(formatJson({ a: 1, b: ["x"] })).toBe(
+      '{\n  "a": 1,\n  "b": [\n    "x"\n  ]\n}',
+    );
+  });
+
+  it("preserves the exact data shape without reordering keys", () => {
+    // Machine-readable mode must echo the API payload verbatim.
+    const payload = { workspaces: [{ id: "ws_1", name: "Acme", slug: "acme" }] };
+    expect(JSON.parse(formatJson(payload))).toEqual(payload);
+  });
+});
+
+describe("renderTable", () => {
+  it("aligns columns to their widest cell and trims trailing space", () => {
+    const table = renderTable(
+      ["ID", "NAME"],
+      [
+        ["a", "Alpha"],
+        ["bb", "B"],
+      ],
+    );
+
+    expect(table).toBe(["ID  NAME", "a   Alpha", "bb  B"].join("\n"));
+  });
+
+  it("renders the header row alone when there are no data rows", () => {
+    expect(renderTable(["ID", "NAME"], [])).toBe("ID  NAME");
+  });
+
+  it("widens a column to fit a header longer than every cell", () => {
+    const table = renderTable(["PLATFORM", "ID"], [["x", "1"]]);
+    expect(table).toBe(["PLATFORM  ID", "x         1"].join("\n"));
+  });
+});

--- a/packages/cli/src/output/output.ts
+++ b/packages/cli/src/output/output.ts
@@ -1,0 +1,36 @@
+/**
+ * Serialize a value as machine-readable JSON for `--json` mode. Two-space
+ * indented and key-order-preserving, so CI pipelines see the API payload
+ * verbatim.
+ */
+export function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Render a fixed-width text table for human (non-`--json`) output.
+ *
+ * Each column is padded to its widest cell (or its header, whichever is
+ * larger); columns are separated by two spaces and trailing whitespace is
+ * trimmed per line. With no data rows, only the header row is returned.
+ */
+export function renderTable(
+  headers: readonly string[],
+  rows: readonly (readonly string[])[],
+): string {
+  const widths = headers.map((header, column) => {
+    const cellWidth = rows.reduce(
+      (max, row) => Math.max(max, (row[column] ?? "").length),
+      0,
+    );
+    return Math.max(header.length, cellWidth);
+  });
+
+  const formatRow = (cells: readonly string[]): string =>
+    headers
+      .map((_, column) => (cells[column] ?? "").padEnd(widths[column] ?? 0))
+      .join("  ")
+      .trimEnd();
+
+  return [formatRow(headers), ...rows.map(formatRow)].join("\n");
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,0 +1,105 @@
+import { Command } from "commander";
+
+import { accountsList } from "./commands/accounts";
+import { assetsList } from "./commands/assets";
+import { authLogin, authStatus } from "./commands/auth";
+import type { AppDeps } from "./commands/context";
+import { UsageError } from "./errors/errors";
+import { workspacesList } from "./commands/workspaces";
+
+/**
+ * Read the effective `--json` flag, accepting it either globally (before the
+ * subcommand) or on the leaf command (after it). `optsWithGlobals` merges the
+ * command chain, so declaring `--json` on both positions makes both work.
+ */
+function wantsJson(command: Command): boolean {
+  return Boolean(command.optsWithGlobals().json);
+}
+
+function withJson(command: Command): Command {
+  return command.option("--json", "output machine-readable JSON");
+}
+
+/**
+ * Build the `nb` command tree from injected dependencies. Every action is a
+ * thin call into a command function; no business logic lives here. Errors
+ * thrown by command functions propagate to the caller (index.ts), which maps
+ * them to exit codes.
+ */
+export function buildProgram(deps: AppDeps): Command {
+  const program = new Command();
+  program
+    .name("nb")
+    .description("Node Banana CLI — drive the public API from a terminal or CI.")
+    .option("--json", "output machine-readable JSON")
+    .enablePositionalOptions();
+
+  const auth = program.command("auth").description("Authenticate the CLI.");
+
+  withJson(
+    auth
+      .command("login")
+      .description("Store and verify an API token.")
+      .option("--token <token>", "workspace-scoped API token (nb_...)")
+      .option("--url <url>", "API base URL, e.g. https://app.example.com"),
+  ).action(async (_opts, command: Command) => {
+    const options = command.opts<{ token?: string; url?: string }>();
+    await authLogin(deps, {
+      json: wantsJson(command),
+      ...(options.token !== undefined ? { token: options.token } : {}),
+      ...(options.url !== undefined ? { url: options.url } : {}),
+    });
+  });
+
+  withJson(auth.command("status").description("Show the stored login state.")).action(
+    async (_opts, command: Command) => {
+      await authStatus(deps, { json: wantsJson(command) });
+    },
+  );
+
+  const workspaces = program
+    .command("workspaces")
+    .description("Workspaces (brands) this token can reach.");
+  withJson(workspaces.command("list").description("List workspaces.")).action(
+    async (_opts, command: Command) => {
+      await workspacesList(deps, { json: wantsJson(command) });
+    },
+  );
+
+  const accounts = program
+    .command("accounts")
+    .description("Connected social accounts (channels).");
+  withJson(accounts.command("list").description("List social accounts.")).action(
+    async (_opts, command: Command) => {
+      await accountsList(deps, { json: wantsJson(command) });
+    },
+  );
+
+  const assets = program.command("assets").description("Workspace media assets.");
+  withJson(
+    assets
+      .command("list")
+      .description("List media assets.")
+      .option(
+        "--type <type>",
+        "filter by type: image | video | audio | model3d | workflow",
+      )
+      .option("--limit <n>", "maximum number of assets (1-200)"),
+  ).action(async (_opts, command: Command) => {
+    const options = command.opts<{ type?: string; limit?: string }>();
+    let limit: number | undefined;
+    if (options.limit !== undefined) {
+      limit = Number(options.limit);
+      if (!Number.isInteger(limit) || limit < 1) {
+        throw new UsageError("--limit must be a positive integer.");
+      }
+    }
+    await assetsList(deps, {
+      json: wantsJson(command),
+      ...(options.type !== undefined ? { type: options.type } : {}),
+      ...(limit !== undefined ? { limit } : {}),
+    });
+  });
+
+  return program;
+}

--- a/packages/cli/src/prompt.ts
+++ b/packages/cli/src/prompt.ts
@@ -1,0 +1,33 @@
+import { createInterface } from "node:readline";
+
+/**
+ * Read a secret from the terminal without echoing keystrokes. Used for the API
+ * token in `nb auth login` when `--token` is not supplied, so the token never
+ * lands in shell history or on-screen. Falls back gracefully on a non-TTY.
+ */
+export function promptSecret(question: string): Promise<string> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+  });
+
+  // Suppress echo of typed characters while still showing the prompt text.
+  const mutable = rl as unknown as {
+    output?: { write: (chunk: string) => void };
+    _writeToOutput?: (chunk: string) => void;
+  };
+  mutable._writeToOutput = (chunk: string) => {
+    if (chunk.includes(question)) {
+      mutable.output?.write(chunk);
+    }
+  };
+
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      process.stdout.write("\n");
+      resolve(answer);
+    });
+  });
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/__tests__/**", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,25 @@ importers:
         specifier: ^4.0.16
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.14(@types/node@24.10.1)(typescript@5.9.3))(tsx@4.21.0)
 
+  packages/cli:
+    dependencies:
+      commander:
+        specifier: ^14.0.0
+        version: 14.0.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.14(@types/node@24.10.1)(typescript@5.9.3))(tsx@4.21.0)
+
 packages:
 
   '@acemir/cssom@0.9.30':
@@ -965,12 +984,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
     engines: {node: '>=18'}
@@ -985,12 +998,6 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1013,12 +1020,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.27.4':
     resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
     engines: {node: '>=18'}
@@ -1033,12 +1034,6 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1061,12 +1056,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
@@ -1081,12 +1070,6 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1109,12 +1092,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
@@ -1129,12 +1106,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1157,12 +1128,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
@@ -1177,12 +1142,6 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1205,12 +1164,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
@@ -1225,12 +1178,6 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1253,12 +1200,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
@@ -1273,12 +1214,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1301,12 +1236,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
@@ -1321,12 +1250,6 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1349,12 +1272,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.4':
     resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
@@ -1363,12 +1280,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1391,12 +1302,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.27.4':
     resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
     engines: {node: '>=18'}
@@ -1405,12 +1310,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1433,12 +1332,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.27.4':
     resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
     engines: {node: '>=18'}
@@ -1447,12 +1340,6 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1475,12 +1362,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.27.4':
     resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
     engines: {node: '>=18'}
@@ -1495,12 +1376,6 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1523,12 +1398,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
@@ -1543,12 +1412,6 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -4525,11 +4388,6 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8596,9 +8454,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
@@ -8606,9 +8461,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.2':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
@@ -8620,9 +8472,6 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.2':
-    optional: true
-
   '@esbuild/android-arm@0.27.4':
     optional: true
 
@@ -8630,9 +8479,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.27.2':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
@@ -8644,9 +8490,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
@@ -8654,9 +8497,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
@@ -8668,9 +8508,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
@@ -8678,9 +8515,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -8692,9 +8526,6 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
@@ -8702,9 +8533,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.2':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
@@ -8716,9 +8544,6 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
@@ -8726,9 +8551,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
@@ -8740,9 +8562,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
@@ -8750,9 +8569,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -8764,9 +8580,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
@@ -8774,9 +8587,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
@@ -8788,16 +8598,10 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.2':
-    optional: true
-
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
@@ -8809,16 +8613,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
@@ -8830,16 +8628,10 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
@@ -8851,9 +8643,6 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
@@ -8861,9 +8650,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.2':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
@@ -8875,9 +8661,6 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
@@ -8885,9 +8668,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -12035,35 +11815,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
-
-  esbuild@0.27.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -15253,7 +15004,7 @@ snapshots:
 
   vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# pnpm workspace definition.
+#
+# The root Node Banana Next.js app is always part of the workspace implicitly
+# (pnpm always includes the root package), so it is intentionally NOT listed
+# here — listing it is unnecessary and its build/scripts stay untouched.
+# Only the additional workspace packages need globbing.
+packages:
+  - "packages/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "packages"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      // CLI workspace package tests run in the same root `pnpm test:run`
+      // invocation. They rely only on Node built-ins + a stubbed global fetch,
+      // so the shared jsdom environment is harmless for them.
+      "packages/*/src/**/*.{test,spec}.{ts,tsx}",
+    ],
     setupFiles: ["./src/test/setup.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
Closes #103. Part of PRD #100 — completes the agent surface trio (API tokens → MCP → CLI). **Stacked on #126** — merge order: #123 → #126 → this.

- Repo converted to pnpm workspaces (`packages/*`; root app implicitly included and untouched — build/tests/scripts identical).
- `packages/cli` → `@node-banana/cli`, bin **`nb`**, deps only commander + zod. Pure API client: imports zero server code (minimal response schemas duplicated locally and runtime-validated — drift surfaces as `invalid_response` rather than silent breakage).
- Commands: `nb auth login` (verifies before saving; token in `~/.config/node-banana/config.json`, 0700/0600, XDG-aware), `nb auth status` (masked), `nb workspaces|accounts|assets list`, global `--json` for CI. Exit codes: 0 ok / 1 API error / 2 usage. Structured `{code,message,fix}` errors render helpfully.
- CLI tests run inside the root `pnpm test:run` via one added vitest include glob; root tsconfig excludes `packages` so app typecheck/build stay app-only.
- READMEs: root pointer + full package doc (install, auth, examples, CI usage).

50 new tests (re-run by reviewer). Root suite green except the 2 tracked pre-existing failures; root typecheck clean; root build unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)