### PR TITLE
feat: asset upload + download-url across registry/MCP/API/CLI (#104)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,6 +47,8 @@ token against the API before saving, so a stored credential always works.
 | `nb workspaces list` | List the workspace (brand) the token can reach. |
 | `nb accounts list` | List connected social accounts (channels). |
 | `nb assets list [--type <t>] [--limit <n>]` | List media assets; `--type` = image \| video \| audio \| model3d \| workflow. |
+| `nb assets upload <file> [--type <t>] [--project-id <id>] [--mime-type <m>]` | Upload a local file as a workspace asset; type/mime are inferred from the extension if omitted. Enforces the workspace's storage quota and type rules. |
+| `nb assets download-url <assetId> [--expires-in <seconds>]` | Get a CDN or presigned download URL for an existing asset. |
 
 ### Examples
 

--- a/packages/cli/src/__tests__/program.test.ts
+++ b/packages/cli/src/__tests__/program.test.ts
@@ -4,12 +4,22 @@ import type { ApiClient } from "../api/client";
 import type { AppDeps } from "../commands/context";
 import { buildProgram } from "../program";
 
-function makeDeps(): { deps: AppDeps; out: string[] } {
+function makeDeps(): { deps: AppDeps; out: string[]; client: ApiClient } {
   const out: string[] = [];
   const client: ApiClient = {
     listWorkspaces: vi.fn(async () => [{ id: "ws_1", name: "Acme", slug: "acme" }]),
     listSocialAccounts: vi.fn(async () => []),
     listAssets: vi.fn(async () => []),
+    uploadAsset: vi.fn(async () => ({
+      assetId: "asset_new",
+      downloadUrl: "https://cdn.example/asset_new.png",
+      expiresInSeconds: null,
+    })),
+    getAssetDownloadUrl: vi.fn(async () => ({
+      assetId: "asset_1",
+      downloadUrl: "https://signed.example/asset_1.png",
+      expiresInSeconds: 900,
+    })),
     verifyToken: vi.fn(async () => undefined),
   };
   const deps: AppDeps = {
@@ -18,9 +28,10 @@ function makeDeps(): { deps: AppDeps; out: string[] } {
     clearConfig: vi.fn(),
     createClient: vi.fn(() => client),
     promptSecret: vi.fn(async () => "nb_prompted"),
+    readFile: vi.fn(() => Buffer.from("file-bytes")),
     io: { out: (line) => out.push(line), err: () => {} },
   };
-  return { deps, out };
+  return { deps, out, client };
 }
 
 async function run(deps: AppDeps, argv: string[]): Promise<void> {
@@ -64,5 +75,32 @@ describe("buildProgram", () => {
     const { deps, out } = makeDeps();
     await run(deps, ["auth", "status"]);
     expect(out.join("\n").toLowerCase()).toContain("https://api.example.com");
+  });
+
+  it("runs `assets upload` and prints the asset id and download url", async () => {
+    const { deps, out } = makeDeps();
+    await run(deps, ["assets", "upload", "/tmp/photo.png"]);
+    const text = out.join("\n");
+    expect(text).toContain("asset_new");
+    expect(text).toContain("https://cdn.example/asset_new.png");
+  });
+
+  it("runs `assets upload --json` with an explicit --type", async () => {
+    const { deps, out, client } = makeDeps();
+    await run(deps, ["assets", "upload", "/tmp/blob.bin", "--type", "video", "--json"]);
+    expect(client.uploadAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ assetType: "video" }),
+    );
+    expect(JSON.parse(out.join("\n"))).toEqual({
+      assetId: "asset_new",
+      downloadUrl: "https://cdn.example/asset_new.png",
+      expiresInSeconds: null,
+    });
+  });
+
+  it("runs `assets download-url` and prints the url", async () => {
+    const { deps, out } = makeDeps();
+    await run(deps, ["assets", "download-url", "asset_1"]);
+    expect(out.join("\n")).toContain("https://signed.example/asset_1.png");
   });
 });

--- a/packages/cli/src/api/__tests__/api.test.ts
+++ b/packages/cli/src/api/__tests__/api.test.ts
@@ -6,6 +6,8 @@ import { createApiClient } from "../client";
 interface Captured {
   url: string;
   headers: Record<string, string>;
+  method: string;
+  body: unknown;
 }
 
 function fakeFetch(
@@ -19,7 +21,13 @@ function fakeFetch(
     headers.forEach((value, key) => {
       record[key] = value;
     });
-    calls.push({ url: String(input), headers: record });
+    calls.push({
+      url: String(input),
+      headers: record,
+      method: options?.method ?? "GET",
+      body:
+        typeof options?.body === "string" ? JSON.parse(options.body) : undefined,
+    });
     return new Response(JSON.stringify(body), {
       status: init.status ?? 200,
       headers: { "content-type": "application/json" },
@@ -179,5 +187,94 @@ describe("createApiClient", () => {
     });
 
     await expect(client.verifyToken()).resolves.toBeUndefined();
+  });
+
+  it("posts an asset upload with a JSON body and bearer token", async () => {
+    const { fetch, calls } = fakeFetch({
+      success: true,
+      assetId: "asset_1",
+      downloadUrl: "https://cdn.example/asset_1.png",
+      expiresInSeconds: null,
+    });
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    const result = await client.uploadAsset({
+      assetType: "image",
+      fileName: "photo.png",
+      mimeType: "image/png",
+      base64Content: "aGVsbG8=",
+    });
+
+    expect(result).toEqual({
+      assetId: "asset_1",
+      downloadUrl: "https://cdn.example/asset_1.png",
+      expiresInSeconds: null,
+    });
+    expect(calls[0]?.url).toBe("https://api.example.com/api/v1/assets");
+    expect(calls[0]?.headers.authorization).toBe("Bearer nb_secret");
+    expect(calls[0]?.headers["content-type"]).toBe("application/json");
+    expect(calls[0]?.body).toEqual({
+      assetType: "image",
+      fileName: "photo.png",
+      mimeType: "image/png",
+      base64Content: "aGVsbG8=",
+    });
+  });
+
+  it("surfaces a quota-exceeded upload failure as a structured ApiError", async () => {
+    const { fetch } = fakeFetch(
+      {
+        success: false,
+        error: {
+          code: "forbidden",
+          message: "Workspace storage quota exceeded.",
+          fix: "Delete unused assets or raise the workspace's storage quota before uploading more.",
+        },
+      },
+      { status: 403 },
+    );
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    const error = await client
+      .uploadAsset({ assetType: "image", base64Content: "aGVsbG8=" })
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.code).toBe("forbidden");
+  });
+
+  it("gets a download url for an asset id, forwarding expiresInSeconds", async () => {
+    const { fetch, calls } = fakeFetch({
+      success: true,
+      assetId: "asset_1",
+      downloadUrl: "https://signed.example/asset_1.png",
+      expiresInSeconds: 60,
+    });
+    const client = createApiClient({
+      token: "nb_secret",
+      url: "https://api.example.com",
+      fetchImpl: fetch,
+    });
+
+    const result = await client.getAssetDownloadUrl("asset_1", {
+      expiresInSeconds: 60,
+    });
+
+    expect(result).toEqual({
+      assetId: "asset_1",
+      downloadUrl: "https://signed.example/asset_1.png",
+      expiresInSeconds: 60,
+    });
+    expect(calls[0]?.url).toBe(
+      "https://api.example.com/api/v1/assets/asset_1/download-url?expiresInSeconds=60",
+    );
   });
 });

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -2,10 +2,15 @@ import type { z } from "zod";
 
 import { ApiError } from "../errors/errors";
 import {
+  assetDownloadUrlResultSchema,
+  assetUploadResultSchema,
   assetsResponseSchema,
   socialAccountsResponseSchema,
   workspacesResponseSchema,
   type Asset,
+  type AssetDownloadUrlResult,
+  type AssetType,
+  type AssetUploadResult,
   type SocialAccount,
   type Workspace,
 } from "./schemas";
@@ -23,6 +28,17 @@ export interface ApiClientOptions {
   fetchImpl?: typeof fetch;
 }
 
+export interface UploadAssetInput {
+  assetType: AssetType;
+  projectId?: string;
+  fileName?: string;
+  mimeType?: string;
+  /** Raw file bytes, base64-encoded. Exactly one of this or sourceUrl. */
+  base64Content?: string;
+  /** A URL the server fetches and stores. Exactly one of this or base64Content. */
+  sourceUrl?: string;
+}
+
 export interface ApiClient {
   listWorkspaces(): Promise<Workspace[]>;
   listSocialAccounts(): Promise<SocialAccount[]>;
@@ -30,6 +46,11 @@ export interface ApiClient {
     type?: string;
     limit?: number;
   }): Promise<Asset[]>;
+  uploadAsset(input: UploadAssetInput): Promise<AssetUploadResult>;
+  getAssetDownloadUrl(
+    assetId: string,
+    options?: { expiresInSeconds?: number },
+  ): Promise<AssetDownloadUrlResult>;
   /** Confirm the token is accepted; used by `nb auth login`. */
   verifyToken(): Promise<void>;
 }
@@ -73,25 +94,32 @@ function toApiError(body: ErrorEnvelope, status: number): ApiError {
 }
 
 /**
- * Create a thin client over the public API. Every method issues one GET,
- * unwraps the `{ success, ... }` envelope, validates the payload against a
- * local schema, and surfaces failures as {@link ApiError} (exit code 1).
+ * Create a thin client over the public API. Every method issues one HTTP
+ * request (GET by default, POST when a body is given), unwraps the
+ * `{ success, ... }` envelope, validates the payload against a local schema,
+ * and surfaces failures as {@link ApiError} (exit code 1).
  */
 export function createApiClient(options: ApiClientOptions): ApiClient {
   const fetchImpl = options.fetchImpl ?? fetch;
   const baseUrl = options.url.replace(/\/+$/, "");
 
-  async function requestJson(path: string): Promise<Record<string, unknown>> {
+  async function requestJson(
+    path: string,
+    requestInit?: { method?: string; body?: unknown },
+  ): Promise<Record<string, unknown>> {
     const url = `${baseUrl}${path}`;
+    const hasBody = requestInit?.body !== undefined;
 
     let response: Response;
     try {
       response = await fetchImpl(url, {
-        method: "GET",
+        method: requestInit?.method ?? "GET",
         headers: {
           authorization: `Bearer ${options.token}`,
           accept: "application/json",
+          ...(hasBody ? { "content-type": "application/json" } : {}),
         },
+        ...(hasBody ? { body: JSON.stringify(requestInit!.body) } : {}),
       });
     } catch (cause) {
       throw new ApiError({
@@ -127,8 +155,9 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
   async function requestParsed<Schema extends z.ZodTypeAny>(
     path: string,
     schema: Schema,
+    requestInit?: { method?: string; body?: unknown },
   ): Promise<z.infer<Schema>> {
-    const body = await requestJson(path);
+    const body = await requestJson(path, requestInit);
     const parsed = schema.safeParse(body);
     if (!parsed.success) {
       throw new ApiError({
@@ -167,6 +196,25 @@ export function createApiClient(options: ApiClientOptions): ApiClient {
       const path = query ? `/api/v1/assets?${query}` : "/api/v1/assets";
       const { assets } = await requestParsed(path, assetsResponseSchema);
       return assets;
+    },
+
+    async uploadAsset(input) {
+      return requestParsed("/api/v1/assets", assetUploadResultSchema, {
+        method: "POST",
+        body: input,
+      });
+    },
+
+    async getAssetDownloadUrl(assetId, downloadOptions) {
+      const params = new URLSearchParams();
+      if (downloadOptions?.expiresInSeconds !== undefined) {
+        params.set("expiresInSeconds", String(downloadOptions.expiresInSeconds));
+      }
+      const query = params.toString();
+      const path = `/api/v1/assets/${encodeURIComponent(assetId)}/download-url${
+        query ? `?${query}` : ""
+      }`;
+      return requestParsed(path, assetDownloadUrlResultSchema);
     },
 
     async verifyToken() {

--- a/packages/cli/src/api/schemas.ts
+++ b/packages/cli/src/api/schemas.ts
@@ -64,3 +64,13 @@ export const socialAccountsResponseSchema = z.object({
 export const assetsResponseSchema = z.object({
   assets: z.array(assetSchema),
 });
+
+export const assetUploadResultSchema = z.object({
+  assetId: z.string(),
+  downloadUrl: z.string(),
+  expiresInSeconds: z.number().nullable().optional(),
+});
+export type AssetUploadResult = z.infer<typeof assetUploadResultSchema>;
+
+export const assetDownloadUrlResultSchema = assetUploadResultSchema;
+export type AssetDownloadUrlResult = z.infer<typeof assetDownloadUrlResultSchema>;

--- a/packages/cli/src/commands/__tests__/commands.test.ts
+++ b/packages/cli/src/commands/__tests__/commands.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ApiClient } from "../../api/client";
-import type { Asset, SocialAccount, Workspace } from "../../api/schemas";
+import type {
+  Asset,
+  AssetDownloadUrlResult,
+  AssetUploadResult,
+  SocialAccount,
+  Workspace,
+} from "../../api/schemas";
 import { UsageError } from "../../errors/errors";
 import { authLogin, authStatus } from "../auth";
 import { accountsList } from "../accounts";
-import { assetsList } from "../assets";
+import { assetsDownloadUrl, assetsList, assetsUpload } from "../assets";
 import { resolveClient, type AppDeps } from "../context";
 import { workspacesList } from "../workspaces";
 
@@ -33,6 +39,16 @@ const ASSET: Asset = {
   durationSeconds: null,
   createdAt: "2026-01-02T00:00:00.000Z",
 };
+const UPLOAD_RESULT: AssetUploadResult = {
+  assetId: "asset_new",
+  downloadUrl: "https://cdn.example/asset_new.png",
+  expiresInSeconds: null,
+};
+const DOWNLOAD_URL_RESULT: AssetDownloadUrlResult = {
+  assetId: "asset_1",
+  downloadUrl: "https://signed.example/asset_1.png",
+  expiresInSeconds: 900,
+};
 
 function makeDeps(overrides: Partial<AppDeps> = {}): {
   deps: AppDeps;
@@ -49,6 +65,8 @@ function makeDeps(overrides: Partial<AppDeps> = {}): {
     listWorkspaces: vi.fn(async () => [WORKSPACE]),
     listSocialAccounts: vi.fn(async () => [ACCOUNT]),
     listAssets: vi.fn(async () => [ASSET]),
+    uploadAsset: vi.fn(async () => UPLOAD_RESULT),
+    getAssetDownloadUrl: vi.fn(async () => DOWNLOAD_URL_RESULT),
     verifyToken: vi.fn(async () => undefined),
   };
 
@@ -61,6 +79,7 @@ function makeDeps(overrides: Partial<AppDeps> = {}): {
       return client;
     }),
     promptSecret: vi.fn(async () => "nb_prompted"),
+    readFile: vi.fn(() => Buffer.from("file-bytes")),
     io: { out: (line) => out.push(line), err: (line) => err.push(line) },
     ...overrides,
   };
@@ -134,6 +153,109 @@ describe("assets list", () => {
     const { deps, out } = makeDeps();
     await assetsList(deps, { json: true });
     expect(JSON.parse(out.join("\n"))).toEqual([ASSET]);
+  });
+});
+
+describe("assets upload", () => {
+  it("reads the file, base64-encodes it, and infers type/mime from the extension", async () => {
+    const { deps, client } = makeDeps();
+    (deps.readFile as ReturnType<typeof vi.fn>).mockReturnValue(
+      Buffer.from("hello world"),
+    );
+
+    await assetsUpload(deps, { json: false, file: "/tmp/photo.png" });
+
+    expect(deps.readFile).toHaveBeenCalledWith("/tmp/photo.png");
+    expect(client.uploadAsset).toHaveBeenCalledWith({
+      assetType: "image",
+      fileName: "photo.png",
+      mimeType: "image/png",
+      base64Content: Buffer.from("hello world").toString("base64"),
+    });
+  });
+
+  it("lets --type and --mime-type override the inferred values", async () => {
+    const { deps, client } = makeDeps();
+
+    await assetsUpload(deps, {
+      json: false,
+      file: "/tmp/blob.bin",
+      type: "video",
+      mimeType: "video/mp4",
+    });
+
+    expect(client.uploadAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ assetType: "video", mimeType: "video/mp4" }),
+    );
+  });
+
+  it("forwards --project-id when given", async () => {
+    const { deps, client } = makeDeps();
+
+    await assetsUpload(deps, {
+      json: false,
+      file: "/tmp/photo.png",
+      projectId: "proj_1",
+    });
+
+    expect(client.uploadAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "proj_1" }),
+    );
+  });
+
+  it("throws a UsageError when the type cannot be inferred and --type is omitted", async () => {
+    const { deps, client } = makeDeps();
+
+    await expect(
+      assetsUpload(deps, { json: false, file: "/tmp/mystery.xyz" }),
+    ).rejects.toThrow(UsageError);
+    expect(client.uploadAsset).not.toHaveBeenCalled();
+  });
+
+  it("prints the asset id and download url by default", async () => {
+    const { deps, out } = makeDeps();
+    await assetsUpload(deps, { json: false, file: "/tmp/photo.png" });
+    const text = out.join("\n");
+    expect(text).toContain("asset_new");
+    expect(text).toContain("https://cdn.example/asset_new.png");
+  });
+
+  it("prints exact JSON data with --json", async () => {
+    const { deps, out } = makeDeps();
+    await assetsUpload(deps, { json: true, file: "/tmp/photo.png" });
+    expect(JSON.parse(out.join("\n"))).toEqual(UPLOAD_RESULT);
+  });
+});
+
+describe("assets download-url", () => {
+  it("requests a download url for the given asset id", async () => {
+    const { deps, client } = makeDeps();
+    await assetsDownloadUrl(deps, { json: false, assetId: "asset_1" });
+    expect(client.getAssetDownloadUrl).toHaveBeenCalledWith("asset_1", undefined);
+  });
+
+  it("forwards --expires-in when given", async () => {
+    const { deps, client } = makeDeps();
+    await assetsDownloadUrl(deps, {
+      json: false,
+      assetId: "asset_1",
+      expiresInSeconds: 60,
+    });
+    expect(client.getAssetDownloadUrl).toHaveBeenCalledWith("asset_1", {
+      expiresInSeconds: 60,
+    });
+  });
+
+  it("prints the download url by default", async () => {
+    const { deps, out } = makeDeps();
+    await assetsDownloadUrl(deps, { json: false, assetId: "asset_1" });
+    expect(out.join("\n")).toContain("https://signed.example/asset_1.png");
+  });
+
+  it("prints exact JSON data with --json", async () => {
+    const { deps, out } = makeDeps();
+    await assetsDownloadUrl(deps, { json: true, assetId: "asset_1" });
+    expect(JSON.parse(out.join("\n"))).toEqual(DOWNLOAD_URL_RESULT);
   });
 });
 

--- a/packages/cli/src/commands/assets.ts
+++ b/packages/cli/src/commands/assets.ts
@@ -1,5 +1,44 @@
+import { basename } from "node:path";
+
+import type { AssetType } from "../api/schemas";
+import { UsageError } from "../errors/errors";
 import { formatJson, renderTable } from "../output/output";
 import { resolveClient, type AppDeps } from "./context";
+
+/**
+ * Infer the asset type and content type from a file extension, mirroring the
+ * server's own mime<->extension mapping (see `getExtensionForMimeType` in
+ * `/api/studio/assets/ingest`). `--type`/`--mime-type` always win over this.
+ */
+const EXTENSION_INFO: Record<string, { assetType: AssetType; mimeType: string }> = {
+  png: { assetType: "image", mimeType: "image/png" },
+  jpg: { assetType: "image", mimeType: "image/jpeg" },
+  jpeg: { assetType: "image", mimeType: "image/jpeg" },
+  gif: { assetType: "image", mimeType: "image/gif" },
+  webp: { assetType: "image", mimeType: "image/webp" },
+  svg: { assetType: "image", mimeType: "image/svg+xml" },
+  mp4: { assetType: "video", mimeType: "video/mp4" },
+  webm: { assetType: "video", mimeType: "video/webm" },
+  mov: { assetType: "video", mimeType: "video/quicktime" },
+  mp3: { assetType: "audio", mimeType: "audio/mpeg" },
+  wav: { assetType: "audio", mimeType: "audio/wav" },
+  ogg: { assetType: "audio", mimeType: "audio/ogg" },
+  flac: { assetType: "audio", mimeType: "audio/flac" },
+  aac: { assetType: "audio", mimeType: "audio/aac" },
+  glb: { assetType: "model3d", mimeType: "model/gltf-binary" },
+  gltf: { assetType: "model3d", mimeType: "model/gltf+json" },
+  obj: { assetType: "model3d", mimeType: "model/obj" },
+  usdz: { assetType: "model3d", mimeType: "model/vnd.usdz+zip" },
+  fbx: { assetType: "model3d", mimeType: "model/fbx" },
+  stl: { assetType: "model3d", mimeType: "model/stl" },
+};
+
+function inferFromFileName(fileName: string): { assetType: AssetType; mimeType: string } | null {
+  const parts = fileName.split(".");
+  if (parts.length < 2) return null;
+  const ext = parts[parts.length - 1]?.toLowerCase();
+  return ext ? EXTENSION_INFO[ext] ?? null : null;
+}
 
 /**
  * `nb assets list` — media assets in the token's workspace, optionally filtered
@@ -36,4 +75,79 @@ export async function assetsList(
     a.createdAt,
   ]);
   deps.io.out(renderTable(["ID", "TYPE", "MIME", "SIZE", "CREATED"], rows));
+}
+
+/**
+ * `nb assets upload <file>` — reads a local file, base64-encodes it, and
+ * uploads it via the `upload_asset` registry tool (through the public API).
+ * Asset type and content type are inferred from the file extension unless
+ * `--type`/`--mime-type` override them; workspace storage quota and type
+ * rules are enforced server-side, identically to the app.
+ */
+export async function assetsUpload(
+  deps: AppDeps,
+  opts: {
+    json: boolean;
+    file: string;
+    type?: string;
+    projectId?: string;
+    mimeType?: string;
+  },
+): Promise<void> {
+  const client = resolveClient(deps);
+
+  const fileName = basename(opts.file);
+  const inferred = inferFromFileName(fileName);
+
+  const assetType = (opts.type as AssetType | undefined) ?? inferred?.assetType;
+  if (!assetType) {
+    throw new UsageError(
+      `Could not infer an asset type from "${fileName}". Pass --type <image|video|audio|model3d|workflow>.`,
+    );
+  }
+
+  const mimeType = opts.mimeType ?? inferred?.mimeType;
+  const bytes = deps.readFile(opts.file);
+
+  const result = await client.uploadAsset({
+    assetType,
+    fileName,
+    ...(mimeType !== undefined ? { mimeType } : {}),
+    ...(opts.projectId !== undefined ? { projectId: opts.projectId } : {}),
+    base64Content: bytes.toString("base64"),
+  });
+
+  if (opts.json) {
+    deps.io.out(formatJson(result));
+    return;
+  }
+
+  deps.io.out(`Uploaded asset ${result.assetId}`);
+  deps.io.out(`Download URL: ${result.downloadUrl}`);
+}
+
+/**
+ * `nb assets download-url <assetId>` — a CDN or presigned URL for an asset
+ * already in the workspace, optionally with a custom `--expires-in` lifetime
+ * (only meaningful when the deployment has no CDN configured).
+ */
+export async function assetsDownloadUrl(
+  deps: AppDeps,
+  opts: { json: boolean; assetId: string; expiresInSeconds?: number },
+): Promise<void> {
+  const client = resolveClient(deps);
+
+  const result = await client.getAssetDownloadUrl(
+    opts.assetId,
+    opts.expiresInSeconds !== undefined
+      ? { expiresInSeconds: opts.expiresInSeconds }
+      : undefined,
+  );
+
+  if (opts.json) {
+    deps.io.out(formatJson(result));
+    return;
+  }
+
+  deps.io.out(result.downloadUrl);
 }

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -19,6 +19,8 @@ export interface AppDeps {
   createClient: (options: ApiClientOptions) => ApiClient;
   /** Read a secret (the API token) from the terminal without echoing it. */
   promptSecret: (question: string) => Promise<string>;
+  /** Read a local file's raw bytes, for `assets upload <file>`. */
+  readFile: (path: string) => Buffer;
   io: Io;
 }
 

--- a/packages/cli/src/deps.ts
+++ b/packages/cli/src/deps.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { createApiClient } from "./api/client";
 import type { AppDeps } from "./commands/context";
 import { clearConfig, loadConfig, saveConfig } from "./config/config";
@@ -15,6 +17,7 @@ export function buildDefaultDeps(): AppDeps {
     clearConfig,
     createClient: (options) => createApiClient(options),
     promptSecret,
+    readFile: (path) => readFileSync(path),
     io: {
       out: (line) => process.stdout.write(`${line}\n`),
       err: (line) => process.stderr.write(`${line}\n`),

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 
 import { accountsList } from "./commands/accounts";
-import { assetsList } from "./commands/assets";
+import { assetsDownloadUrl, assetsList, assetsUpload } from "./commands/assets";
 import { authLogin, authStatus } from "./commands/auth";
 import type { AppDeps } from "./commands/context";
 import { UsageError } from "./errors/errors";
@@ -98,6 +98,50 @@ export function buildProgram(deps: AppDeps): Command {
       json: wantsJson(command),
       ...(options.type !== undefined ? { type: options.type } : {}),
       ...(limit !== undefined ? { limit } : {}),
+    });
+  });
+
+  withJson(
+    assets
+      .command("upload")
+      .description("Upload a local file as a workspace asset.")
+      .argument("<file>", "path to the local file to upload")
+      .option(
+        "--type <type>",
+        "asset type: image | video | audio | model3d | workflow (inferred from the file extension if omitted)",
+      )
+      .option("--project-id <id>", "project to attach the asset to")
+      .option("--mime-type <mime>", "override the detected content type"),
+  ).action(async (file: string, _opts, command: Command) => {
+    const options = command.opts<{ type?: string; projectId?: string; mimeType?: string }>();
+    await assetsUpload(deps, {
+      json: wantsJson(command),
+      file,
+      ...(options.type !== undefined ? { type: options.type } : {}),
+      ...(options.projectId !== undefined ? { projectId: options.projectId } : {}),
+      ...(options.mimeType !== undefined ? { mimeType: options.mimeType } : {}),
+    });
+  });
+
+  withJson(
+    assets
+      .command("download-url")
+      .description("Get a download URL for an asset already in the workspace.")
+      .argument("<assetId>", "asset id")
+      .option("--expires-in <seconds>", "presigned URL lifetime in seconds"),
+  ).action(async (assetId: string, _opts, command: Command) => {
+    const options = command.opts<{ expiresIn?: string }>();
+    let expiresInSeconds: number | undefined;
+    if (options.expiresIn !== undefined) {
+      expiresInSeconds = Number(options.expiresIn);
+      if (!Number.isInteger(expiresInSeconds) || expiresInSeconds < 1) {
+        throw new UsageError("--expires-in must be a positive integer.");
+      }
+    }
+    await assetsDownloadUrl(deps, {
+      json: wantsJson(command),
+      assetId,
+      ...(expiresInSeconds !== undefined ? { expiresInSeconds } : {}),
     });
   });
 

--- a/src/app/api/v1/assets/[assetId]/download-url/__tests__/route.test.ts
+++ b/src/app/api/v1/assets/[assetId]/download-url/__tests__/route.test.ts
@@ -14,13 +14,9 @@ const {
   mockAuthorize: vi.fn(),
   mockIsDatabaseConfigured: vi.fn(() => true),
   mockGetAsset: vi.fn(),
-  mockCanUseS3Storage: vi.fn(() => true),
-  mockBuildCdnDownloadUrl: vi.fn(() => null),
-  mockCreatePresignedDownload: vi.fn(async () => ({
-    key: "workspace/ws_1/unscoped/image/file.png",
-    downloadUrl: "https://signed.example/file.png",
-    expiresInSeconds: 900,
-  })),
+  mockCanUseS3Storage: vi.fn(),
+  mockBuildCdnDownloadUrl: vi.fn(),
+  mockCreatePresignedDownload: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/server", () => ({

--- a/src/app/api/v1/assets/[assetId]/download-url/__tests__/route.test.ts
+++ b/src/app/api/v1/assets/[assetId]/download-url/__tests__/route.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const {
+  mockAuthorize,
+  mockIsDatabaseConfigured,
+  mockGetAsset,
+  mockCanUseS3Storage,
+  mockBuildCdnDownloadUrl,
+  mockCreatePresignedDownload,
+} = vi.hoisted(() => ({
+  mockAuthorize: vi.fn(),
+  mockIsDatabaseConfigured: vi.fn(() => true),
+  mockGetAsset: vi.fn(),
+  mockCanUseS3Storage: vi.fn(() => true),
+  mockBuildCdnDownloadUrl: vi.fn(() => null),
+  mockCreatePresignedDownload: vi.fn(async () => ({
+    key: "workspace/ws_1/unscoped/image/file.png",
+    downloadUrl: "https://signed.example/file.png",
+    expiresInSeconds: 900,
+  })),
+}));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({
+  isDatabaseConfigured: () => mockIsDatabaseConfigured(),
+  getDb: vi.fn(),
+}));
+
+vi.mock("@/lib/api-tokens/auth", () => ({
+  authorizePublicApiRequest: (...args: unknown[]) => mockAuthorize(...args),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  canUseS3Storage: (...args: unknown[]) => mockCanUseS3Storage(...args),
+  buildCdnDownloadUrl: (...args: unknown[]) => mockBuildCdnDownloadUrl(...args),
+  createPresignedDownload: (...args: unknown[]) => mockCreatePresignedDownload(...args),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getAsset: (...args: unknown[]) => mockGetAsset(...args),
+}));
+
+import { GET } from "../route";
+
+function createRequest(url: string, headers?: HeadersInit): NextRequest {
+  return {
+    headers: new Headers(headers),
+    nextUrl: new URL(url),
+  } as unknown as NextRequest;
+}
+
+function authorized(workspaceId = "ws_1") {
+  return {
+    authorized: true,
+    session: {
+      user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+      workspace: { id: workspaceId, organizationId: null },
+      role: "owner" as const,
+      planTier: "free" as const,
+      permissions: getPermissionsForRole("owner"),
+    },
+  };
+}
+
+function readyAsset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "asset_1",
+    storageProvider: "s3",
+    storageKey: "workspace/ws_1/unscoped/image/file.png",
+    metadata: { uploadState: "ready" },
+    ...overrides,
+  };
+}
+
+const BASE = "http://localhost:3000/api/v1/assets/asset_1/download-url";
+
+function context(assetId = "asset_1") {
+  return { params: Promise.resolve({ assetId }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDatabaseConfigured.mockReturnValue(true);
+  mockCanUseS3Storage.mockReturnValue(true);
+  mockBuildCdnDownloadUrl.mockReturnValue(null);
+  mockCreatePresignedDownload.mockResolvedValue({
+    key: "workspace/ws_1/unscoped/image/file.png",
+    downloadUrl: "https://signed.example/file.png",
+    expiresInSeconds: 900,
+  });
+});
+
+describe("/api/v1/assets/[assetId]/download-url GET", () => {
+  it("returns 503 when the database is not configured", async () => {
+    mockIsDatabaseConfigured.mockReturnValue(false);
+
+    const response = await GET(
+      createRequest(BASE, { authorization: "Bearer nb_valid" }),
+      context(),
+    );
+
+    expect(response.status).toBe(503);
+  });
+
+  it("returns a presigned download url for a ready asset", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+    mockGetAsset.mockResolvedValue(readyAsset());
+
+    const response = await GET(
+      createRequest(BASE, { authorization: "Bearer nb_valid" }),
+      context("asset_1"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.assetId).toBe("asset_1");
+    expect(data.downloadUrl).toBe("https://signed.example/file.png");
+    expect(mockGetAsset).toHaveBeenCalledWith("ws_1", "asset_1");
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ permission: "assets:read" }),
+    );
+  });
+
+  it("returns a structured 404 when the asset does not exist", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+    mockGetAsset.mockResolvedValue(null);
+
+    const response = await GET(
+      createRequest(BASE, { authorization: "Bearer nb_valid" }),
+      context("asset_missing"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("not_found");
+  });
+
+  it("passes through the auth layer's 401 for an invalid token", async () => {
+    mockAuthorize.mockResolvedValue({
+      authorized: false,
+      response: NextResponse.json(
+        { success: false, error: "Invalid or revoked API token." },
+        { status: 401 },
+      ),
+    });
+
+    const response = await GET(
+      createRequest(BASE, { authorization: "Bearer nb_bogus" }),
+      context(),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockGetAsset).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/assets/[assetId]/download-url/route.ts
+++ b/src/app/api/v1/assets/[assetId]/download-url/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAssetDownloadUrlTool } from "@/lib/agent-tools/tools/get-asset-download-url";
+import { toolErrorResponse } from "@/lib/agent-tools/http";
+import { runTool } from "@/lib/agent-tools/runtime";
+import { authorizePublicApiRequest } from "@/lib/api-tokens/auth";
+import { isDatabaseConfigured } from "@/lib/db";
+
+const ROUTE = "/api/v1/assets/[assetId]/download-url";
+
+type AssetIdContext = { params: Promise<{ assetId: string }> };
+
+/**
+ * Public API v1: get a download URL (CDN or presigned) for an asset already in
+ * this workspace.
+ *
+ * A thin wrapper over the `get_asset_download_url` registry tool — the same
+ * handler the MCP server and CLI use — so no business logic lives here.
+ */
+export async function GET(
+  request: NextRequest,
+  context: AssetIdContext,
+): Promise<NextResponse> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use the API.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const auth = await authorizePublicApiRequest(request, {
+    route: ROUTE,
+    permission: getAssetDownloadUrlTool.requiredPermission,
+  });
+
+  if (!auth.authorized) {
+    return auth.response;
+  }
+
+  const { assetId } = await context.params;
+
+  try {
+    const output = await runTool(
+      getAssetDownloadUrlTool,
+      { assetId },
+      { session: auth.session },
+    );
+    return NextResponse.json({ success: true, ...output });
+  } catch (error) {
+    return toolErrorResponse(error);
+  }
+}

--- a/src/app/api/v1/assets/__tests__/route.test.ts
+++ b/src/app/api/v1/assets/__tests__/route.test.ts
@@ -22,14 +22,10 @@ const {
   mockGetProject: vi.fn(),
   mockRecordPending: vi.fn(),
   mockFinalizeAssetUpload: vi.fn(),
-  mockCanUseS3Storage: vi.fn(() => true),
-  mockBuildAssetObjectKey: vi.fn(() => "workspace/ws_1/unscoped/image/file.png"),
-  mockBuildCdnDownloadUrl: vi.fn(() => null),
-  mockCreatePresignedDownload: vi.fn(async () => ({
-    key: "workspace/ws_1/unscoped/image/file.png",
-    downloadUrl: "https://signed.example/file.png",
-    expiresInSeconds: 900,
-  })),
+  mockCanUseS3Storage: vi.fn(),
+  mockBuildAssetObjectKey: vi.fn(),
+  mockBuildCdnDownloadUrl: vi.fn(),
+  mockCreatePresignedDownload: vi.fn(),
   mockPutObjectToS3: vi.fn(),
 }));
 

--- a/src/app/api/v1/assets/__tests__/route.test.ts
+++ b/src/app/api/v1/assets/__tests__/route.test.ts
@@ -3,12 +3,45 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { getPermissionsForRole } from "@/lib/studio/authz";
 
-const { mockAuthorize, mockIsDatabaseConfigured, mockListWorkspaceAssets } =
-  vi.hoisted(() => ({
-    mockAuthorize: vi.fn(),
-    mockIsDatabaseConfigured: vi.fn(() => true),
-    mockListWorkspaceAssets: vi.fn(),
-  }));
+const {
+  mockAuthorize,
+  mockIsDatabaseConfigured,
+  mockListWorkspaceAssets,
+  mockGetProject,
+  mockRecordPending,
+  mockFinalizeAssetUpload,
+  mockCanUseS3Storage,
+  mockBuildAssetObjectKey,
+  mockBuildCdnDownloadUrl,
+  mockCreatePresignedDownload,
+  mockPutObjectToS3,
+} = vi.hoisted(() => ({
+  mockAuthorize: vi.fn(),
+  mockIsDatabaseConfigured: vi.fn(() => true),
+  mockListWorkspaceAssets: vi.fn(),
+  mockGetProject: vi.fn(),
+  mockRecordPending: vi.fn(),
+  mockFinalizeAssetUpload: vi.fn(),
+  mockCanUseS3Storage: vi.fn(() => true),
+  mockBuildAssetObjectKey: vi.fn(() => "workspace/ws_1/unscoped/image/file.png"),
+  mockBuildCdnDownloadUrl: vi.fn(() => null),
+  mockCreatePresignedDownload: vi.fn(async () => ({
+    key: "workspace/ws_1/unscoped/image/file.png",
+    downloadUrl: "https://signed.example/file.png",
+    expiresInSeconds: 900,
+  })),
+  mockPutObjectToS3: vi.fn(),
+}));
+
+const { MockStudioAssetQuotaExceededError } = vi.hoisted(() => {
+  class StudioAssetQuotaExceededError extends Error {
+    constructor() {
+      super("Workspace storage quota exceeded.");
+      this.name = "StudioAssetQuotaExceededError";
+    }
+  }
+  return { MockStudioAssetQuotaExceededError: StudioAssetQuotaExceededError };
+});
 
 vi.mock("@/lib/auth/server", () => ({
   auth: { api: { getSession: vi.fn() } },
@@ -23,21 +56,43 @@ vi.mock("@/lib/api-tokens/auth", () => ({
   authorizePublicApiRequest: (...args: unknown[]) => mockAuthorize(...args),
 }));
 
+vi.mock("@/lib/storage", () => ({
+  canUseS3Storage: (...args: unknown[]) => mockCanUseS3Storage(...args),
+  buildAssetObjectKey: (...args: unknown[]) => mockBuildAssetObjectKey(...args),
+  buildCdnDownloadUrl: (...args: unknown[]) => mockBuildCdnDownloadUrl(...args),
+  createPresignedDownload: (...args: unknown[]) => mockCreatePresignedDownload(...args),
+  putObjectToS3: (...args: unknown[]) => mockPutObjectToS3(...args),
+  streamUploadToS3: vi.fn(),
+  deleteObjectFromS3: vi.fn(),
+}));
+
 vi.mock("@/lib/studio/repository", () => ({
   getWorkspaceById: vi.fn(),
   listWorkspaceAssets: (...args: unknown[]) => mockListWorkspaceAssets(...args),
+  getProject: (...args: unknown[]) => mockGetProject(...args),
+  recordPendingS3AssetWithQuota: (...args: unknown[]) => mockRecordPending(...args),
+  finalizeAssetUpload: (...args: unknown[]) => mockFinalizeAssetUpload(...args),
+  StudioAssetQuotaExceededError: MockStudioAssetQuotaExceededError,
 }));
 
 vi.mock("@/lib/social/repository", () => ({
   listSocialAccounts: vi.fn(),
 }));
 
-import { GET } from "../route";
+import { GET, POST } from "../route";
 
 function createRequest(url: string, headers?: HeadersInit): NextRequest {
   return {
     headers: new Headers(headers),
     nextUrl: new URL(url),
+  } as unknown as NextRequest;
+}
+
+function createPostRequest(body: unknown, headers?: HeadersInit): NextRequest {
+  return {
+    headers: new Headers(headers),
+    nextUrl: new URL(BASE),
+    json: async () => body,
   } as unknown as NextRequest;
 }
 
@@ -59,6 +114,16 @@ const BASE = "http://localhost:3000/api/v1/assets";
 beforeEach(() => {
   vi.clearAllMocks();
   mockIsDatabaseConfigured.mockReturnValue(true);
+  mockCanUseS3Storage.mockReturnValue(true);
+  mockBuildAssetObjectKey.mockReturnValue("workspace/ws_1/unscoped/image/file.png");
+  mockBuildCdnDownloadUrl.mockReturnValue(null);
+  mockCreatePresignedDownload.mockResolvedValue({
+    key: "workspace/ws_1/unscoped/image/file.png",
+    downloadUrl: "https://signed.example/file.png",
+    expiresInSeconds: 900,
+  });
+  mockRecordPending.mockResolvedValue({ id: "asset_new" });
+  mockFinalizeAssetUpload.mockResolvedValue({ id: "asset_new" });
 });
 
 describe("/api/v1/assets GET", () => {
@@ -140,5 +205,117 @@ describe("/api/v1/assets GET", () => {
 
     expect(response.status).toBe(401);
     expect(mockListWorkspaceAssets).not.toHaveBeenCalled();
+  });
+});
+
+describe("/api/v1/assets POST", () => {
+  it("returns 503 when the database is not configured", async () => {
+    mockIsDatabaseConfigured.mockReturnValue(false);
+
+    const response = await POST(
+      createPostRequest(
+        { assetType: "image", base64Content: "aGVsbG8=" },
+        { authorization: "Bearer nb_valid" },
+      ),
+    );
+
+    expect(response.status).toBe(503);
+  });
+
+  it("uploads base64 content and returns the new asset id + download url", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+
+    const response = await POST(
+      createPostRequest(
+        { assetType: "image", fileName: "photo.png", base64Content: "aGVsbG8=" },
+        { authorization: "Bearer nb_valid" },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(data.assetId).toBe("asset_new");
+    expect(data.downloadUrl).toBe("https://signed.example/file.png");
+    expect(mockRecordPending).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws_1", type: "image" }),
+    );
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ permission: "assets:write" }),
+    );
+  });
+
+  it("returns a structured 400 when neither base64Content nor sourceUrl is given", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+
+    const response = await POST(
+      createPostRequest(
+        { assetType: "image" },
+        { authorization: "Bearer nb_valid" },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("invalid_input");
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it("returns a structured 403 when the workspace storage quota is exceeded", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+    mockRecordPending.mockRejectedValue(new MockStudioAssetQuotaExceededError());
+
+    const response = await POST(
+      createPostRequest(
+        { assetType: "image", base64Content: "aGVsbG8=" },
+        { authorization: "Bearer nb_valid" },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("forbidden");
+  });
+
+  it("returns a structured 400 for an invalid JSON body", async () => {
+    mockAuthorize.mockResolvedValue(authorized("ws_1"));
+    const request = {
+      headers: new Headers({ authorization: "Bearer nb_valid" }),
+      nextUrl: new URL(BASE),
+      json: async () => {
+        throw new SyntaxError("Unexpected end of JSON input");
+      },
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe("invalid_input");
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it("passes through the auth layer's 401 for an invalid token", async () => {
+    mockAuthorize.mockResolvedValue({
+      authorized: false,
+      response: NextResponse.json(
+        { success: false, error: "Invalid or revoked API token." },
+        { status: 401 },
+      ),
+    });
+
+    const response = await POST(
+      createPostRequest(
+        { assetType: "image", base64Content: "aGVsbG8=" },
+        { authorization: "Bearer nb_bogus" },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockRecordPending).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/v1/assets/route.ts
+++ b/src/app/api/v1/assets/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { listAssetsTool } from "@/lib/agent-tools/tools/list-assets";
+import { uploadAssetTool } from "@/lib/agent-tools/tools/upload-asset";
+import { ToolError } from "@/lib/agent-tools/errors";
 import { toolErrorResponse } from "@/lib/agent-tools/http";
 import { runTool } from "@/lib/agent-tools/runtime";
 import { authorizePublicApiRequest } from "@/lib/api-tokens/auth";
@@ -50,6 +52,57 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       session: auth.session,
     });
     return NextResponse.json({ success: true, ...output });
+  } catch (error) {
+    return toolErrorResponse(error);
+  }
+}
+
+/**
+ * Public API v1: upload media into the workspace, from base64 content or a
+ * source URL.
+ *
+ * A thin wrapper over the `upload_asset` registry tool, which enforces the
+ * exact same type and workspace storage-quota rules as the Studio upload UI.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isDatabaseConfigured()) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "DATABASE_URL is not configured. Configure Postgres to use the API.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const auth = await authorizePublicApiRequest(request, {
+    route: ROUTE,
+    permission: uploadAssetTool.requiredPermission,
+  });
+
+  if (!auth.authorized) {
+    return auth.response;
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return toolErrorResponse(
+      new ToolError({
+        code: "invalid_input",
+        message: "Request body must be valid JSON.",
+        fix: "Send a JSON body with assetType and either base64Content or sourceUrl.",
+      }),
+    );
+  }
+
+  try {
+    const output = await runTool(uploadAssetTool, body, {
+      session: auth.session,
+    });
+    return NextResponse.json({ success: true, ...output }, { status: 201 });
   } catch (error) {
     return toolErrorResponse(error);
   }

--- a/src/lib/agent-tools/mcp/__tests__/server.test.ts
+++ b/src/lib/agent-tools/mcp/__tests__/server.test.ts
@@ -58,9 +58,11 @@ describe("buildMcpServer (registry-derived MCP tools)", () => {
     const names = tools.map((t) => t.name).sort();
 
     expect(names).toEqual([
+      "get_asset_download_url",
       "list_assets",
       "list_social_accounts",
       "list_workspaces",
+      "upload_asset",
     ]);
     for (const tool of tools) {
       expect(tool.description).toBeTruthy();

--- a/src/lib/agent-tools/mcp/__tests__/stdio-bridge.test.ts
+++ b/src/lib/agent-tools/mcp/__tests__/stdio-bridge.test.ts
@@ -71,9 +71,11 @@ describe("createStdioProxyServer", () => {
     const { tools } = await downstream.listTools();
 
     expect(tools.map((t) => t.name).sort()).toEqual([
+      "get_asset_download_url",
       "list_assets",
       "list_social_accounts",
       "list_workspaces",
+      "upload_asset",
     ]);
 
     await downstream.close();

--- a/src/lib/agent-tools/registry.ts
+++ b/src/lib/agent-tools/registry.ts
@@ -1,6 +1,8 @@
+import { getAssetDownloadUrlTool } from "./tools/get-asset-download-url";
 import { listAssetsTool } from "./tools/list-assets";
 import { listSocialAccountsTool } from "./tools/list-social-accounts";
 import { listWorkspacesTool } from "./tools/list-workspaces";
+import { uploadAssetTool } from "./tools/upload-asset";
 import type { AnyToolDefinition } from "./types";
 
 /**
@@ -15,6 +17,8 @@ export const toolRegistry: readonly AnyToolDefinition[] = [
   listWorkspacesTool,
   listSocialAccountsTool,
   listAssetsTool,
+  uploadAssetTool,
+  getAssetDownloadUrlTool,
 ] as const;
 
 const toolsByName = new Map<string, AnyToolDefinition>(

--- a/src/lib/agent-tools/tools/__tests__/get-asset-download-url.test.ts
+++ b/src/lib/agent-tools/tools/__tests__/get-asset-download-url.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ContentOSSession } from "@/lib/studio/authz";
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const { mockGetAsset, mockBuildCdnDownloadUrl, mockCreatePresignedDownload, mockCanUseS3Storage } =
+  vi.hoisted(() => ({
+    mockGetAsset: vi.fn(),
+    mockBuildCdnDownloadUrl: vi.fn(),
+    mockCreatePresignedDownload: vi.fn(),
+    mockCanUseS3Storage: vi.fn(() => true),
+  }));
+
+vi.mock("@/lib/storage", () => ({
+  canUseS3Storage: (...args: unknown[]) => mockCanUseS3Storage(...args),
+  buildCdnDownloadUrl: (...args: unknown[]) => mockBuildCdnDownloadUrl(...args),
+  createPresignedDownload: (...args: unknown[]) => mockCreatePresignedDownload(...args),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getAsset: (...args: unknown[]) => mockGetAsset(...args),
+}));
+
+import { runTool } from "../../runtime";
+import { getAssetDownloadUrlTool } from "../get-asset-download-url";
+
+function session(
+  role: "owner" | "member" = "owner",
+  workspaceId = "ws_1",
+): ContentOSSession {
+  return {
+    user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+    workspace: { id: workspaceId, organizationId: null },
+    role,
+    planTier: "free",
+    permissions: getPermissionsForRole(role),
+  };
+}
+
+function readyAsset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "asset_1",
+    storageProvider: "s3",
+    storageKey: "workspace/ws_1/unscoped/image/file.png",
+    metadata: { uploadState: "ready" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCanUseS3Storage.mockReturnValue(true);
+  mockBuildCdnDownloadUrl.mockReturnValue(null);
+  mockCreatePresignedDownload.mockResolvedValue({
+    key: "workspace/ws_1/unscoped/image/file.png",
+    downloadUrl: "https://signed.example/file.png",
+    expiresInSeconds: 900,
+  });
+});
+
+describe("get_asset_download_url tool", () => {
+  it("returns a presigned url for a ready s3-backed asset", async () => {
+    mockGetAsset.mockResolvedValue(readyAsset());
+
+    const result = await runTool(
+      getAssetDownloadUrlTool,
+      { assetId: "asset_1" },
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(mockGetAsset).toHaveBeenCalledWith("ws_1", "asset_1");
+    expect(mockCreatePresignedDownload).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "workspace/ws_1/unscoped/image/file.png" }),
+    );
+    expect(result).toEqual({
+      assetId: "asset_1",
+      downloadUrl: "https://signed.example/file.png",
+      expiresInSeconds: 900,
+    });
+  });
+
+  it("prefers a CDN url when one is configured", async () => {
+    mockGetAsset.mockResolvedValue(readyAsset());
+    mockBuildCdnDownloadUrl.mockReturnValue("https://cdn.example/file.png");
+
+    const result = await runTool(
+      getAssetDownloadUrlTool,
+      { assetId: "asset_1" },
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(result.downloadUrl).toBe("https://cdn.example/file.png");
+    expect(mockCreatePresignedDownload).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found when the asset does not exist in this workspace", async () => {
+    mockGetAsset.mockResolvedValue(null);
+
+    const error = await runTool(
+      getAssetDownloadUrlTool,
+      { assetId: "asset_missing" },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("not_found");
+  });
+
+  it("rejects an asset whose upload is still pending", async () => {
+    mockGetAsset.mockResolvedValue(
+      readyAsset({ metadata: { uploadState: "pending" } }),
+    );
+
+    const error = await runTool(
+      getAssetDownloadUrlTool,
+      { assetId: "asset_1" },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("invalid_input");
+    expect(mockCreatePresignedDownload).not.toHaveBeenCalled();
+  });
+
+  it("rejects an asset that is not stored in S3/R2", async () => {
+    mockGetAsset.mockResolvedValue(readyAsset({ storageProvider: "local" }));
+
+    const error = await runTool(
+      getAssetDownloadUrlTool,
+      { assetId: "asset_1" },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("invalid_input");
+  });
+
+  it("denies callers whose role lacks assets:read", async () => {
+    const memberSession = session("member");
+    memberSession.permissions = memberSession.permissions.filter(
+      (p) => p !== "assets:read",
+    );
+
+    const error = await runTool(
+      getAssetDownloadUrlTool,
+      { assetId: "asset_1" },
+      { session: memberSession },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("forbidden");
+    expect(mockGetAsset).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/agent-tools/tools/__tests__/get-asset-download-url.test.ts
+++ b/src/lib/agent-tools/tools/__tests__/get-asset-download-url.test.ts
@@ -8,7 +8,7 @@ const { mockGetAsset, mockBuildCdnDownloadUrl, mockCreatePresignedDownload, mock
     mockGetAsset: vi.fn(),
     mockBuildCdnDownloadUrl: vi.fn(),
     mockCreatePresignedDownload: vi.fn(),
-    mockCanUseS3Storage: vi.fn(() => true),
+    mockCanUseS3Storage: vi.fn(),
   }));
 
 vi.mock("@/lib/storage", () => ({

--- a/src/lib/agent-tools/tools/__tests__/upload-asset.test.ts
+++ b/src/lib/agent-tools/tools/__tests__/upload-asset.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ContentOSSession } from "@/lib/studio/authz";
+import { getPermissionsForRole } from "@/lib/studio/authz";
+
+const {
+  mockGetProject,
+  mockRecordPending,
+  mockFinalizeAssetUpload,
+  mockBuildAssetObjectKey,
+  mockPutObjectToS3,
+  mockStreamUploadToS3,
+  mockDeleteObjectFromS3,
+  mockCreatePresignedDownload,
+  mockBuildCdnDownloadUrl,
+  mockCanUseS3Storage,
+  mockFetch,
+} = vi.hoisted(() => ({
+  mockGetProject: vi.fn(),
+  mockRecordPending: vi.fn(),
+  mockFinalizeAssetUpload: vi.fn(),
+  mockBuildAssetObjectKey: vi.fn(),
+  mockPutObjectToS3: vi.fn(),
+  mockStreamUploadToS3: vi.fn(),
+  mockDeleteObjectFromS3: vi.fn(),
+  mockCreatePresignedDownload: vi.fn(),
+  mockBuildCdnDownloadUrl: vi.fn(),
+  mockCanUseS3Storage: vi.fn(() => true),
+  mockFetch: vi.fn(),
+}));
+
+const { MockStudioAssetQuotaExceededError } = vi.hoisted(() => {
+  class StudioAssetQuotaExceededError extends Error {
+    constructor() {
+      super("Workspace storage quota exceeded.");
+      this.name = "StudioAssetQuotaExceededError";
+    }
+  }
+  return { MockStudioAssetQuotaExceededError: StudioAssetQuotaExceededError };
+});
+
+vi.mock("@/lib/storage", () => ({
+  canUseS3Storage: (...args: unknown[]) => mockCanUseS3Storage(...args),
+  buildAssetObjectKey: (...args: unknown[]) => mockBuildAssetObjectKey(...args),
+  buildCdnDownloadUrl: (...args: unknown[]) => mockBuildCdnDownloadUrl(...args),
+  createPresignedDownload: (...args: unknown[]) => mockCreatePresignedDownload(...args),
+  putObjectToS3: (...args: unknown[]) => mockPutObjectToS3(...args),
+  streamUploadToS3: (...args: unknown[]) => mockStreamUploadToS3(...args),
+  deleteObjectFromS3: (...args: unknown[]) => mockDeleteObjectFromS3(...args),
+}));
+
+vi.mock("@/lib/studio/repository", () => ({
+  getProject: (...args: unknown[]) => mockGetProject(...args),
+  recordPendingS3AssetWithQuota: (...args: unknown[]) => mockRecordPending(...args),
+  finalizeAssetUpload: (...args: unknown[]) => mockFinalizeAssetUpload(...args),
+  StudioAssetQuotaExceededError: MockStudioAssetQuotaExceededError,
+}));
+
+import { runTool } from "../../runtime";
+import { uploadAssetTool } from "../upload-asset";
+
+function session(
+  role: "owner" | "member" = "owner",
+  workspaceId = "ws_1",
+): ContentOSSession {
+  return {
+    user: { id: `apitoken:${workspaceId}`, name: null, email: null },
+    workspace: { id: workspaceId, organizationId: null },
+    role,
+    planTier: "free",
+    permissions: getPermissionsForRole(role),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCanUseS3Storage.mockReturnValue(true);
+  mockBuildAssetObjectKey.mockReturnValue("workspace/ws_1/unscoped/image/file.png");
+  mockRecordPending.mockResolvedValue({ id: "asset_new" });
+  mockFinalizeAssetUpload.mockResolvedValue({ id: "asset_new" });
+  mockBuildCdnDownloadUrl.mockReturnValue(null);
+  mockCreatePresignedDownload.mockResolvedValue({
+    key: "workspace/ws_1/unscoped/image/file.png",
+    downloadUrl: "https://signed.example/file.png",
+    expiresInSeconds: 900,
+  });
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+describe("upload_asset tool", () => {
+  it("uploads base64 content and returns an asset id + presigned url", async () => {
+    const base64 = Buffer.from("hello world").toString("base64");
+
+    const result = await runTool(
+      uploadAssetTool,
+      {
+        assetType: "image",
+        fileName: "photo.png",
+        mimeType: "image/png",
+        base64Content: base64,
+      },
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(mockRecordPending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        type: "image",
+        mimeType: "image/png",
+        expectedSizeBytes: Buffer.from("hello world").length,
+      }),
+    );
+    expect(mockPutObjectToS3).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "image/png" }),
+    );
+    expect(mockFinalizeAssetUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        assetId: "asset_new",
+        uploadState: "ready",
+      }),
+    );
+    expect(result).toEqual({
+      assetId: "asset_new",
+      downloadUrl: "https://signed.example/file.png",
+      expiresInSeconds: 900,
+    });
+  });
+
+  it("prefers a CDN url over a presigned url when configured", async () => {
+    mockBuildCdnDownloadUrl.mockReturnValue("https://cdn.example/file.png");
+    const base64 = Buffer.from("hello").toString("base64");
+
+    const result = await runTool(
+      uploadAssetTool,
+      { assetType: "image", base64Content: base64 },
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(result.downloadUrl).toBe("https://cdn.example/file.png");
+    expect(result.expiresInSeconds ?? null).toBeNull();
+    expect(mockCreatePresignedDownload).not.toHaveBeenCalled();
+  });
+
+  it("uploads from a sourceUrl by streaming it to storage", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    });
+    mockFetch.mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "image/jpeg", "content-length": "3" },
+      }),
+    );
+    mockStreamUploadToS3.mockResolvedValue({ sizeBytes: 3 });
+
+    const result = await runTool(
+      uploadAssetTool,
+      { assetType: "image", sourceUrl: "https://example.com/pic.jpg" },
+      { session: session("owner", "ws_1") },
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/pic.jpg",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(mockStreamUploadToS3).toHaveBeenCalled();
+    expect(mockFinalizeAssetUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ uploadState: "ready", sizeBytes: 3 }),
+    );
+    expect(result.assetId).toBe("asset_new");
+  });
+
+  it("rejects when neither base64Content nor sourceUrl is provided", async () => {
+    const error = await runTool(
+      uploadAssetTool,
+      { assetType: "image" },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("invalid_input");
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it("rejects when both base64Content and sourceUrl are provided", async () => {
+    const error = await runTool(
+      uploadAssetTool,
+      {
+        assetType: "image",
+        base64Content: Buffer.from("x").toString("base64"),
+        sourceUrl: "https://example.com/a.png",
+      },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("invalid_input");
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported asset type before touching storage", async () => {
+    const error = await runTool(
+      uploadAssetTool,
+      { assetType: "bogus", base64Content: Buffer.from("x").toString("base64") },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("invalid_input");
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it("rejects content over the size limit", async () => {
+    // Just over the 50MB base64Content cap (kept well under 500MB so the
+    // base64-inflated string stays far from V8's string-length ceiling).
+    const huge = Buffer.alloc(51 * 1024 * 1024, 1).toString("base64");
+
+    const error = await runTool(
+      uploadAssetTool,
+      { assetType: "video", base64Content: huge },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("invalid_input");
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a workspace quota breach as a forbidden tool error", async () => {
+    mockRecordPending.mockRejectedValue(new MockStudioAssetQuotaExceededError());
+
+    const error = await runTool(
+      uploadAssetTool,
+      { assetType: "image", base64Content: Buffer.from("hi").toString("base64") },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("forbidden");
+    expect(mockPutObjectToS3).not.toHaveBeenCalled();
+  });
+
+  it("rejects a projectId the workspace cannot access", async () => {
+    mockGetProject.mockResolvedValue(null);
+
+    const error = await runTool(
+      uploadAssetTool,
+      {
+        assetType: "image",
+        projectId: "proj_other",
+        base64Content: Buffer.from("hi").toString("base64"),
+      },
+      { session: session("owner", "ws_1") },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("not_found");
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it("denies callers whose role lacks assets:write", async () => {
+    const memberSession = session("member");
+    memberSession.permissions = memberSession.permissions.filter(
+      (p) => p !== "assets:write",
+    );
+
+    const error = await runTool(
+      uploadAssetTool,
+      { assetType: "image", base64Content: Buffer.from("hi").toString("base64") },
+      { session: memberSession },
+    ).catch((e) => e);
+
+    expect(error.code).toBe("forbidden");
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/agent-tools/tools/__tests__/upload-asset.test.ts
+++ b/src/lib/agent-tools/tools/__tests__/upload-asset.test.ts
@@ -25,7 +25,7 @@ const {
   mockDeleteObjectFromS3: vi.fn(),
   mockCreatePresignedDownload: vi.fn(),
   mockBuildCdnDownloadUrl: vi.fn(),
-  mockCanUseS3Storage: vi.fn(() => true),
+  mockCanUseS3Storage: vi.fn(),
   mockFetch: vi.fn(),
 }));
 

--- a/src/lib/agent-tools/tools/get-asset-download-url.ts
+++ b/src/lib/agent-tools/tools/get-asset-download-url.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+import { buildCdnDownloadUrl, createPresignedDownload } from "@/lib/storage";
+import { getAsset } from "@/lib/studio/repository";
+
+import { ToolError } from "../errors";
+import type { ToolDefinition } from "../types";
+
+const inputSchema = z.object({
+  assetId: z.string(),
+});
+
+const outputSchema = z.object({
+  assetId: z.string(),
+  downloadUrl: z.string(),
+  expiresInSeconds: z.number().nullable().optional(),
+});
+
+/** Mirrors the studio download route's readiness check: an asset with no
+ * metadata (pre-quota assets) is treated as ready; only an explicit
+ * pending/failed upload state blocks a download url. */
+function isAssetReady(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return true;
+  }
+
+  const uploadState = (metadata as Record<string, unknown>).uploadState;
+  if (uploadState === "failed") return false;
+  if (uploadState === "pending") return false;
+  return true;
+}
+
+/**
+ * Get a download URL for an asset already in this workspace — a CDN url when
+ * `CDN_BASE_URL` is configured, otherwise a short-lived S3/R2 presigned url,
+ * exactly as `/api/studio/assets/[assetId]/download` resolves it. Use after
+ * `upload_asset` or `list_assets` to fetch or share the underlying media.
+ */
+export const getAssetDownloadUrlTool: ToolDefinition<
+  typeof inputSchema,
+  typeof outputSchema
+> = {
+  name: "get_asset_download_url",
+  description:
+    "Get a download URL (CDN or presigned) for an asset id already in this workspace.",
+  requiredPermission: "assets:read",
+  inputSchema,
+  outputSchema,
+  handler: async (input, ctx) => {
+    const asset = await getAsset(ctx.session.workspace.id, input.assetId);
+    if (!asset) {
+      throw new ToolError({
+        code: "not_found",
+        message: "Asset not found.",
+        fix: "Check the asset id, or call list_assets to find a valid one.",
+      });
+    }
+
+    if (asset.storageProvider !== "s3") {
+      throw new ToolError({
+        code: "invalid_input",
+        message: "Asset is not stored in S3/R2.",
+        fix: "This asset predates cloud storage and has no downloadable URL.",
+      });
+    }
+
+    if (!asset.storageKey?.trim()) {
+      throw new ToolError({
+        code: "invalid_input",
+        message: "Asset has no storage key.",
+        fix: "This asset record is incomplete and cannot be downloaded.",
+      });
+    }
+
+    if (!isAssetReady(asset.metadata)) {
+      throw new ToolError({
+        code: "invalid_input",
+        message: "Asset upload is not ready.",
+        fix: "Wait for the upload to finish, or re-upload if it failed.",
+      });
+    }
+
+    const cdnUrl = buildCdnDownloadUrl({ key: asset.storageKey });
+    if (cdnUrl) {
+      return { assetId: asset.id, downloadUrl: cdnUrl, expiresInSeconds: null };
+    }
+
+    const signed = await createPresignedDownload({ key: asset.storageKey });
+    return {
+      assetId: asset.id,
+      downloadUrl: signed.downloadUrl,
+      expiresInSeconds: signed.expiresInSeconds,
+    };
+  },
+};

--- a/src/lib/agent-tools/tools/upload-asset.ts
+++ b/src/lib/agent-tools/tools/upload-asset.ts
@@ -1,0 +1,454 @@
+import { z } from "zod";
+
+import {
+  buildAssetObjectKey,
+  buildCdnDownloadUrl,
+  canUseS3Storage,
+  createPresignedDownload,
+  deleteObjectFromS3,
+  putObjectToS3,
+  streamUploadToS3,
+} from "@/lib/storage";
+import {
+  getProject,
+  finalizeAssetUpload,
+  recordPendingS3AssetWithQuota,
+  StudioAssetQuotaExceededError,
+} from "@/lib/studio/repository";
+
+import { ToolError } from "../errors";
+import type { ToolDefinition } from "../types";
+
+const assetTypeSchema = z.enum([
+  "image",
+  "video",
+  "audio",
+  "model3d",
+  "workflow",
+]);
+
+// Kept in sync with /api/studio/assets/ingest's MAX_INGEST_BYTES — the same
+// upper bound applies to a streamed sourceUrl regardless of which surface
+// uploaded the content.
+const MAX_UPLOAD_BYTES = 500 * 1024 * 1024;
+// base64Content must live as a single in-memory JS string (a ~500MB file would
+// base64-inflate to ~667M UTF-16 code units, over V8's string-length ceiling)
+// and is transported inline in a JSON request body, so direct content is
+// capped well below the streamed-sourceUrl limit. Larger files should be
+// uploaded via sourceUrl instead.
+const MAX_BASE64_CONTENT_BYTES = 50 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 60_000;
+
+const inputSchema = z.object({
+  assetType: assetTypeSchema,
+  projectId: z.string().optional(),
+  fileName: z.string().optional(),
+  mimeType: z.string().optional(),
+  /** Raw file bytes, base64-encoded (no `data:` prefix). */
+  base64Content: z.string().optional(),
+  /** A URL the server fetches and stores. Exactly one of this or base64Content. */
+  sourceUrl: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  assetId: z.string(),
+  downloadUrl: z.string(),
+  expiresInSeconds: z.number().nullable().optional(),
+});
+
+function pickDefaultMimeType(assetType: z.infer<typeof assetTypeSchema>): string {
+  if (assetType === "video") return "video/mp4";
+  if (assetType === "audio") return "audio/mpeg";
+  if (assetType === "model3d") return "model/gltf-binary";
+  return "image/png";
+}
+
+const EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+  "audio/mpeg": "mp3",
+  "audio/wav": "wav",
+  "audio/ogg": "ogg",
+  "audio/flac": "flac",
+  "audio/aac": "aac",
+  "model/gltf-binary": "glb",
+  "model/gltf+json": "gltf",
+  "model/obj": "obj",
+  "model/vnd.usdz+zip": "usdz",
+  "model/fbx": "fbx",
+  "model/stl": "stl",
+};
+
+function getExtensionForMimeType(mimeType: string, fallback = "bin"): string {
+  return EXTENSION_BY_MIME_TYPE[mimeType.toLowerCase().trim()] || fallback;
+}
+
+function getExtensionFromFileName(fileName?: string | null): string | null {
+  if (!fileName) return null;
+  const parts = fileName.split(".");
+  if (parts.length < 2) return null;
+  const ext = parts[parts.length - 1]?.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return ext || null;
+}
+
+function sanitizeFileName(fileName?: string): string | null {
+  if (!fileName) return null;
+  const trimmed = fileName.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function decodeBase64(content: string): Buffer {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    throw new ToolError({
+      code: "invalid_input",
+      message: "base64Content must not be empty.",
+      fix: "Provide the file's bytes as a base64-encoded string.",
+    });
+  }
+
+  // Accept a `data:...;base64,` prefix defensively, but the canonical input is
+  // raw base64 with no prefix.
+  const match = trimmed.match(/^data:([^;]+);base64,(.+)$/);
+  const raw = match ? match[2] : trimmed;
+
+  let bytes: Buffer;
+  try {
+    bytes = Buffer.from(raw, "base64");
+  } catch {
+    bytes = Buffer.alloc(0);
+  }
+
+  if (bytes.length === 0) {
+    throw new ToolError({
+      code: "invalid_input",
+      message: "base64Content could not be decoded to non-empty bytes.",
+      fix: "Confirm the content is valid base64 and not empty.",
+    });
+  }
+
+  return bytes;
+}
+
+async function fetchRemoteStream(sourceUrl: string): Promise<{
+  mimeType: string | null;
+  body: ReadableStream<Uint8Array>;
+  contentLength: number | null;
+}> {
+  let parsed: URL;
+  try {
+    parsed = new URL(sourceUrl);
+  } catch {
+    throw new ToolError({
+      code: "invalid_input",
+      message: "sourceUrl must be a valid URL.",
+      fix: "Pass an absolute http(s) URL.",
+    });
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new ToolError({
+      code: "invalid_input",
+      message: "sourceUrl must use http or https.",
+      fix: "Pass an absolute http(s) URL.",
+    });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(sourceUrl, { signal: controller.signal });
+  } catch (error) {
+    clearTimeout(timeout);
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new ToolError({
+        code: "invalid_input",
+        message: `sourceUrl fetch timed out after ${FETCH_TIMEOUT_MS}ms.`,
+        fix: "Use a URL that responds quickly, or upload the content directly via base64Content.",
+      });
+    }
+    throw new ToolError({
+      code: "invalid_input",
+      message: `Failed to fetch sourceUrl: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      fix: "Confirm the URL is reachable, or upload the content directly via base64Content.",
+    });
+  }
+
+  if (!response.ok) {
+    clearTimeout(timeout);
+    throw new ToolError({
+      code: "invalid_input",
+      message: `Failed to fetch sourceUrl: HTTP ${response.status}`,
+      fix: "Confirm the URL is publicly reachable and returns a success status.",
+    });
+  }
+
+  const contentLengthHeader = response.headers.get("content-length");
+  let contentLength: number | null = null;
+  if (contentLengthHeader) {
+    const length = Number(contentLengthHeader);
+    if (Number.isFinite(length)) {
+      if (length > MAX_UPLOAD_BYTES) {
+        clearTimeout(timeout);
+        throw new ToolError({
+          code: "invalid_input",
+          message: `Source size exceeds ${MAX_UPLOAD_BYTES} bytes.`,
+          fix: "Upload a smaller file.",
+        });
+      }
+      contentLength = length;
+    }
+  }
+
+  const contentType = response.headers.get("content-type");
+  const mimeType = contentType ? contentType.split(";")[0].trim().toLowerCase() : null;
+
+  if (!response.body) {
+    clearTimeout(timeout);
+    throw new ToolError({
+      code: "invalid_input",
+      message: "sourceUrl response has no body.",
+      fix: "Use a URL that returns file content, or upload via base64Content.",
+    });
+  }
+
+  // Timeout intentionally stays active during stream consumption to bound the
+  // overall fetch, mirroring the ingest route's behaviour.
+  return { mimeType, body: response.body, contentLength };
+}
+
+async function resolveDownloadUrl(
+  key: string,
+): Promise<{ downloadUrl: string; expiresInSeconds: number | null }> {
+  const cdnUrl = buildCdnDownloadUrl({ key });
+  if (cdnUrl) {
+    return { downloadUrl: cdnUrl, expiresInSeconds: null };
+  }
+
+  const signed = await createPresignedDownload({ key });
+  return { downloadUrl: signed.downloadUrl, expiresInSeconds: signed.expiresInSeconds };
+}
+
+/**
+ * Upload media into the token's workspace — either raw base64 content or a
+ * source URL the server fetches — subject to the exact same type and workspace
+ * storage-quota rules as the Studio upload UI (`recordPendingS3AssetWithQuota`).
+ * Returns the new asset's id and a URL to download it, so an agent can
+ * immediately reference the asset (e.g. when composing a post) without a
+ * second round trip.
+ */
+export const uploadAssetTool: ToolDefinition<typeof inputSchema, typeof outputSchema> = {
+  name: "upload_asset",
+  description:
+    "Upload media into this workspace from base64 content or a source URL. Enforces the workspace's storage quota and asset type rules. Returns the new asset id and a download URL.",
+  requiredPermission: "assets:write",
+  inputSchema,
+  outputSchema,
+  handler: async (input, ctx) => {
+    if (!canUseS3Storage()) {
+      throw new ToolError({
+        code: "internal",
+        message:
+          "S3 storage is not configured. Set STORAGE_BACKEND=s3 and required S3_* environment variables.",
+        fix: "Ask the workspace operator to configure cloud storage before uploading assets.",
+      });
+    }
+
+    const hasContent =
+      typeof input.base64Content === "string" && input.base64Content.trim().length > 0;
+    const hasUrl = typeof input.sourceUrl === "string" && input.sourceUrl.trim().length > 0;
+
+    if (hasContent === hasUrl) {
+      throw new ToolError({
+        code: "invalid_input",
+        message: "Provide exactly one of base64Content or sourceUrl.",
+        fix: "Pass either base64Content (with fileName/mimeType) or sourceUrl, not both.",
+      });
+    }
+
+    const workspaceId = ctx.session.workspace.id;
+    const userId = ctx.session.user.id;
+
+    const projectId = input.projectId?.trim() || null;
+    if (projectId) {
+      const project = await getProject(workspaceId, projectId);
+      if (!project) {
+        throw new ToolError({
+          code: "not_found",
+          message: "No access to this project.",
+          fix: "Use a projectId that exists in this workspace, or omit it to leave the asset unscoped.",
+        });
+      }
+    }
+
+    let createdAssetId: string | null = null;
+    let uploadMimeType: string | null = null;
+
+    try {
+      if (hasContent) {
+        const bytes = decodeBase64(input.base64Content!);
+
+        if (bytes.length > MAX_BASE64_CONTENT_BYTES) {
+          throw new ToolError({
+            code: "invalid_input",
+            message: `Content exceeds ${MAX_BASE64_CONTENT_BYTES} bytes.`,
+            fix: "Upload a smaller file, or use sourceUrl to stream a larger one instead.",
+          });
+        }
+
+        uploadMimeType =
+          input.mimeType?.trim().toLowerCase() || pickDefaultMimeType(input.assetType);
+        const sanitizedName = sanitizeFileName(input.fileName);
+        const extension =
+          getExtensionFromFileName(sanitizedName) ||
+          getExtensionForMimeType(uploadMimeType, "bin");
+
+        const key = buildAssetObjectKey({
+          workspaceId,
+          projectId,
+          assetType: input.assetType,
+          fileExtension: extension,
+        });
+
+        const pending = await recordPendingS3AssetWithQuota({
+          workspaceId,
+          userId,
+          projectId,
+          type: input.assetType,
+          storageBucket: process.env.S3_BUCKET_NAME || null,
+          storageKey: key,
+          mimeType: uploadMimeType,
+          originalFileName: sanitizedName,
+          expectedSizeBytes: bytes.length,
+        });
+        createdAssetId = pending.id;
+
+        await putObjectToS3({ key, body: bytes, contentType: uploadMimeType });
+
+        await finalizeAssetUpload({
+          workspaceId,
+          assetId: pending.id,
+          uploadState: "ready",
+          sizeBytes: bytes.length,
+          mimeType: uploadMimeType,
+        });
+
+        const { downloadUrl, expiresInSeconds } = await resolveDownloadUrl(key);
+        return { assetId: pending.id, downloadUrl, expiresInSeconds };
+      }
+
+      const fetched = await fetchRemoteStream(input.sourceUrl!.trim());
+
+      uploadMimeType =
+        input.mimeType?.trim().toLowerCase() ||
+        fetched.mimeType ||
+        pickDefaultMimeType(input.assetType);
+      const sanitizedName = sanitizeFileName(input.fileName);
+      const extension =
+        getExtensionFromFileName(sanitizedName) ||
+        getExtensionForMimeType(uploadMimeType, "bin");
+
+      const key = buildAssetObjectKey({
+        workspaceId,
+        projectId,
+        assetType: input.assetType,
+        fileExtension: extension,
+      });
+
+      const expectedSizeBytes = fetched.contentLength ?? MAX_UPLOAD_BYTES;
+
+      const pending = await recordPendingS3AssetWithQuota({
+        workspaceId,
+        userId,
+        projectId,
+        type: input.assetType,
+        storageBucket: process.env.S3_BUCKET_NAME || null,
+        storageKey: key,
+        mimeType: uploadMimeType,
+        originalFileName: sanitizedName,
+        expectedSizeBytes,
+      });
+      createdAssetId = pending.id;
+
+      const { sizeBytes } = await streamUploadToS3({
+        key,
+        body: fetched.body,
+        contentType: uploadMimeType,
+        contentLength: fetched.contentLength ?? undefined,
+      });
+
+      if (sizeBytes === 0) {
+        await deleteObjectFromS3({ key }).catch(() => {});
+        await finalizeAssetUpload({
+          workspaceId,
+          assetId: pending.id,
+          uploadState: "failed",
+          error: "Source content is empty.",
+        });
+        throw new ToolError({
+          code: "invalid_input",
+          message: "Source content is empty.",
+          fix: "Use a sourceUrl that returns non-empty content.",
+        });
+      }
+
+      if (sizeBytes > MAX_UPLOAD_BYTES) {
+        await deleteObjectFromS3({ key }).catch(() => {});
+        await finalizeAssetUpload({
+          workspaceId,
+          assetId: pending.id,
+          uploadState: "failed",
+          error: `Source size exceeds ${MAX_UPLOAD_BYTES} bytes.`,
+        });
+        throw new ToolError({
+          code: "invalid_input",
+          message: `Source size exceeds ${MAX_UPLOAD_BYTES} bytes.`,
+          fix: "Use a smaller source file.",
+        });
+      }
+
+      await finalizeAssetUpload({
+        workspaceId,
+        assetId: pending.id,
+        uploadState: "ready",
+        sizeBytes,
+        mimeType: uploadMimeType,
+      });
+
+      const { downloadUrl, expiresInSeconds } = await resolveDownloadUrl(key);
+      return { assetId: pending.id, downloadUrl, expiresInSeconds };
+    } catch (error) {
+      if (error instanceof StudioAssetQuotaExceededError) {
+        throw new ToolError({
+          code: "forbidden",
+          message: "Workspace storage quota exceeded.",
+          fix: "Delete unused assets or raise the workspace's storage quota before uploading more.",
+        });
+      }
+
+      if (createdAssetId) {
+        await finalizeAssetUpload({
+          workspaceId,
+          assetId: createdAssetId,
+          uploadState: "failed",
+          mimeType: uploadMimeType || undefined,
+          error: error instanceof Error ? error.message : "Asset upload failed",
+        }).catch(() => {});
+      }
+
+      throw error;
+    }
+  },
+};


### PR DESCRIPTION
Closes #104. Part of PRD #100. **Stacked on #129** — merge order: #123 → #126 → #129 → this.

- Registry tools `upload_asset` (base64 ≤50MB or server-fetched sourceUrl ≤500MB; quota/type enforcement reuses `recordPendingS3AssetWithQuota`/`finalizeAssetUpload` verbatim — nothing reimplemented) and `get_asset_download_url` (CDN-first-then-presigned, mirroring the app download route). MCP picks both up automatically.
- v1 routes: `POST /api/v1/assets`, `GET /api/v1/assets/[assetId]/download-url`.
- CLI: `nb assets upload <file>`, `nb assets download-url <id>`, `--json` supported.
- Errors map to the structured tool-error union (quota→403 forbidden, bad input→400, missing→404).

42 new tests — re-run by reviewer. Full suite at the documented baseline (only the 2 tracked pre-existing failures); typecheck clean root + CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)