### PR TITLE
feat: migrate chat + quickstart to BYOK resolution (#109)

### DIFF
--- a/src/app/api/chat/__tests__/route.test.ts
+++ b/src/app/api/chat/__tests__/route.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Use vi.hoisted so mocks are available inside hoisted vi.mock factories.
+const { mockStreamText, mockCreateGoogleGenerativeAI, mockGoogleProviderFn } = vi.hoisted(() => {
+  const mockGoogleProviderFn = vi.fn((modelId: string) => ({ modelId }));
+  const mockCreateGoogleGenerativeAI = vi.fn((config: { apiKey: string }) => {
+    mockCreateGoogleGenerativeAI.lastCalledWith = config;
+    return mockGoogleProviderFn;
+  }) as unknown as ReturnType<typeof vi.fn> & { lastCalledWith?: { apiKey: string } };
+  const mockStreamText = vi.fn(() => ({
+    toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+  }));
+  return { mockStreamText, mockCreateGoogleGenerativeAI, mockGoogleProviderFn };
+});
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    streamText: mockStreamText,
+    convertToModelMessages: vi.fn(async (messages: unknown) => messages),
+    stepCountIs: vi.fn(() => () => false),
+  };
+});
+
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: mockCreateGoogleGenerativeAI,
+}));
+
+vi.mock("@/lib/chat/tools", () => ({
+  createChatTools: vi.fn(() => ({})),
+  buildEditSystemPrompt: vi.fn(() => "system prompt"),
+}));
+
+vi.mock("@/lib/chat/contextBuilder", () => ({
+  buildWorkflowContext: vi.fn(() => ({})),
+}));
+
+vi.mock("@/lib/chat/subgraphExtractor", () => ({
+  extractSubgraph: vi.fn(() => ({
+    selectedNodes: [],
+    selectedEdges: [],
+    restSummary: undefined,
+  })),
+}));
+
+// BYOK vault shim: mirrors src/app/api/llm/__tests__/route.test.ts.
+const PROVIDER_ENV_MAP: Record<string, string> = {
+  gemini: "GEMINI_API_KEY",
+};
+
+vi.mock("@/lib/byok/repository", () => ({
+  resolveProviderKey: vi.fn(
+    async (_workspaceId: string, provider: string) =>
+      process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+  ),
+}));
+
+import { resolveProviderKey } from "@/lib/byok/repository";
+import { POST } from "../route";
+
+const mockedResolveProviderKey = vi.mocked(resolveProviderKey);
+
+const originalEnv = { ...process.env };
+
+function createMockPostRequest(
+  body: unknown,
+  headers?: Record<string, string>
+): Request {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+    headers: new Headers({ "x-workspace-id": "ws-test", ...headers }),
+  } as unknown as Request;
+}
+
+describe("/api/chat route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateGoogleGenerativeAI.lastCalledWith = undefined;
+    process.env = { ...originalEnv };
+    mockedResolveProviderKey.mockImplementation(
+      async (_workspaceId: string, provider: string) =>
+        process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+    );
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("streams a response using the vault-resolved Gemini key", async () => {
+    delete process.env.GEMINI_API_KEY;
+    mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
+
+    const request = createMockPostRequest({ messages: [] });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockCreateGoogleGenerativeAI.lastCalledWith).toEqual({
+      apiKey: "vault-gemini-key",
+    });
+  });
+
+  it("uses the X-Gemini-API-Key header over the vault", async () => {
+    mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
+
+    const request = createMockPostRequest(
+      { messages: [] },
+      { "X-Gemini-API-Key": "header-gemini-key" }
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockCreateGoogleGenerativeAI.lastCalledWith).toEqual({
+      apiKey: "header-gemini-key",
+    });
+  });
+
+  it("returns a typed byok_key_missing error when no key is resolvable", async () => {
+    delete process.env.GEMINI_API_KEY;
+    mockedResolveProviderKey.mockResolvedValue(null);
+
+    const request = createMockPostRequest({ messages: [] });
+    const response = await POST(request);
+    const text = await response.text();
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBeLessThan(500);
+    expect(text).toContain("Google Gemini");
+    expect(text).toContain("Provider Keys");
+    expect(text).not.toMatch(/GEMINI_API_KEY|process\.env/);
+    expect(mockStreamText).not.toHaveBeenCalled();
+  });
+
+  it("never falls back to the server env key", async () => {
+    process.env.GEMINI_API_KEY = "env-gemini-key";
+    mockedResolveProviderKey.mockResolvedValue(null);
+
+    const request = createMockPostRequest({ messages: [] });
+    const response = await POST(request);
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBeLessThan(500);
+    expect(mockStreamText).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -5,6 +5,10 @@ import { buildWorkflowContext } from '@/lib/chat/contextBuilder';
 import { extractSubgraph } from '@/lib/chat/subgraphExtractor';
 import { WorkflowNode } from '@/types';
 import { WorkflowEdge } from '@/types/workflow';
+import {
+  resolveInferenceKey,
+  isInferenceKeyError,
+} from '@/lib/byok/resolveInferenceKey';
 
 export const maxDuration = 60; // 1 minute timeout
 
@@ -16,11 +20,14 @@ export async function POST(request: Request) {
       selectedNodeIds?: string[];
     };
 
-    // Get API key from environment
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      return new Response('GEMINI_API_KEY not configured', { status: 500 });
-    }
+    // BYOK: request header override → workspace vault → typed error. No env.
+    const geminiApiKey = request.headers.get('X-Gemini-API-Key');
+    const workspaceId = request.headers.get('x-workspace-id');
+    const apiKey = await resolveInferenceKey({
+      headerKey: geminiApiKey,
+      workspaceId,
+      provider: 'gemini',
+    });
 
     // Extract subgraph if nodes are selected, otherwise use full workflow
     const subgraph = extractSubgraph(
@@ -64,6 +71,14 @@ export async function POST(request: Request) {
     return result.toUIMessageStreamResponse();
   } catch (error) {
     console.error('[Chat API Error]', error);
+
+    // No resolvable BYOK key: return a clear, user-facing 401 naming the
+    // provider and pointing to Settings → Provider Keys — never a 500, never
+    // a leaked env var name. The chat transport surfaces the response body
+    // text directly as the error message shown in the UI.
+    if (isInferenceKeyError(error)) {
+      return new Response(error.message, { status: 401 });
+    }
 
     if (error instanceof Error && error.message.includes('429')) {
       return new Response('Rate limit reached. Please wait and try again.', { status: 429 });

--- a/src/app/api/quickstart/__tests__/route.test.ts
+++ b/src/app/api/quickstart/__tests__/route.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Use vi.hoisted to define mocks that work with hoisted vi.mock
+const { mockGenerateContent, MockGoogleGenAI, mockGoogleGenAIInstance } = vi.hoisted(() => {
+  const mockGenerateContent = vi.fn();
+  const mockGoogleGenAIInstance = {
+    models: {
+      generateContent: mockGenerateContent,
+    },
+  };
+  class MockGoogleGenAI {
+    apiKey: string;
+    models = mockGoogleGenAIInstance.models;
+
+    constructor(config: { apiKey: string }) {
+      this.apiKey = config.apiKey;
+      MockGoogleGenAI.lastCalledWith = config;
+      MockGoogleGenAI.callCount++;
+    }
+
+    static lastCalledWith: { apiKey: string } | null = null;
+    static callCount = 0;
+    static reset() {
+      MockGoogleGenAI.lastCalledWith = null;
+      MockGoogleGenAI.callCount = 0;
+    }
+  }
+  return { mockGenerateContent, MockGoogleGenAI, mockGoogleGenAIInstance };
+});
+
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: MockGoogleGenAI,
+}));
+
+// `next/headers` is only used by the templateId branch (to build a base URL
+// for local sample images); stub it so the BYOK-focused tests below never
+// touch real request headers machinery.
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Headers({ host: "localhost:3000" })),
+}));
+
+// BYOK vault shim: mirrors the pattern in src/app/api/llm/__tests__/route.test.ts —
+// the route resolves keys via resolveInferenceKey, whose vault tier delegates to
+// resolveProviderKey. Mock the repository so tests never touch the database.
+const PROVIDER_ENV_MAP: Record<string, string> = {
+  gemini: "GEMINI_API_KEY",
+};
+
+vi.mock("@/lib/byok/repository", () => ({
+  resolveProviderKey: vi.fn(
+    async (_workspaceId: string, provider: string) =>
+      process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+  ),
+}));
+
+import { resolveProviderKey } from "@/lib/byok/repository";
+import { POST } from "../route";
+
+const mockedResolveProviderKey = vi.mocked(resolveProviderKey);
+
+const originalEnv = { ...process.env };
+
+function createMockPostRequest(
+  body: unknown,
+  headers?: Record<string, string>
+): NextRequest {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+    headers: new Headers({ "x-workspace-id": "ws-test", ...headers }),
+  } as unknown as NextRequest;
+}
+
+describe("/api/quickstart route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockGoogleGenAI.reset();
+    process.env = { ...originalEnv };
+    mockedResolveProviderKey.mockImplementation(
+      async (_workspaceId: string, provider: string) =>
+        process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+    );
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("generates a workflow successfully using the vault-resolved Gemini key", async () => {
+    delete process.env.GEMINI_API_KEY;
+    mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
+
+    mockGenerateContent.mockResolvedValueOnce({
+      text: JSON.stringify({
+        id: "wf_1",
+        version: 1,
+        name: "Generated",
+        edgeStyle: "curved",
+        nodes: [],
+        edges: [],
+      }),
+    });
+
+    const request = createMockPostRequest({
+      description: "Create a product photo workflow",
+      contentLevel: "full",
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(MockGoogleGenAI.lastCalledWith).toEqual({ apiKey: "vault-gemini-key" });
+  });
+
+  it("uses the X-Gemini-API-Key header over the vault", async () => {
+    mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
+
+    mockGenerateContent.mockResolvedValueOnce({
+      text: JSON.stringify({
+        id: "wf_1",
+        version: 1,
+        name: "Generated",
+        edgeStyle: "curved",
+        nodes: [],
+        edges: [],
+      }),
+    });
+
+    const request = createMockPostRequest(
+      { description: "Create a product photo workflow", contentLevel: "full" },
+      { "X-Gemini-API-Key": "header-gemini-key" }
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(MockGoogleGenAI.lastCalledWith).toEqual({ apiKey: "header-gemini-key" });
+  });
+
+  it("returns a typed byok_key_missing error when no key is resolvable", async () => {
+    delete process.env.GEMINI_API_KEY;
+    mockedResolveProviderKey.mockResolvedValue(null);
+
+    const request = createMockPostRequest({
+      description: "Create a product photo workflow",
+      contentLevel: "full",
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBeLessThan(500);
+    expect(data.success).toBe(false);
+    expect(data.code).toBe("byok_key_missing");
+    expect(data.provider).toBe("gemini");
+    expect(data.error).toContain("Google Gemini");
+    expect(data.error).toContain("Provider Keys");
+    expect(data.error).not.toMatch(/GEMINI_API_KEY|process\.env/);
+  });
+
+  it("never falls back to the server env key", async () => {
+    process.env.GEMINI_API_KEY = "env-gemini-key";
+    mockedResolveProviderKey.mockResolvedValue(null);
+
+    const request = createMockPostRequest({
+      description: "Create a product photo workflow",
+      contentLevel: "full",
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBeLessThan(500);
+    expect(data.code).toBe("byok_key_missing");
+    expect(MockGoogleGenAI.callCount).toBe(0);
+  });
+
+  it("does not require a resolvable key for the preset templateId path", async () => {
+    delete process.env.GEMINI_API_KEY;
+    mockedResolveProviderKey.mockResolvedValue(null);
+
+    const request = createMockPostRequest({
+      templateId: "product-shot",
+      contentLevel: "full",
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(MockGoogleGenAI.callCount).toBe(0);
+  });
+});

--- a/src/app/api/quickstart/propose/__tests__/route.test.ts
+++ b/src/app/api/quickstart/propose/__tests__/route.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGenerateContent, MockGoogleGenAI } = vi.hoisted(() => {
+  const mockGenerateContent = vi.fn();
+  class MockGoogleGenAI {
+    apiKey: string;
+    models = { generateContent: mockGenerateContent };
+
+    constructor(config: { apiKey: string }) {
+      this.apiKey = config.apiKey;
+      MockGoogleGenAI.lastCalledWith = config;
+      MockGoogleGenAI.callCount++;
+    }
+
+    static lastCalledWith: { apiKey: string } | null = null;
+    static callCount = 0;
+    static reset() {
+      MockGoogleGenAI.lastCalledWith = null;
+      MockGoogleGenAI.callCount = 0;
+    }
+  }
+  return { mockGenerateContent, MockGoogleGenAI };
+});
+
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: MockGoogleGenAI,
+}));
+
+const PROVIDER_ENV_MAP: Record<string, string> = {
+  gemini: "GEMINI_API_KEY",
+};
+
+vi.mock("@/lib/byok/repository", () => ({
+  resolveProviderKey: vi.fn(
+    async (_workspaceId: string, provider: string) =>
+      process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+  ),
+}));
+
+import { resolveProviderKey } from "@/lib/byok/repository";
+import { POST } from "../route";
+
+const mockedResolveProviderKey = vi.mocked(resolveProviderKey);
+
+const originalEnv = { ...process.env };
+
+function createMockPostRequest(
+  body: unknown,
+  headers?: Record<string, string>
+): NextRequest {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+    headers: new Headers({ "x-workspace-id": "ws-test", ...headers }),
+  } as unknown as NextRequest;
+}
+
+const VALID_PROPOSAL = {
+  name: "Product Shot",
+  description: "Generates a product photo",
+  nodes: [
+    {
+      id: "n1",
+      type: "imageInput",
+      purpose: "input",
+      suggestedTitle: "Product",
+    },
+  ],
+  connections: [],
+  estimatedComplexity: "simple",
+};
+
+describe("/api/quickstart/propose route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockGoogleGenAI.reset();
+    process.env = { ...originalEnv };
+    mockedResolveProviderKey.mockImplementation(
+      async (_workspaceId: string, provider: string) =>
+        process.env[PROVIDER_ENV_MAP[provider]] ?? null,
+    );
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("generates a proposal successfully using the vault-resolved Gemini key", async () => {
+    delete process.env.GEMINI_API_KEY;
+    mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
+
+    mockGenerateContent.mockResolvedValueOnce({
+      text: JSON.stringify(VALID_PROPOSAL),
+    });
+
+    const request = createMockPostRequest({
+      description: "Create a product photo workflow",
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(MockGoogleGenAI.lastCalledWith).toEqual({ apiKey: "vault-gemini-key" });
+  });
+
+  it("uses the X-Gemini-API-Key header over the vault", async () => {
+    mockedResolveProviderKey.mockResolvedValue("vault-gemini-key");
+
+    mockGenerateContent.mockResolvedValueOnce({
+      text: JSON.stringify(VALID_PROPOSAL),
+    });
+
+    const request = createMockPostRequest(
+      { description: "Create a product photo workflow" },
+      { "X-Gemini-API-Key": "header-gemini-key" }
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(MockGoogleGenAI.lastCalledWith).toEqual({ apiKey: "header-gemini-key" });
+  });
+
+  it("returns a typed byok_key_missing error when no key is resolvable", async () => {
+    delete process.env.GEMINI_API_KEY;
+    mockedResolveProviderKey.mockResolvedValue(null);
+
+    const request = createMockPostRequest({
+      description: "Create a product photo workflow",
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBeLessThan(500);
+    expect(data.success).toBe(false);
+    expect(data.code).toBe("byok_key_missing");
+    expect(data.provider).toBe("gemini");
+    expect(data.error).toContain("Google Gemini");
+    expect(data.error).toContain("Provider Keys");
+    expect(data.error).not.toMatch(/GEMINI_API_KEY|process\.env/);
+  });
+
+  it("never falls back to the server env key", async () => {
+    process.env.GEMINI_API_KEY = "env-gemini-key";
+    mockedResolveProviderKey.mockResolvedValue(null);
+
+    const request = createMockPostRequest({
+      description: "Create a product photo workflow",
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBeLessThan(500);
+    expect(data.code).toBe("byok_key_missing");
+    expect(MockGoogleGenAI.callCount).toBe(0);
+  });
+});

--- a/src/app/api/quickstart/propose/route.ts
+++ b/src/app/api/quickstart/propose/route.ts
@@ -3,6 +3,10 @@ import { GoogleGenAI } from "@google/genai";
 import { buildProposalPrompt } from "@/lib/quickstart/proposalPrompt";
 import { parseJSONFromResponse } from "@/lib/quickstart/validation";
 import type { WorkflowProposal, WorkflowComplexity, NodeType } from "@/types";
+import {
+  resolveInferenceKey,
+  isInferenceKeyError,
+} from "@/lib/byok/resolveInferenceKey";
 
 export const maxDuration = 60; // 1 minute timeout
 
@@ -190,18 +194,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check API key
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      console.error(`[Propose:${requestId}] No GEMINI_API_KEY configured`);
-      return NextResponse.json<ProposeResponse>(
-        {
-          success: false,
-          error: "API key not configured. Add GEMINI_API_KEY to .env.local",
-        },
-        { status: 500 }
-      );
-    }
+    // BYOK: request header override → workspace vault → typed error. No env.
+    const geminiApiKey = request.headers.get("X-Gemini-API-Key");
+    const workspaceId = request.headers.get("x-workspace-id");
+    const apiKey = await resolveInferenceKey({
+      headerKey: geminiApiKey,
+      workspaceId,
+      provider: "gemini",
+    });
 
     // Build the proposal prompt
     const prompt = buildProposalPrompt(description.trim());
@@ -288,6 +288,16 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error(`[Propose:${requestId}] Unexpected error:`, error);
+
+    // No resolvable BYOK key: return a typed 4xx naming the provider and
+    // pointing to Settings → Provider Keys — never a 500, never a leaked env
+    // name. `error` mirrors `message` so the quickstart UI's error display shows it.
+    if (isInferenceKeyError(error)) {
+      return NextResponse.json(
+        { success: false, error: error.message, ...error.toJSON() },
+        { status: 401 }
+      );
+    }
 
     // Handle rate limiting
     if (error instanceof Error && error.message.includes("429")) {

--- a/src/app/api/quickstart/route.ts
+++ b/src/app/api/quickstart/route.ts
@@ -10,6 +10,10 @@ import {
 } from "@/lib/quickstart/validation";
 import { ImageInputNodeData } from "@/types";
 import { headers } from "next/headers";
+import {
+  resolveInferenceKey,
+  isInferenceKeyError,
+} from "@/lib/byok/resolveInferenceKey";
 
 export const maxDuration = 60; // 1 minute timeout
 
@@ -141,18 +145,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check API key
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      console.error(`[Quickstart:${requestId}] No GEMINI_API_KEY configured`);
-      return NextResponse.json<QuickstartResponse>(
-        {
-          success: false,
-          error: "API key not configured. Add GEMINI_API_KEY to .env.local",
-        },
-        { status: 500 }
-      );
-    }
+    // BYOK: request header override → workspace vault → typed error. No env.
+    const geminiApiKey = request.headers.get("X-Gemini-API-Key");
+    const workspaceId = request.headers.get("x-workspace-id");
+    const apiKey = await resolveInferenceKey({
+      headerKey: geminiApiKey,
+      workspaceId,
+      provider: "gemini",
+    });
 
     // Build the prompt
     const prompt = buildQuickstartPrompt(description.trim(), contentLevel);
@@ -240,6 +240,16 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error(`[Quickstart:${requestId}] Unexpected error:`, error);
+
+    // No resolvable BYOK key: return a typed 4xx naming the provider and
+    // pointing to Settings → Provider Keys — never a 500, never a leaked env
+    // name. `error` mirrors `message` so the quickstart UI's error display shows it.
+    if (isInferenceKeyError(error)) {
+      return NextResponse.json(
+        { success: false, error: error.message, ...error.toJSON() },
+        { status: 401 }
+      );
+    }
 
     // Handle rate limiting
     if (error instanceof Error && error.message.includes("429")) {

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -5,6 +5,8 @@ import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import ReactMarkdown from "react-markdown";
 import { EditOperation } from "@/lib/chat/editOperations";
+import { useProviderApiKeys } from "@/store/workflowStore";
+import { buildGeminiOnlyHeaders } from "@/store/utils/buildApiHeaders";
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -32,10 +34,23 @@ export function ChatPanel({ isOpen, onClose, onBuildWorkflow, isBuildingWorkflow
   const selectedNodeIdsRef = useRef(selectedNodeIds);
   selectedNodeIdsRef.current = selectedNodeIds;
 
+  // BYOK: forward the user's configured Gemini key (if any) as a header
+  // override, same as node execution. Kept in a ref so the fetch closure
+  // always reads the latest value without needing to re-create the transport.
+  const { geminiApiKey } = useProviderApiKeys();
+  const geminiApiKeyRef = useRef(geminiApiKey);
+  geminiApiKeyRef.current = geminiApiKey;
+
   // Stable fetch function that reads workflowState and selectedNodeIds from ref
   const customFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const byokHeaders = buildGeminiOnlyHeaders(geminiApiKeyRef.current);
+    const headers = new Headers(init?.headers);
+    Object.entries(byokHeaders).forEach(([key, value]) => {
+      if (!headers.has(key)) headers.set(key, value);
+    });
+
     if (!init?.body) {
-      return fetch(input, init);
+      return fetch(input, { ...init, headers });
     }
 
     const body = JSON.parse(init.body as string);
@@ -47,6 +62,7 @@ export function ChatPanel({ isOpen, onClose, onBuildWorkflow, isBuildingWorkflow
 
     return fetch(input, {
       ...init,
+      headers,
       body: JSON.stringify(bodyWithWorkflow),
     });
   }, []);

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -18,7 +18,8 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
-import { useWorkflowStore, WorkflowFile } from "@/store/workflowStore";
+import { useWorkflowStore, WorkflowFile, useProviderApiKeys } from "@/store/workflowStore";
+import { buildGeminiOnlyHeaders } from "@/store/utils/buildApiHeaders";
 import { useShallow } from "zustand/shallow";
 import { useToast } from "@/components/Toast";
 import dynamic from "next/dynamic";
@@ -307,6 +308,7 @@ export function WorkflowCanvas() {
   const clearWorkflow = useWorkflowStore((state) => state.clearWorkflow);
   const setHoveredNodeId = useWorkflowStore((state) => state.setHoveredNodeId);
   const openAnnotationModal = useAnnotationStore((state) => state.openModal);
+  const { geminiApiKey } = useProviderApiKeys();
   const { screenToFlowPosition, getViewport, zoomIn, zoomOut, setViewport, setCenter } = useReactFlow();
   const { show: showToast } = useToast();
   const router = useRouter();
@@ -1018,7 +1020,7 @@ export function WorkflowCanvas() {
     try {
       const response = await fetch("/api/quickstart", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: buildGeminiOnlyHeaders(geminiApiKey),
         body: JSON.stringify({
           description,
           contentLevel: "full",
@@ -1041,7 +1043,7 @@ export function WorkflowCanvas() {
     } finally {
       setIsBuildingWorkflow(false);
     }
-  }, [loadWorkflow, showToast, captureSnapshot]);
+  }, [loadWorkflow, showToast, captureSnapshot, geminiApiKey]);
 
   // Create lightweight workflow state for chat (strip base64 images)
   const chatWorkflowState = useMemo(() => {

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -27,6 +27,15 @@ vi.mock("@/store/workflowStore", () => ({
     }
     return mockUseWorkflowStore((s: unknown) => s);
   },
+  useProviderApiKeys: () => ({
+    geminiApiKey: null,
+    replicateApiKey: null,
+    falApiKey: null,
+    kieApiKey: null,
+    wavespeedApiKey: null,
+    replicateEnabled: false,
+    kieEnabled: false,
+  }),
 }));
 
 // Mock useReactFlow

--- a/src/components/quickstart/PromptWorkflowView.tsx
+++ b/src/components/quickstart/PromptWorkflowView.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { WorkflowFile } from "@/store/workflowStore";
+import { WorkflowFile, useProviderApiKeys } from "@/store/workflowStore";
 import { QuickstartBackButton } from "./QuickstartBackButton";
+import { buildGeminiOnlyHeaders } from "@/store/utils/buildApiHeaders";
 
 interface PromptWorkflowViewProps {
   onBack: () => void;
@@ -16,6 +17,7 @@ export function PromptWorkflowView({
   const [description, setDescription] = useState("");
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { geminiApiKey } = useProviderApiKeys();
 
   const handleGenerate = useCallback(async () => {
     if (!description || description.trim().length < 3) {
@@ -29,7 +31,7 @@ export function PromptWorkflowView({
     try {
       const response = await fetch("/api/quickstart", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: buildGeminiOnlyHeaders(geminiApiKey),
         body: JSON.stringify({
           description: description.trim(),
           contentLevel: "full",
@@ -53,7 +55,7 @@ export function PromptWorkflowView({
     } finally {
       setIsGenerating(false);
     }
-  }, [description, onWorkflowGenerated]);
+  }, [description, onWorkflowGenerated, geminiApiKey]);
 
   const canGenerate = description.trim().length >= 3 && !isGenerating;
 

--- a/src/components/quickstart/QuickstartTemplatesView.tsx
+++ b/src/components/quickstart/QuickstartTemplatesView.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { WorkflowFile } from "@/store/workflowStore";
+import { WorkflowFile, useProviderApiKeys } from "@/store/workflowStore";
 import { getAllPresets } from "@/lib/quickstart/templates";
 import { QuickstartBackButton } from "./QuickstartBackButton";
 import { CommunityWorkflowMeta } from "@/types/quickstart";
+import { buildGeminiOnlyHeaders } from "@/store/utils/buildApiHeaders";
 
 interface QuickstartTemplatesViewProps {
   onBack: () => void;
@@ -19,6 +20,7 @@ export function QuickstartTemplatesView({
   const [isLoadingList, setIsLoadingList] = useState(true);
   const [loadingWorkflowId, setLoadingWorkflowId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const { geminiApiKey } = useProviderApiKeys();
 
   const presets = getAllPresets();
 
@@ -52,7 +54,7 @@ export function QuickstartTemplatesView({
       try {
         const response = await fetch("/api/quickstart", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: buildGeminiOnlyHeaders(geminiApiKey),
           body: JSON.stringify({
             templateId,
             contentLevel: "full",
@@ -75,7 +77,7 @@ export function QuickstartTemplatesView({
         setLoadingWorkflowId(null);
       }
     },
-    [onWorkflowSelected]
+    [onWorkflowSelected, geminiApiKey]
   );
 
   const handleCommunitySelect = useCallback(

--- a/src/components/quickstart/TemplateExplorerView.tsx
+++ b/src/components/quickstart/TemplateExplorerView.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import { WorkflowFile } from "@/store/workflowStore";
+import { WorkflowFile, useProviderApiKeys } from "@/store/workflowStore";
 import { getAllPresets, PRESET_TEMPLATES } from "@/lib/quickstart/templates";
 import { QuickstartBackButton } from "./QuickstartBackButton";
 import { TemplateCard } from "./TemplateCard";
 import { CommunityWorkflowMeta, TemplateCategory, TemplateMetadata } from "@/types/quickstart";
+import { buildGeminiOnlyHeaders } from "@/store/utils/buildApiHeaders";
 
 interface TemplateExplorerViewProps {
   onBack: () => void;
@@ -29,6 +30,7 @@ export function TemplateExplorerView({
   const [isLoadingList, setIsLoadingList] = useState(true);
   const [loadingWorkflowId, setLoadingWorkflowId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const { geminiApiKey } = useProviderApiKeys();
 
   // Filter state
   const [searchQuery, setSearchQuery] = useState("");
@@ -220,7 +222,7 @@ export function TemplateExplorerView({
       try {
         const response = await fetch("/api/quickstart", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: buildGeminiOnlyHeaders(geminiApiKey),
           body: JSON.stringify({
             templateId,
             contentLevel: "full",
@@ -243,7 +245,7 @@ export function TemplateExplorerView({
         setLoadingWorkflowId(null);
       }
     },
-    [onWorkflowSelected]
+    [onWorkflowSelected, geminiApiKey]
   );
 
   const handleCommunitySelect = useCallback(

--- a/src/store/utils/buildApiHeaders.ts
+++ b/src/store/utils/buildApiHeaders.ts
@@ -22,7 +22,7 @@ const PROVIDER_HEADER_MAP: Record<ProviderType, string> = {
   anthropic: "X-Anthropic-API-Key",
 };
 
-function addWorkspaceHeader(headers: Record<string, string>): void {
+export function addWorkspaceHeader(headers: Record<string, string>): void {
   if (isCloudMode()) {
     const workspaceId = getActiveWorkspaceId();
     if (workspaceId) {
@@ -83,6 +83,27 @@ export function buildLlmHeaders(
     if (anthropicConfig?.apiKey) {
       headers["X-Anthropic-API-Key"] = anthropicConfig.apiKey;
     }
+  }
+
+  addWorkspaceHeader(headers);
+  return headers;
+}
+
+/**
+ * Build headers for the Gemini-only chat/quickstart API calls.
+ * Adds the X-Gemini-API-Key override (if the user configured one) plus the
+ * workspace header (cloud mode only) — the same BYOK resolution surface as
+ * buildLlmHeaders, scoped to routes that always call Gemini.
+ */
+export function buildGeminiOnlyHeaders(
+  geminiApiKey?: string | null
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (geminiApiKey) {
+    headers["X-Gemini-API-Key"] = geminiApiKey;
   }
 
   addWorkspaceHeader(headers);


### PR DESCRIPTION
Closes #109. Part of PRD #100 — completes the BYOK track. **Stacked on #128** — merge order: #123 → #125 → #128 → this.

- `/api/chat`, `/api/quickstart`, `/api/quickstart/propose` migrated from hardcoded `process.env.GEMINI_API_KEY` (which 500'd when absent) to `resolveInferenceKey` (header → workspace vault → typed 401).
- Chat streams, so its 401 returns the message as body text — the AI SDK transport feeds it to the existing red-box error UI verbatim; zero UI changes needed. Quickstart routes return the standard `byok_key_missing` JSON shape.
- Workspace context reuses the existing `getActiveWorkspaceId()` mechanism via a new `buildGeminiOnlyHeaders()`; wired into ChatPanel, WorkflowCanvas build-flow, and the three quickstart views.
- Grep-proven: no `GEMINI_API_KEY` reads remain outside the explicitly out-of-scope `env-status`/`models` routes and tests.

13 new route tests (vault-hit / header-override / typed-401 / no-env-fallback × 3 routes) — re-run by reviewer. Full suite green except the 2 tracked pre-existing failures; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)